### PR TITLE
Refactor

### DIFF
--- a/BioDendro/__init__.py
+++ b/BioDendro/__init__.py
@@ -33,6 +33,8 @@ def pipeline(
         scaling=False,
         filtering=False,
         eps=0.0,
+        mz_tol=0.002,
+        retention_tol=5,
         **kwargs
         ):
     """ Runs the default BioDendro pipeline. """
@@ -61,6 +63,8 @@ def pipeline(
              "- scaling = {scal}\n"
              "- filtering = {fil}\n"
              "- eps = {eps}\n"
+             "- mz_tolerance = {mz_tol}\n"
+             "- retention_tolerance = {retention_tol}\n"
              "\n").format(
                  name=__name__,
                  version=__version__,
@@ -78,6 +82,8 @@ def pipeline(
                  scal=scaling,
                  fil=filtering,
                  eps=eps,
+                 mz_tol=mz_tol,
+                 retention_tol=retention_tol,
                  )
     )
 
@@ -96,7 +102,7 @@ def pipeline(
 
     #Now remove redundancy and print best trigger ion list
     printer("Processing inputs")
-    table = remove_redundancy(components, mgf, neutral=neutral)
+    table = remove_redundancy(components, mgf, neutral=neutral, mz_tol=mz_tol, retention_tol=retention_tol )
 
     # Write out an excel file too
     table.to_excel(processed, index=False)
@@ -224,6 +230,19 @@ def main():
         help="Intensity threshold for filtering, set value between 0.0-1.0",
         type=float,
         default=0.6
+        )
+    parser.add_argument(
+        "-mz_tol", "--mz_tol",
+        help="Mass tolerance to remove redundancy, default is 0.002",
+        type=float,
+        default=0.002
+        )
+
+    parser.add_argument(
+        "-retention_tol", "--retention_tol",
+        help="Retention time tolerance to remove redundancy, default is 5 secs",
+        type=float,
+        default=5
         )
 
     args = parser.parse_args()

--- a/BioDendro/__init__.py
+++ b/BioDendro/__init__.py
@@ -5,10 +5,9 @@ __name__ = "BioDendro"
 __version__ = "0.0.1"
 
 import os
+from os.path import join as pjoin
 import argparse
 from datetime import datetime
-
-import plotly
 
 from BioDendro.preprocess import MGF
 from BioDendro.preprocess import SampleRecord
@@ -18,25 +17,25 @@ from BioDendro.cluster import Tree
 
 
 def pipeline(
-        mgf_path,
-        components_path,
-        neutral=False,
-        cutoff=0.6,
-        bin_threshold=8e-4,
-        clustering_method="jaccard",
-        processed="processed.xlsx",
-        results_dir=None,
-        out_html="simple_dendrogram.html",
-        width=900,
-        height=400,
-        quiet=False,
-        scaling=False,
-        filtering=False,
-        eps=0.0,
-        mz_tol=0.002,
-        retention_tol=5,
-        **kwargs
-        ):
+    mgf_path,
+    components_path,
+    neutral=False,
+    cutoff=0.6,
+    bin_threshold=8e-4,
+    clustering_method="jaccard",
+    processed="processed.xlsx",
+    results_dir=None,
+    out_html="simple_dendrogram.html",
+    width=900,
+    height=400,
+    quiet=False,
+    scaling=False,
+    filtering=False,
+    eps=0.0,
+    mz_tol=0.002,
+    retention_tol=5,
+    **kwargs
+):
     """ Runs the default BioDendro pipeline. """
 
     if quiet:
@@ -48,46 +47,65 @@ def pipeline(
         dt = datetime.now()
         results_dir = "results_{}".format(dt.strftime("%Y%m%d%H%M%S"))
 
-    printer(("Running {name} v{version}\n\n"
-             "- input mgf file = {mgf}\n"
-             "- input components file = {comp}\n"
-             "- neutral = {neu}\n"
-             "- cutoff = {cut}\n"
-             "- bin_threshold = {bin}\n"
-             "- clustering_method = {clu}\n"
-             "- output processed file = {pro}\n"
-             "- output results directory = {res}\n"
-             "- output html dendrogram = {html}\n"
-             "- dendrogram figure width = {x}\n"
-             "- dendrogram figure height = {y}\n"
-             "- scaling = {scal}\n"
-             "- filtering = {fil}\n"
-             "- eps = {eps}\n"
-             "- mz_tolerance = {mz_tol}\n"
-             "- retention_tolerance = {retention_tol}\n"
-             "\n").format(
-                 name=__name__,
-                 version=__version__,
-                 mgf=mgf_path,
-                 comp=components_path,
-                 neu=neutral,
-                 cut=cutoff,
-                 bin=bin_threshold,
-                 clu=clustering_method,
-                 pro=processed,
-                 res=results_dir,
-                 html=out_html,
-                 x=width,
-                 y=height,
-                 scal=scaling,
-                 fil=filtering,
-                 eps=eps,
-                 mz_tol=mz_tol,
-                 retention_tol=retention_tol,
-                 )
-    )
+    printer((
+        "Running {name} v{version}\n\n"
+        "- input mgf file = {mgf}\n"
+        "- input components file = {comp}\n"
+        "- neutral = {neu}\n"
+        "- cutoff = {cut}\n"
+        "- bin_threshold = {bin}\n"
+        "- clustering_method = {clu}\n"
+        "- output processed file = {pro}\n"
+        "- output results directory = {res}\n"
+        "- output html dendrogram = {html}\n"
+        "- dendrogram figure width = {x}\n"
+        "- dendrogram figure height = {y}\n"
+        "- scaling = {scal}\n"
+        "- filtering = {fil}\n"
+        "- eps = {eps}\n"
+        "- mz_tolerance = {mz_tol}\n"
+        "- retention_tolerance = {retention_tol}\n"
+        "\n"
+    ).format(
+        name=__name__,
+        version=__version__,
+        mgf=mgf_path,
+        comp=components_path,
+        neu=neutral,
+        cut=cutoff,
+        bin=bin_threshold,
+        clu=clustering_method,
+        res=results_dir,
+        pro=pjoin(results_dir, processed),
+        html=pjoin(results_dir, out_html),
+        x=width,
+        y=height,
+        scal=scaling,
+        fil=filtering,
+        eps=eps,
+        mz_tol=mz_tol,
+        retention_tol=retention_tol,
+    ))
 
-    #Open the trigger data <file>.msg
+    params = [
+        ("version", __version__),
+        ("input mgf file", mgf_path),
+        ("input components file", components_path),
+        ("neutral", neutral),
+        ("cutoff", cutoff),
+        ("bin_threshold", bin_threshold),
+        ("clustering_method", clustering_method),
+        ("output results directory", results_dir),
+        ("output processed file", pjoin(results_dir, processed)),
+        ("output html dendrogram", pjoin(results_dir, out_html)),
+        ("dendrogram figure width", width),
+        ("dendrogram figure height", height),
+        ("scaling", scaling),
+        ("filtering", filtering),
+        ("eps", eps),
+    ]
+
+    # Open the trigger data <file>.msg
     with open(mgf_path, 'r') as handle:
         mgf = MGF.parse(handle, scaling=scaling, filtering=filtering, eps=eps)
 
@@ -96,16 +114,19 @@ def pipeline(
     for rec in mgf.records:
         rec.title = split_msms_title(rec.title)
 
-    #Open the sample list <file>.csv
+    # Open the sample list <file>.csv
     with open(components_path, 'r') as handle:
         components = SampleRecord.parse(handle)
 
-    #Now remove redundancy and print best trigger ion list
+    # Now remove redundancy and print best trigger ion list
     printer("Processing inputs")
-    table = remove_redundancy(components, mgf, neutral=neutral, mz_tol=mz_tol, retention_tol=retention_tol )
-
-    # Write out an excel file too
-    table.to_excel(processed, index=False)
+    table = remove_redundancy(
+        components,
+        mgf,
+        neutral=neutral,
+        mz_tol=mz_tol,
+        retention_tol=retention_tol
+    )
 
     printer("Binning and clustering\nThis may take some time...")
     tree = Tree(bin_threshold, clustering_method, cutoff)
@@ -115,39 +136,54 @@ def pipeline(
     os.makedirs(results_dir, exist_ok=True)
     tree.write_summaries(path=results_dir)
 
+    # Write out an excel file too
+    table.drop(columns="mz").drop_duplicates().to_excel(
+        pjoin(results_dir, processed), index=False)
+
+    with open(pjoin(results_dir, "params.txt"), "w") as handle:
+        params_file = "\n".join(["{}\t{}".format(k, v) for k, v in params])
+        handle.write(params_file)
+
     printer("Writing output html dendrogram")
-    _ = tree.iplot(filename=out_html, width=width, height=height)
+
+    _ = tree.plot(
+        filename=pjoin(results_dir, out_html),
+        width=width,
+        height=height
+    )
 
     printer("Finished")
     return tree
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Run the BioDendro pipeline."
-        )
+    )
 
     parser.add_argument(
         "mgf",
         help="MGF input file.",
-        )
+    )
+
     parser.add_argument(
         "components",
         help="Listed components file.",
-        )
+    )
 
     parser.add_argument(
         "-n", "--neutral",
         help="Apply neutral loss.",
         action="store_true",
         default=False
-        )
+    )
 
     parser.add_argument(
         "-c", "--cutoff",
         help="Distance threshold for selecting clusters from tree.",
         type=float,
         default=0.6
-        )
+    )
 
     parser.add_argument(
         "-b", "--bin-threshold",
@@ -155,7 +191,7 @@ def main():
         dest="bin_threshold",
         type=float,
         default=8e-4
-        )
+    )
 
     parser.add_argument(
         "-d", "--cluster-method",
@@ -163,20 +199,20 @@ def main():
         dest="clustering_method",
         default="jaccard",
         choices=["jaccard", "braycurtis"],
-        )
+    )
 
     parser.add_argument(
         "-p", "--processed",
         default="processed.xlsx",
         help="Path to write preprocessed output to."
-        )
+    )
 
     parser.add_argument(
         "-o", "--output",
         dest="out_html",
         default="simple_dendrogram.html",
         help="Path to write interactive html plot to."
-        )
+    )
 
     parser.add_argument(
         "-r", "--results-dir",
@@ -186,7 +222,7 @@ def main():
               "Default is to use 'results_20180606112200' where the number is"
               "the current datetime.\n"
               "WARNING: will overwrite contents of existing directories.")
-        )
+    )
 
     parser.add_argument(
         "-x", "--width",
@@ -194,7 +230,7 @@ def main():
         help="The width of the dendrogram plot in pixels.",
         type=int,
         default=900
-        )
+    )
 
     parser.add_argument(
         "-y", "--height",
@@ -202,49 +238,56 @@ def main():
         help="The height of the dendrogram plot in pixels.",
         type=int,
         default=400
-        )
+    )
 
     parser.add_argument(
         "-q", "--quiet",
         help="Suppress status notifications written to stdout.",
         action="store_true",
         default=False
-        )
+    )
 
     parser.add_argument(
         "-s", "--scaling",
         help="Flag to scale the m/z intensities values",
         action="store_true",
         default=False
-        )
+    )
 
     parser.add_argument(
         "-f", "--filtering",
         help="Flag to filter the m/z intensities values",
         action="store_true",
         default=False
-        )
+    )
 
     parser.add_argument(
         "-e", "--eps",
         help="Intensity threshold for filtering, set value between 0.0-1.0",
         type=float,
         default=0.6
-        )
+    )
+
     parser.add_argument(
         "-mz_tol", "--mz_tol",
         help="Mass tolerance to remove redundancy, default is 0.002",
         type=float,
         default=0.002
-        )
+    )
 
     parser.add_argument(
         "-retention_tol", "--retention_tol",
-        help="Retention time tolerance to remove redundancy, default is 5 secs",
+        help=("Retention time tolerance to remove redundancy, "
+              "default is 5 secs"),
         type=float,
         default=5
-        )
+    )
 
     args = parser.parse_args()
-    pipeline(mgf_path=args.mgf, components_path=args.components, **args.__dict__)
+
+    pipeline(
+        mgf_path=args.mgf,
+        components_path=args.components,
+        **args.__dict__
+    )
     return

--- a/BioDendro/__init__.py
+++ b/BioDendro/__init__.py
@@ -58,6 +58,9 @@ def pipeline(
              "- output html dendrogram = {html}\n"
              "- dendrogram figure width = {x}\n"
              "- dendrogram figure height = {y}\n"
+             "- scaling = {scal}\n"
+             "- filtering = {fil}\n"
+             "- eps = {eps}\n"
              "\n").format(
                  name=__name__,
                  version=__version__,
@@ -72,6 +75,9 @@ def pipeline(
                  html=out_html,
                  x=width,
                  y=height,
+                 scal=scaling,
+                 fil=filtering,
+                 eps=eps,
                  )
     )
 
@@ -199,6 +205,26 @@ def main():
         default=False
         )
 
+    parser.add_argument(
+        "-s", "--scaling",
+        help="Flag to scale the m/z intensities values",
+        action="store_true",
+        default=False
+        )
+
+    parser.add_argument(
+        "-f", "--filtering",
+        help="Flag to filter the m/z intensities values",
+        action="store_true",
+        default=False
+        )
+
+    parser.add_argument(
+        "-e", "--eps",
+        help="Intensity threshold for filtering, set value between 0.0-1.0",
+        type=float,
+        default=0.6
+        )
 
     args = parser.parse_args()
     pipeline(mgf_path=args.mgf, components_path=args.components, **args.__dict__)

--- a/BioDendro/__init__.py
+++ b/BioDendro/__init__.py
@@ -27,11 +27,11 @@ def pipeline(
     results_dir=None,
     out_html="simple_dendrogram.html",
     width=900,
-    height=400,
+    height=800,
     quiet=False,
     scaling=False,
     filtering=False,
-    eps=0.0,
+    eps=0.6,
     mz_tol=0.002,
     retention_tol=5,
     **kwargs
@@ -237,7 +237,7 @@ def main():
         dest="height_px",
         help="The height of the dendrogram plot in pixels.",
         type=int,
-        default=400
+        default=800
     )
 
     parser.add_argument(

--- a/BioDendro/plot.py
+++ b/BioDendro/plot.py
@@ -1,317 +1,376 @@
 """
-This module is an updated copy of a section of the Plotly library.
-The changes have been committed, but not yet integrated into the distribution
-library.
+Plots a tree object as a dendrogram for visualisation with plotly.
 """
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from itertools import repeat
+from copy import deepcopy
+import re
 
-from collections import OrderedDict
-
-from plotly import exceptions, optional_imports
 from plotly.graph_objs import graph_objs
 
-# Optional imports, may be None for users that only use our core functionality.
-np = optional_imports.get_module('numpy')
-scp = optional_imports.get_module('scipy')
-sch = optional_imports.get_module('scipy.cluster.hierarchy')
-scs = optional_imports.get_module('scipy.spatial')
+import numpy as np
+from scipy.cluster import hierarchy as sph
 
 
-def create_dendro(X, orientation="bottom", labels=None,
-                      colorscale=None, 
-                      linkagefun=lambda x: sch.linkage(x, 'complete'),
-                      distfun=lambda x: scs.distance.pdist(x, metric='jaccard'), # Added jaccard
-                      hovertext=None, color_threshold=None):
+def dendrogram(
+    tree,
+    orientation='bottom',
+    colorscale=None,
+    width=np.inf,
+    height=np.inf,
+    xaxis='xaxis',
+    yaxis='yaxis',
+    title=None,
+    xlabel=None,
+    ylabel=None,
+    hovertext=None,
+    margin_scalar=12,
+):
+    layout = {xaxis: {}, yaxis: {}}
+    if title is not None:
+        layout["title"] = title
+
+    if xlabel is not None:
+        layout[xaxis]["title"] = xlabel
+
+    if ylabel is not None:
+        layout[yaxis]["title"] = ylabel
+
+    sign = _get_sign(orientation, xaxis, yaxis)
+
+    (dd_traces, xvals, yvals, ordered_labels, leaves) = _get_traces(
+        hierarchy=tree.tree,
+        labels=tree.onehot_df.index.to_list(),
+        threshold=tree.cutoff,
+        orientation=orientation,
+        sign=sign,
+        xaxis=xaxis,
+        yaxis=yaxis,
+        hovertext=hovertext,
+        colorscale=colorscale,
+    )
+
+    yvals_flat = yvals.flatten()
+    xvals_flat = xvals.flatten()
+
+    zero_vals = {x for x, y in zip(xvals_flat, yvals_flat) if y == 0.0}
+
+    if len(zero_vals) > len(yvals) + 1:
+        # If the length of zero_vals is larger than the length of yvals,
+        # it means that there are wrong vals because of the identicial samples.
+        # Three and more identicial samples will make the yvals of spliting
+        # center into 0 and it will accidentally take it as leaves.
+
+        l_border = int(min(zero_vals))
+        r_border = int(max(zero_vals))
+
+        correct_leaves_pos = range(
+            l_border,
+            r_border + 1,
+            int((r_border - l_border) / len(yvals))
+        )
+
+        # Regenerating the leaves pos from the zero_vals with equal intervals.
+        zero_vals = list(correct_leaves_pos)
+    else:
+        zero_vals = list(zero_vals)
+
+    zero_vals.sort()
+    layout = _figure_layout(
+        layout,
+        width,
+        height,
+        ordered_labels,
+        xaxis,
+        yaxis,
+        sign,
+        orientation,
+        zero_vals,
+    )
+
+    # Adjust the margins to account for long sample labels.
+    longest_label = max([len(l) for l in ordered_labels])
+    if "margin" not in layout:
+        ori = orientation[0]  # This spec used just l, r, t, or b
+        layout["margin"] = {ori: int(margin_scalar) * (longest_label + 1)}
+
+    if hovertext is None:
+        cluster_map = dict(zip(tree.onehot_df.index, tree.clusters))
+        data = _format_cluster_hovertexts(dd_traces, layout, cluster_map)
+    else:
+        data = dd_traces
+
+    return graph_objs.Figure(data, layout)
+
+
+def _format_cluster_hovertexts(data, layout, cluster_map):
+    """ Updates data elements to add hover text for cluster names. """
+
+    labels = dict(zip(layout["xaxis"]["tickvals"],
+                      layout["xaxis"]["ticktext"]))
+    hover_labs = {
+        k: "cluster: {}, component: {}".format(cluster_map[v], v)
+        for k, v
+        in labels.items()
+    }
+
+    out = []
+    for scatter in data:
+        # Avoid side-effects just in case.
+        scatter = deepcopy(scatter)
+        xaxis = scatter["xaxis"]
+        yaxis = scatter["yaxis"]
+        textl = None
+        textr = None
+
+        # If left is at 0.
+        if scatter[yaxis][0] == 0.0:
+            textl = hover_labs.get(scatter[xaxis][0], None)
+
+        if scatter[yaxis][3] == 0.0:
+            textr = hover_labs.get(scatter[xaxis][3], None)
+
+        scatter["text"] = [textl, textl, textr, textr]
+        out.append(scatter)
+
+    return out
+
+
+def _get_sign(orientation, xaxis, yaxis):
+    """ Helper to find multiplicative factors to get rotations right. """
+
+    sign = {xaxis: 1, yaxis: 1}
+
+    if orientation in ['left', 'bottom']:
+        sign[xaxis] = 1
+    else:
+        sign[xaxis] = -1
+
+    if orientation in ['right', 'bottom']:
+        sign[yaxis] = 1
+    else:
+        sign[yaxis] = -1
+    return sign
+
+
+def _get_color_dict(colorscale=None):
+    """ Returns colorscale used for dendrogram tree clusters.
+
+    Keyword arguments:
+    colorscale -- Colors to use for the plot in rgb format.
+        Should have 8 colours.
     """
-    BETA function that returns a dendrogram Plotly figure object.
-    :param (ndarray) X: Matrix of observations as array of arrays
-    :param (str) orientation: 'top', 'right', 'bottom', or 'left'
-    :param (list) labels: List of axis category labels(observation labels)
-    :param (list) colorscale: Optional colorscale for dendrogram tree
-    :param (function) distfun: Function to compute the pairwise distance from
-                               the observations
-    :param (function) linkagefun: Function to compute the linkage matrix from
-                               the pairwise distances
-    :param (list[list]) hovertext: List of hovertext for constituent traces of dendrogram
-                               clusters
-    :param (double) color_threshold: Value at which the separation of clusters will be made
-    Example 1: Simple bottom oriented dendrogram
-    ```
-    import plotly.plotly as py
-    from plotly.figure_factory import create_dendrogram
-    import numpy as np
-    X = np.random.rand(10,10)
-    dendro = create_dendrogram(X)
-    plot_url = py.plot(dendro, filename='simple-dendrogram')
-    ```
-    Example 2: Dendrogram to put on the left of the heatmap
-    ```
-    import plotly.plotly as py
-    from plotly.figure_factory import create_dendrogram
-    import numpy as np
-    X = np.random.rand(5,5)
-    names = ['Jack', 'Oxana', 'John', 'Chelsea', 'Mark']
-    dendro = create_dendrogram(X, orientation='right', labels=names)
-    dendro['layout'].update({'width':700, 'height':500})
-    py.iplot(dendro, filename='vertical-dendrogram')
-    ```
-    Example 3: Dendrogram with Pandas
-    ```
-    import plotly.plotly as py
-    from plotly.figure_factory import create_dendrogram
-    import numpy as np
-    import pandas as pd
-    Index= ['A','B','C','D','E','F','G','H','I','J']
-    df = pd.DataFrame(abs(np.random.randn(10, 10)), index=Index)
-    fig = create_dendrogram(df, labels=Index)
-    url = py.plot(fig, filename='pandas-dendrogram')
-    ```
+
+    # These are the color codes returned for dendrograms
+    # We're replacing them with nicer colors
+    default_colors = [
+        ('b', "blue"),
+        ('c', "cyan"),
+        ('g', "green"),
+        ('k', "black"),
+        ('m', "magenta"),
+        ('r', "red"),
+        ('w', "white"),
+        ('y', "yellow"),
+    ]
+
+    if colorscale is None:
+        colorscale = [
+            'rgb(0,116,217)',  # instead of blue
+            'rgb(35,205,205)',  # cyan
+            'rgb(61,153,112)',  # green
+            'rgb(40,35,35)',  # black
+            'rgb(133,20,75)',  # magenta
+            'rgb(255,65,54)',  # red
+            'rgb(255,255,255)',  # white
+            'rgb(255,220,0)',  # yellow
+        ]
+
+    mapped_colors = {
+        k: o
+        for (k, v), o
+        in zip(default_colors, colorscale)
+    }
+
+    return mapped_colors
+
+
+def _get_traces(
+    hierarchy,
+    labels,
+    threshold,
+    orientation,
+    sign,
+    xaxis,
+    yaxis,
+    hovertext=None,
+    colorscale=None,
+):
+    """ Format the dendrogram nodes/clades as edges in graph. """
+
+    # Scipy does most of the heavy lifting.
+    dendro = sph.dendrogram(
+        hierarchy,
+        orientation=orientation,
+        labels=labels,
+        no_plot=True,
+        color_threshold=threshold
+    )
+
+    icoords = np.array(dendro["icoord"])
+    dcoords = np.array(dendro["dcoord"])
+
+    # xs and ys are arrays of 4 points that make up the '∩' shapes
+    # of the dendrogram tree
+    if orientation in ["top", "bottom"]:
+        xs = icoords
+        ys = dcoords
+    else:
+        ys = icoords
+        xs = dcoords
+
+    # Multiply by 1 or -1 to get correct rotation
+    xs = sign[xaxis] * xs
+    ys = sign[yaxis] * ys
+
+    ordered_labels = dendro["ivl"]
+
+    if hovertext is None:
+        # Infinite generator of None values.
+        hovertext = repeat(None)
+
+    color_map = _get_color_dict(colorscale)
+    colors = [color_map[k] for k in dendro["color_list"]]
+    traces = _trace_as_scatter(xs, ys, colors, hovertext, xaxis, yaxis)
+
+    return traces, icoords, dcoords, ordered_labels, dendro["leaves"]
+
+
+def _trace_as_scatter(xs, ys, colors, hovertext, xaxis, yaxis):
+    """ Formats the values from the scipy dendro as a list of plotly
+    compatible dicts. There will be converted into Scatter objects by Figure."
     """
-    if not scp or not scs or not sch:
-        raise ImportError("FigureFactory.create_dendrogram requires scipy, \
-                            scipy.spatial and scipy.hierarchy")
 
-    s = X.shape
-    if len(s) != 2:
-        exceptions.PlotlyError("X should be 2-dimensional array.")
+    traces = []
+    for x, y, color, htext in zip(xs, ys, colors, hovertext):
+        trace = {
+            "type": "scatter",
+            "x": x,
+            "y": y,
+            "mode": 'lines',
+            "marker": {"color": color},
+            "text": htext,
+            "hoverinfo": 'text',
+            "xaxis": _axis_index(xaxis, "x"),
+            "yaxis": _axis_index(yaxis, "y"),
+        }
+        # The axis index stuff seems to be an anticipation of people having
+        # multiple plots in the same figure.
 
-    if distfun is None:
-        distfun = scs.distance.pdist
-
-    dendrogram = _Dendrogram(X, orientation, labels, colorscale,
-                             distfun=distfun, linkagefun=linkagefun,
-                             hovertext=hovertext, color_threshold=color_threshold)
-
-    return graph_objs.Figure(data=dendrogram.data,
-                             layout=dendrogram.layout)
+        traces.append(trace)
+    return traces
 
 
-class _Dendrogram(object):
-    """Refer to FigureFactory.create_dendrogram() for docstring."""
+def _axis_index(string, prefix):
+    """ In the case of a plot with sub-plots, the axes may have numbers after
+    This captures those number for us.
 
-    def __init__(self, X, orientation='bottom', labels=None, colorscale=None,
-                 width=np.inf, height=np.inf, xaxis='xaxis', yaxis='yaxis',
-                 linkagefun=lambda x: sch.linkage(x, 'complete'),
-                 distfun=lambda x: scs.distance.pdist(x, metric='jaccard'), #testing
-                 hovertext=None, color_threshold=None):
-        self.orientation = orientation
-        self.labels = labels
-        self.xaxis = xaxis
-        self.yaxis = yaxis
-        self.data = []
-        self.leaves = []
-        self.sign = {self.xaxis: 1, self.yaxis: 1}
-        self.layout = {self.xaxis: {}, self.yaxis: {}}
+    Note, I can't see why this is actually necessary, (i.e. if multiplots
+    will actually break it) but I'm porting it over from the original plotly
+    code just in case.
+    """
 
-        if self.orientation in ['left', 'bottom']:
-            self.sign[self.xaxis] = 1
+    regex = re.compile(r"(?P<integer>\d+)$")
+
+    match = regex.search(string)
+    if match is None:
+        return prefix
+    else:
+        return "".join([prefix, match.groupdict().get("integer", "")])
+
+
+def _axis_layout_defaults(layout={}):
+    """ Updates layout dict with some defauls.
+
+    Returns copy of data, i.e. doesn't mutate.
+    """
+
+    axis_defaults = {
+        'type': 'linear',
+        'ticks': 'outside',
+        'mirror': 'allticks',
+        'rangemode': 'tozero',
+        'showticklabels': True,
+        'zeroline': False,
+        'showgrid': False,
+        'showline': True,
+    }
+
+    layout = deepcopy(layout)
+    layout.update(axis_defaults)
+    return layout
+
+
+def _key_labels_layout(sign, zero_vals, labels):
+    """ Format the leaf labels to be shown on the axis. """
+
+    layout = {
+        "tickvals": [sign * zv for zv in zero_vals],
+        "ticktext": labels,
+        "tickmode": "array",
+    }
+    return layout
+
+
+def _figure_layout_defaults(width, height, layout={}):
+    """ Updates layout dict with some defaults.
+
+    Returns copy of data, i.e. no mutation.
+    """
+
+    figure_defaults = {
+        'showlegend': False,
+        'autosize': False,
+        'hovermode': 'closest',
+        'width': width,
+        'height': height
+    }
+
+    layout = deepcopy(layout)
+    layout.update(figure_defaults)
+    return layout
+
+
+def _figure_layout(
+    layout,
+    width,
+    height,
+    labels,
+    xaxis,
+    yaxis,
+    sign,
+    orientation,
+    zero_vals
+):
+    """ Sets up figure and axis layouts, and adds leaf labels. """
+
+    if len(labels) > 0:
+        if orientation in ["left", "right"]:
+            axis_key_labels = yaxis
         else:
-            self.sign[self.xaxis] = -1
+            axis_key_labels = xaxis
 
-        if self.orientation in ['right', 'bottom']:
-            self.sign[self.yaxis] = 1
-        else:
-            self.sign[self.yaxis] = -1
+        label_layout = _key_labels_layout(
+            sign=sign[axis_key_labels],
+            zero_vals=zero_vals,
+            labels=labels
+        )
 
-        if distfun is None:
-            distfun = scs.distance.pdist
+        layout[axis_key_labels].update(label_layout)
 
-        (dd_traces, xvals, yvals,
-            ordered_labels, leaves) = self.get_dendrogram_traces(X, colorscale,
-                                                                 distfun,
-                                                                 linkagefun,
-                                                                 hovertext,
-                                                                 color_threshold)
+    figure_defaults = _figure_layout_defaults(width, height)
+    layout.update(figure_defaults)
 
-        self.labels = ordered_labels
-        self.leaves = leaves
-        yvals_flat = yvals.flatten()
-        xvals_flat = xvals.flatten()
-
-        self.zero_vals = []
-
-        for i in range(len(yvals_flat)):
-            if yvals_flat[i] == 0.0 and xvals_flat[i] not in self.zero_vals:
-                self.zero_vals.append(xvals_flat[i])
-
-        if len(self.zero_vals) > len(yvals) + 1:
-            # If the length of zero_vals is larger than the length of yvals,
-            # it means that there are wrong vals because of the identicial samples.
-            # Three and more identicial samples will make the yvals of spliting center into 0 and it will \
-            # accidentally take it as leaves.
-            l_border = int(min(self.zero_vals))
-            r_border = int(max(self.zero_vals))
-            correct_leaves_pos = range(l_border,
-                                       r_border + 1,
-                                       int((r_border - l_border) / len(yvals)))
-            # Regenerating the leaves pos from the self.zero_vals with equally intervals.
-            self.zero_vals = [v for v in correct_leaves_pos]
-
-        self.zero_vals.sort()
-        self.layout = self.set_figure_layout(width, height)
-        self.data = dd_traces
-
-    def get_color_dict(self, colorscale):
-        """
-        Returns colorscale used for dendrogram tree clusters.
-        :param (list) colorscale: Colors to use for the plot in rgb format.
-        :rtype (dict): A dict of default colors mapped to the user colorscale.
-        """
-
-        # These are the color codes returned for dendrograms
-        # We're replacing them with nicer colors
-        d = {'r': 'red',
-             'g': 'green',
-             'b': 'blue',
-             'c': 'cyan',
-             'm': 'magenta',
-             'y': 'yellow',
-             'k': 'black',
-             'w': 'white'}
-        default_colors = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
-
-        if colorscale is None:
-            colorscale = [
-                'rgb(0,116,217)',  # blue
-                'rgb(35,205,205)',  # cyan
-                'rgb(61,153,112)',  # green
-                'rgb(40,35,35)',  # black
-                'rgb(133,20,75)',  # magenta
-                'rgb(255,65,54)',  # red
-                'rgb(255,255,255)',  # white
-                'rgb(255,220,0)']  # yellow
-
-        for i in range(len(default_colors.keys())):
-            k = list(default_colors.keys())[i]  # PY3 won't index keys
-            if i < len(colorscale):
-                default_colors[k] = colorscale[i]
-
-        return default_colors
-
-    def set_axis_layout(self, axis_key):
-        """
-        Sets and returns default axis object for dendrogram figure.
-        :param (str) axis_key: E.g., 'xaxis', 'xaxis1', 'yaxis', yaxis1', etc.
-        :rtype (dict): An axis_key dictionary with set parameters.
-        """
-        axis_defaults = {
-                'type': 'linear',
-                'ticks': 'outside',
-                'mirror': 'allticks',
-                'rangemode': 'tozero',
-                'showticklabels': True,
-                'zeroline': False,
-                'showgrid': False,
-                'showline': True,
-            }
-
-        if len(self.labels) != 0:
-            axis_key_labels = self.xaxis
-            if self.orientation in ['left', 'right']:
-                axis_key_labels = self.yaxis
-            if axis_key_labels not in self.layout:
-                self.layout[axis_key_labels] = {}
-            self.layout[axis_key_labels]['tickvals'] = \
-                [zv*self.sign[axis_key] for zv in self.zero_vals]
-            self.layout[axis_key_labels]['ticktext'] = self.labels
-            self.layout[axis_key_labels]['tickmode'] = 'array'
-
-        self.layout[axis_key].update(axis_defaults)
-
-        return self.layout[axis_key]
-
-    def set_figure_layout(self, width, height):
-        """
-        Sets and returns default layout object for dendrogram figure.
-        """
-        self.layout.update({
-            'showlegend': False,
-            'autosize': False,
-            'hovermode': 'closest',
-            'width': width,
-            'height': height
-        })
-
-        self.set_axis_layout(self.xaxis)
-        self.set_axis_layout(self.yaxis)
-
-        return self.layout
-
-    def get_dendrogram_traces(self, X, colorscale, distfun, linkagefun, hovertext, color_threshold):
-        """
-        Calculates all the elements needed for plotting a dendrogram.
-        :param (ndarray) X: Matrix of observations as array of arrays
-        :param (list) colorscale: Color scale for dendrogram tree clusters
-        :param (function) distfun: Function to compute the pairwise distance
-                                   from the observations
-        :param (function) linkagefun: Function to compute the linkage matrix
-                                      from the pairwise distances
-        :param (list) hovertext: List of hovertext for constituent traces of dendrogram
-        :rtype (tuple): Contains all the traces in the following order:
-            (a) trace_list: List of Plotly trace objects for dendrogram tree
-            (b) icoord: All X points of the dendrogram tree as array of arrays
-                with length 4
-            (c) dcoord: All Y points of the dendrogram tree as array of arrays
-                with length 4
-            (d) ordered_labels: leaf labels in the order they are going to
-                appear on the plot
-            (e) P['leaves']: left-to-right traversal of the leaves
-        """
-        d = distfun(X)
-        Z = linkagefun(d)
-        P = sch.dendrogram(Z, orientation=self.orientation,
-                           labels=self.labels, no_plot=True,
-                           color_threshold=color_threshold)
-
-        icoord = scp.array(P['icoord'])
-        dcoord = scp.array(P['dcoord'])
-        ordered_labels = scp.array(P['ivl'])
-        color_list = scp.array(P['color_list'])
-        colors = self.get_color_dict(colorscale)
-
-        trace_list = []
-
-        for i in range(len(icoord)):
-            # xs and ys are arrays of 4 points that make up the '∩' shapes
-            # of the dendrogram tree
-            if self.orientation in ['top', 'bottom']:
-                xs = icoord[i]
-            else:
-                xs = dcoord[i]
-
-            if self.orientation in ['top', 'bottom']:
-                ys = dcoord[i]
-            else:
-                ys = icoord[i]
-            color_key = color_list[i]
-            hovertext_label = None
-            if hovertext:
-                hovertext_label = hovertext[i]
-            trace = dict(
-                type='scatter',
-                x=np.multiply(self.sign[self.xaxis], xs),
-                y=np.multiply(self.sign[self.yaxis], ys),
-                mode='lines',
-                marker=dict(color=colors[color_key]),
-                text=hovertext_label,
-                hoverinfo='text'
-            )
-
-            try:
-                x_index = int(self.xaxis[-1])
-            except ValueError:
-                x_index = ''
-
-            try:
-                y_index = int(self.yaxis[-1])
-            except ValueError:
-                y_index = ''
-
-            trace['xaxis'] = 'x' + x_index
-            trace['yaxis'] = 'y' + y_index
-
-            trace_list.append(trace)
-
-        return trace_list, icoord, dcoord, ordered_labels, P['leaves']
+    layout[xaxis].update(_axis_layout_defaults())
+    layout[yaxis].update(_axis_layout_defaults())
+    return layout

--- a/BioDendro/preprocess.py
+++ b/BioDendro/preprocess.py
@@ -22,6 +22,20 @@ class MGF(object):
         self.mzs = [r.pepmass.mz for r in records]
         return
 
+    def __str__(self):
+        cls = self.__class__.__name__
+        template = "{}(records=[\n{}\n{}])"
+        n_to_display = 5
+        trailing = "...\n" if n_to_display < len(self.records) else ""
+        return template.format(
+            cls,
+            ",\n".join(map(str, self.records[:n_to_display])),
+            trailing
+        )
+
+    def __repr__(self):
+        return str(self)
+
     @classmethod
     def parse(cls, handle, scaling=False, filtering=False, eps=0.0):
         records = MGFRecord.parse(
@@ -188,18 +202,22 @@ class MGFRecord(object):
         if max_inten > 0.0:
             # Divide by max if values aren't none.
             # Keep none values around though.
-            scaled_intensities = map(
+            scaled_intensities = list(map(
                 lambda i: i / max_inten if i is not None else None,
                 intensities
-            )
+            ))
         else:
             scaled_intensities = intensities
+
+        # If we're scaling, we can discard regular intensities.
+        if scaling:
+            intensities = scaled_intensities
 
         # Precompute filter mask.
         # Still get cost if not filtering, but makes code simpler.
         # When this is true, the value will be retained
         filter_mask = map(
-            lambda: i >= eps if i is not None else True,
+            lambda i: i >= eps if i is not None else True,
             scaled_intensities
         )
 

--- a/BioDendro/preprocess.py
+++ b/BioDendro/preprocess.py
@@ -31,7 +31,7 @@ class MGF(object):
         return cls(records)
 
 
-    def closest(self, mz, retention, mz_tol=0.002, retention_tol=5):
+    def closest(self, mz, retention, mz_tol, retention_tol):
         """ Find the closest trigger match to a mz and retention value.
 
         Keyword arguments:

--- a/BioDendro/preprocess.py
+++ b/BioDendro/preprocess.py
@@ -7,7 +7,6 @@ import re
 from bisect import bisect_left
 from collections import namedtuple
 
-import numpy as np
 import pandas as pd
 
 
@@ -23,13 +22,16 @@ class MGF(object):
         self.mzs = [r.pepmass.mz for r in records]
         return
 
-
     @classmethod
-    def parse(cls, handle, scaling = False, filtering = False, eps=0.0):
-        records = MGFRecord.parse(handle, scaling = scaling, filtering = filtering, eps=eps)
+    def parse(cls, handle, scaling=False, filtering=False, eps=0.0):
+        records = MGFRecord.parse(
+            handle,
+            scaling=scaling,
+            filtering=filtering,
+            eps=eps
+        )
         records.sort(key=lambda x: x.pepmass.mz)
         return cls(records)
-
 
     def closest(self, mz, retention, mz_tol, retention_tol):
         """ Find the closest trigger match to a mz and retention value.
@@ -58,7 +60,7 @@ class MGF(object):
 
         # Initialise the minimum mass distance
         # Unrealistic number to guarantee match
-        min_dist_mz = float("inf")
+        # min_dist_mz = float("inf")
         # Initialise minimum retention distance
         min_dist_retention = float("inf")
 
@@ -102,7 +104,6 @@ class MGFRecord(object):
         self.ions = ions
         return
 
-
     def __str__(self):
         cls = self.__class__.__name__
         template = ("{}(title='{}', retention={}, pepmass={}, "
@@ -110,16 +111,13 @@ class MGFRecord(object):
         return template.format(cls, self.title, self.retention, self.pepmass,
                                self.charge, self.ions)
 
-
     def __repr__(self):
         return str(self)
 
-
     @staticmethod
     def _split_kvline(key, string):
-        """ Takes a field key and string and removes the key and equals sign """
+        """ Takes a field key and string, removes the key and equals sign """
         return string[len(key) + 1:].strip()
-
 
     @classmethod
     def _get_title(cls, string, key="TITLE"):
@@ -130,13 +128,11 @@ class MGFRecord(object):
         """
         return cls._split_kvline(key, string)
 
-
     @classmethod
     def _get_pepmass(cls, string, key="PEPMASS"):
         """ Strips key from mass and returns an Ion object. """
         pepmass = cls._split_kvline(key, string)
         return cls._get_ion(pepmass)
-
 
     @classmethod
     def _get_retention(cls, string, key="RTINSECONDS"):
@@ -148,7 +144,6 @@ class MGFRecord(object):
     def _get_charge(cls, string, key="CHARGE"):
         """ Not fully implemented. Just basic support. """
         return cls._split_kvline(key, string)
-
 
     @classmethod
     def _get_ion(cls, string):
@@ -167,79 +162,58 @@ class MGFRecord(object):
 
     @staticmethod
     def _get_altered_ions(ions, scaling, filtering, eps=0.0):
-        if scaling == False and filtering == False:
-            return ions # Nothing is done
+        if not scaling and not filtering:
+            return ions  # Nothing is done
+
+        # extract the flattened mz and intensities as lists
+        mzs = []
+        intensities = []
+
+        all_none = True
+        max_inten = float("-inf")
+        for i in ions:
+            mzs.append(i.mz)
+            intensities.append(i.intensity)
+
+            if i.intensity is not None:
+                all_none = False
+
+            if i.intensity > max_inten:
+                max_inten = i.intensity
+
+        # Can't do anything without intensities.
+        if all_none:
+            return ions
+
+        if max_inten > 0.0:
+            # Divide by max if values aren't none.
+            # Keep none values around though.
+            scaled_intensities = map(
+                lambda i: i / max_inten if i is not None else None,
+                intensities
+            )
         else:
-            mz = []
-            intensity = []
-            ret_mz = []
-            ret_inten = []
-            ret_ions = []
-            for i in ions: # extract the mz and intensities in lists
-                mz.append(i.mz)
-                intensity.append(i.intensity)
-            # Converting into np array with None values converted to np.nan
-            np_intensity = np.array(intensity, dtype=np.float)
-            if(np.isnan(np_intensity).all()): # If all intensities are nan
-                return ions
-            else:
-                max_inten = max(np_intensity)
-                if max_inten > 0.0:
-                    scaled_intensity = np_intensity/max_inten
-                else:
-                    scaled_intensity = np_intensity
-                    
-                # 1. Only filtering using eps value
-                if scaling == False and filtering == True:
-                    if(np.isnan(np_intensity).any()):
-                        for k, inten in enumerate(scaled_intensity):
-                            if np.isnan(inten):
-                                ret_inten.append(None)
-                                ret_mz.append(mz[k])
-                            else:
-                                if inten >= eps:
-                                    ret_inten.append(intensity[k])
-                                    ret_mz.append(mz[k])
-                    else:
-                        ret_inten = np_intensity[scaled_intensity >= eps].tolist()
-                        ret_mz = (np.array(mz)[scaled_intensity >= eps]).tolist()
-                elif scaling == True and filtering == False:
-                    if(np.isnan(np_intensity).any()):
-                        for k, inten in enumerate(scaled_intensity):
-                            if np.isnan(inten):
-                                ret_inten.append(None)
-                                ret_mz.append(mz[k])
-                            else:
-                                ret_inten.append(scaled_intensity[k])
-                                ret_mz.append(mz[k])
-                    else:
-                        ret_inten = scaled_intensity.tolist() # need to change nans into None
-                        ret_mz = mz
-                else:
-                    if(np.isnan(np_intensity).any()):
-                        for k, inten in enumerate(scaled_intensity):
-                            if np.isnan(inten):
-                                ret_inten.append(None)
-                                ret_mz.append(mz[k])
-                            else:
-                                if inten >= eps:
-                                    ret_inten.append(scaled_intensity[k])
-                                    ret_mz.append(mz[k])
-                    else:
-                        ret_inten = (scaled_intensity[scaled_intensity >= eps]).tolist()
-                        ret_mz = (np.array(mz)[scaled_intensity >= eps]).tolist()
-                    
-                for j in range(len(ret_inten)):
-                    ion = Ion(ret_mz[j], ret_inten[j])
-                    ret_ions.append(ion)
+            scaled_intensities = intensities
+
+        # Precompute filter mask.
+        # Still get cost if not filtering, but makes code simpler.
+        # When this is true, the value will be retained
+        filter_mask = map(
+            lambda: i >= eps if i is not None else True,
+            scaled_intensities
+        )
+
+        ret_ions = [
+            Ion(mz, inten)
+            for mz, inten, mask
+            in zip(mzs, intensities, filter_mask)
+            if (filtering and mask) or (not filtering)
+        ]
+
         return ret_ions
-        
-                
-            
-            
-        
+
     @classmethod
-    def _read(cls, lines, scaling = False, filtering = False, eps = 0.0):
+    def _read(cls, lines, scaling=False, filtering=False, eps=0.0):
         title = None
         retention = None
         pepmass = None
@@ -267,14 +241,18 @@ class MGFRecord(object):
                 # Eventually need to wrap this in try... except
                 ion = cls._get_ion(line)
                 ions.append(ion)
-                
-            ret_ions = MGFRecord._get_altered_ions(ions, scaling=scaling, filtering=filtering, eps=eps)
+
+            ret_ions = MGFRecord._get_altered_ions(
+                ions,
+                scaling=scaling,
+                filtering=filtering,
+                eps=eps
+            )
 
         return cls(title, retention, pepmass, charge, ret_ions)
 
-
     @classmethod
-    def parse(cls, handle, scaling = False, filtering = False, eps=0.0):
+    def parse(cls, handle, scaling=False, filtering=False, eps=0.0):
         """ Parses an MGF file into a list of MGF objects.
 
         keyword arguments:
@@ -287,7 +265,14 @@ class MGFRecord(object):
         block = []
         for line in handle:
             if line.startswith("END"):
-                output.append(cls._read(block, scaling = scaling, filtering = filtering, eps=eps))
+                output.append(
+                    cls._read(
+                        block,
+                        scaling=scaling,
+                        filtering=filtering,
+                        eps=eps
+                    )
+                )
                 block = []
                 in_block = False
 
@@ -307,7 +292,6 @@ def split_msms_title(line):
     regex = re.compile(r"\\|/")
     sline = line.split(" ")
 
-
     # Using a regex to spit on file paths to handle
     # different OS's
     filename = regex.split(sline[1])[-1]
@@ -317,12 +301,12 @@ def split_msms_title(line):
 
 class SampleRecord(object):
 
-    def __init__(self, mz, retention):
+    def __init__(self, mz, retention, original):
         """ A simple class to store 'real samples'. """
         self.mz = mz
         self.retention = retention
+        self.original = original
         return
-
 
     @classmethod
     def _read(cls, line, sep="_"):
@@ -334,8 +318,7 @@ class SampleRecord(object):
 
         # Get real sample retention time in seconds.
         retention = float(sline[4].lstrip('RT')) * 60
-        return cls(mz, retention)
-
+        return cls(mz, retention, line.strip())
 
     @classmethod
     def parse(cls, handle):
@@ -351,6 +334,14 @@ class SampleRecord(object):
             output.append(cls._read(line))
 
         return output
+
+    def __str__(self):
+        cls = self.__class__.__name__
+        template = "{}(mz={}, retention={}, original='{}')"
+        return template.format(cls, self.mz, self.retention, self.original)
+
+    def __repr__(self):
+        return str(self)
 
 
 def remove_redundancy(samples, mgf, mz_tol=0.002, retention_tol=5,
@@ -379,13 +370,16 @@ def remove_redundancy(samples, mgf, mz_tol=0.002, retention_tol=5,
                 ion_mz = ion.mz
 
             record = (
-                "{}_{}_{}".format(trigger.title, trigger.pepmass.mz, trigger.retention),
+                sample.original,
+                "{}_{}_{}".format(trigger.title,
+                                  trigger.pepmass.mz,
+                                  trigger.retention),
                 ion_mz
                 )
             output.append(record)
 
     # Return the table, sorted by mz
-    table = pd.DataFrame(output, columns=['sample', 'mz'])
+    table = pd.DataFrame(output, columns=['component', 'sample', 'mz'])
     table.sort_values(by='mz', inplace=True)
     table.reset_index(drop=True, inplace=True)
     return table

--- a/longer-example.ipynb
+++ b/longer-example.ipynb
@@ -4,113 +4,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Running BioDendro Pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "usage: BioDendro [-h] [-n] [-c CUTOFF] [-b BIN_THRESHOLD]\r\n",
-      "                 [-d {jaccard,braycurtis}] [-p PROCESSED] [-o OUT_HTML]\r\n",
-      "                 [-r RESULTS_DIR] [-x WIDTH_PX] [-y HEIGHT_PX] [-q]\r\n",
-      "                 mgf components\r\n",
-      "\r\n",
-      "Run the BioDendro pipeline.\r\n",
-      "\r\n",
-      "positional arguments:\r\n",
-      "  mgf                   MGF input file.\r\n",
-      "  components            Listed components file.\r\n",
-      "\r\n",
-      "optional arguments:\r\n",
-      "  -h, --help            show this help message and exit\r\n",
-      "  -n, --neutral         Apply neutral loss.\r\n",
-      "  -c CUTOFF, --cutoff CUTOFF\r\n",
-      "                        Distance threshold for selecting clusters from tree.\r\n",
-      "  -b BIN_THRESHOLD, --bin-threshold BIN_THRESHOLD\r\n",
-      "                        Threshold for binning m/z values prior to clustering.\r\n",
-      "  -d {jaccard,braycurtis}, --cluster-method {jaccard,braycurtis}\r\n",
-      "                        The distance metric used during tree construction.\r\n",
-      "  -p PROCESSED, --processed PROCESSED\r\n",
-      "                        Path to write preprocessed output to.\r\n",
-      "  -o OUT_HTML, --output OUT_HTML\r\n",
-      "                        Path to write interactive html plot to.\r\n",
-      "  -r RESULTS_DIR, --results-dir RESULTS_DIR\r\n",
-      "                        Directory to write per-cluster plots and table\r\n",
-      "                        to.Default is to use 'results_20180606112200' where\r\n",
-      "                        the number isthe current datetime. WARNING: will\r\n",
-      "                        overwrite contents of existing directories.\r\n",
-      "  -x WIDTH_PX, --width WIDTH_PX\r\n",
-      "                        The width of the dendrogram plot in pixels.\r\n",
-      "  -y HEIGHT_PX, --height HEIGHT_PX\r\n",
-      "                        The height of the dendrogram plot in pixels.\r\n",
-      "  -q, --quiet           Suppress status notifications written to stdout.\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "# listed are all BioDendro pipeline arguments\n",
-    "\n",
-    "!BioDendro -h"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running BioDendro v0.0.1\n",
-      "\n",
-      "- input mgf file = ./MSMS.mgf\n",
-      "- input components file = ./component_list.txt\n",
-      "- neutral = False\n",
-      "- cutoff = 0.6\n",
-      "- bin_threshold = 0.0008\n",
-      "- clustering_method = jaccard\n",
-      "- output processed file = processed.xlsx\n",
-      "- output results directory = results_20180604130113\n",
-      "- output html dendrogram = simple_dendrogram.html\n",
-      "- dendrogram figure width = 900\n",
-      "- dendrogram figure height = 400\n",
-      "\n",
-      "\n",
-      "Processing inputs\n",
-      "Binning and clustering\n",
-      "This may take some time...\n",
-      "Writing per-cluster summaries\n",
-      "Writing output html dendrogram\n",
-      "Finished\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Run the complete pipeline\n",
-    "\n",
-    "! BioDendro ./MSMS.mgf ./component_list.txt"
+    "# Details of the BioDendro pipeline"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Running the pipeline interactively."
+    "## Running the pipeline manually\n",
+    "\n",
+    "BioDendro essentially does the following steps:\n",
+    "\n",
+    "1. Parse the MGF and components files\n",
+    "   - Optionally scaling and filtering Ions from MGF with a minimum intensity threshold.\n",
+    "2. Find Ions matching components\n",
+    "3. Bins mz values by proximity\n",
+    "4. Uses binned mz values to cluster components into a tree"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load required modules\n",
@@ -122,6 +37,104 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Loading the MGF file is relatively straight forward using python.\n",
+    "\n",
+    "The pipeline changes the MGF record titles in a way that won't always be portable.\n",
+    "If you encounter issues with record titles, you may wish to exclude the `split_msms_title` step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MGF(records=[\n",
+       "MGFRecord(title='QE_2017_001814', retention=141.0, pepmass=Ion(mz=81.52061, intensity=1678597.25), charge='1+', ions=[Ion(mz=53.00264, intensity=1252.15), Ion(mz=60.7764, intensity=1324.65)]),\n",
+       "MGFRecord(title='QE_2017_001814', retention=877.0, pepmass=Ion(mz=81.52061, intensity=19463956.0), charge='2+', ions=[Ion(mz=59.32066, intensity=14996.5), Ion(mz=131.81848, intensity=18682.3), Ion(mz=176.21725, intensity=18992.1)]),\n",
+       "MGFRecord(title='QE_2017_001816', retention=447.0, pepmass=Ion(mz=81.52061, intensity=2814306.5), charge='1+', ions=[Ion(mz=53.0393, intensity=1853.67)]),\n",
+       "MGFRecord(title='QE_2017_001814', retention=436.0, pepmass=Ion(mz=81.52064, intensity=2750625.5), charge='1+', ions=[Ion(mz=63.59929, intensity=2020.82)]),\n",
+       "MGFRecord(title='QE_2017_001815', retention=887.0, pepmass=Ion(mz=81.52064, intensity=15775805.0), charge='2+', ions=[Ion(mz=124.5074, intensity=13727.9), Ion(mz=184.32289, intensity=14260.0)])\n",
+       "...\n",
+       "])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the MSMS records\n",
+    "\n",
+    "with open(\"MSMS.mgf\") as handle:\n",
+    "    mgf = preprocess.MGF.parse(handle)\n",
+    "\n",
+    "# Splits the title up.\n",
+    "# You may need to skip this step.\n",
+    "for record in mgf.records:\n",
+    "    record.title = preprocess.split_msms_title(record.title)\n",
+    "\n",
+    "mgf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point we might decide to scale and/or filter the Ions for each MGFRecord."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MGF(records=[\n",
+       "MGFRecord(title='QE_2017_001814', retention=141.0, pepmass=Ion(mz=81.52061, intensity=1678597.25), charge='1+', ions=[Ion(mz=53.00264, intensity=0.9452685615068132), Ion(mz=60.7764, intensity=1.0)]),\n",
+       "MGFRecord(title='QE_2017_001814', retention=877.0, pepmass=Ion(mz=81.52061, intensity=19463956.0), charge='2+', ions=[Ion(mz=59.32066, intensity=0.7896177884488814), Ion(mz=131.81848, intensity=0.9836879544652777), Ion(mz=176.21725, intensity=1.0)]),\n",
+       "MGFRecord(title='QE_2017_001816', retention=447.0, pepmass=Ion(mz=81.52061, intensity=2814306.5), charge='1+', ions=[Ion(mz=53.0393, intensity=1.0)]),\n",
+       "MGFRecord(title='QE_2017_001814', retention=436.0, pepmass=Ion(mz=81.52064, intensity=2750625.5), charge='1+', ions=[Ion(mz=63.59929, intensity=1.0)]),\n",
+       "MGFRecord(title='QE_2017_001815', retention=887.0, pepmass=Ion(mz=81.52064, intensity=15775805.0), charge='2+', ions=[Ion(mz=124.5074, intensity=0.9626858345021038), Ion(mz=184.32289, intensity=1.0)])\n",
+       "...\n",
+       "])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(\"MSMS.mgf\") as handle:\n",
+    "    mgf_scaled = preprocess.MGF.parse(handle, scaling=True, filtering=True, eps=0.2)\n",
+    "\n",
+    "# Splits the title up.\n",
+    "# You may need to skip this step.\n",
+    "for record in mgf_scaled.records:\n",
+    "    record.title = preprocess.split_msms_title(record.title)\n",
+    "\n",
+    "mgf_scaled"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You'll notice in the ions field of each MGF record that the \"intensity\" values have been scaled to numbers between 0 and 1, and that any ions with scaled intensity below 0.2 will be filtered out.\n",
+    "\n",
+    "Loading components files is a similar process."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -129,46 +142,14 @@
     {
      "data": {
       "text/plain": [
-       "[MGFRecord(title='QE_2017_001814', retention=141.0, pepmass=Ion(mz=81.52061, intensity=1678597.25), charge='1+', ions=[Ion(mz=53.00264, intensity=1252.15), Ion(mz=60.7764, intensity=1324.65)]),\n",
-       " MGFRecord(title='QE_2017_001814', retention=877.0, pepmass=Ion(mz=81.52061, intensity=19463956.0), charge='2+', ions=[Ion(mz=59.32066, intensity=14996.5), Ion(mz=131.81848, intensity=18682.3), Ion(mz=176.21725, intensity=18992.1)]),\n",
-       " MGFRecord(title='QE_2017_001816', retention=447.0, pepmass=Ion(mz=81.52061, intensity=2814306.5), charge='1+', ions=[Ion(mz=53.0393, intensity=1853.67)]),\n",
-       " MGFRecord(title='QE_2017_001814', retention=436.0, pepmass=Ion(mz=81.52064, intensity=2750625.5), charge='1+', ions=[Ion(mz=63.59929, intensity=2020.82)]),\n",
-       " MGFRecord(title='QE_2017_001815', retention=887.0, pepmass=Ion(mz=81.52064, intensity=15775805.0), charge='2+', ions=[Ion(mz=124.5074, intensity=13727.9), Ion(mz=184.32289, intensity=14260.0)])]"
+       "[SampleRecord(mz=125.9862, retention=56.964, original='Chinese Spring 1_001829_0849_m/z125.9862_RT0.9494'),\n",
+       " SampleRecord(mz=129.1273, retention=318.834, original='Chinese Spring 1_001829_4030_m/z129.1273_RT5.3139'),\n",
+       " SampleRecord(mz=129.1273, retention=348.516, original='Chinese Spring 1_001829_4681_m/z129.1273_RT5.8086'),\n",
+       " SampleRecord(mz=129.1274, retention=327.924, original='Chinese Spring 1_001829_4250_m/z129.1274_RT5.4654'),\n",
+       " SampleRecord(mz=129.1274, retention=392.68800000000005, original='Chinese Spring 1_001829_5303_m/z129.1274_RT6.5448')]"
       ]
      },
      "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Load the MSMS records \n",
-    "\n",
-    "with open(\"./MSMS.mgf\") as handle:\n",
-    "    mgf = preprocess.MGF.parse(handle)\n",
-    "\n",
-    "for record in mgf.records:\n",
-    "    record.title = preprocess.split_msms_title(record.title)\n",
-    "\n",
-    "mgf.records[:5]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<BioDendro.preprocess.SampleRecord at 0x7fd97c94eba8>,\n",
-       " <BioDendro.preprocess.SampleRecord at 0x7fd97c94eb70>,\n",
-       " <BioDendro.preprocess.SampleRecord at 0x7fd97c94e860>,\n",
-       " <BioDendro.preprocess.SampleRecord at 0x7fd97c94ea90>,\n",
-       " <BioDendro.preprocess.SampleRecord at 0x7fd97c94eac8>]"
-      ]
-     },
-     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -183,8 +164,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we find the ions for each components."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -208,6 +196,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>component</th>\n",
        "      <th>sample</th>\n",
        "      <th>mz</th>\n",
        "    </tr>\n",
@@ -215,43 +204,55 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>Chinese Spring 1_001829_6995_m/z353.2686_RT10....</td>\n",
        "      <td>QE_2017_001814_353.26889_609.0</td>\n",
        "      <td>50.06792</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
+       "      <td>Chinese Spring 1_001829_2250_m/z177.0544_RT3.6957</td>\n",
        "      <td>QE_2017_001816_177.05449_217.0</td>\n",
        "      <td>50.44534</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
+       "      <td>Chinese Spring 1_001829_2318_m/z235.1439_RT3.7670</td>\n",
        "      <td>QE_2017_001815_235.14398_226.0</td>\n",
        "      <td>50.48630</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>QE_2017_001816_211.16916_405.0</td>\n",
-       "      <td>50.49868</td>\n",
+       "      <td>Chinese Spring 1_001829_5175_m/z219.1014_RT6.3621</td>\n",
+       "      <td>QE_2017_001816_219.10153_382.0</td>\n",
+       "      <td>50.49461</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>QE_2017_001815_613.4826_734.0</td>\n",
-       "      <td>50.57634</td>\n",
+       "      <td>Chinese Spring 1_001829_5465_m/z211.1690_RT6.7722</td>\n",
+       "      <td>QE_2017_001816_211.16916_405.0</td>\n",
+       "      <td>50.49868</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                           sample        mz\n",
-       "0  QE_2017_001814_353.26889_609.0  50.06792\n",
-       "1  QE_2017_001816_177.05449_217.0  50.44534\n",
-       "2  QE_2017_001815_235.14398_226.0  50.48630\n",
-       "3  QE_2017_001816_211.16916_405.0  50.49868\n",
-       "4   QE_2017_001815_613.4826_734.0  50.57634"
+       "                                           component  \\\n",
+       "0  Chinese Spring 1_001829_6995_m/z353.2686_RT10....   \n",
+       "1  Chinese Spring 1_001829_2250_m/z177.0544_RT3.6957   \n",
+       "2  Chinese Spring 1_001829_2318_m/z235.1439_RT3.7670   \n",
+       "3  Chinese Spring 1_001829_5175_m/z219.1014_RT6.3621   \n",
+       "4  Chinese Spring 1_001829_5465_m/z211.1690_RT6.7722   \n",
+       "\n",
+       "                           sample        mz  \n",
+       "0  QE_2017_001814_353.26889_609.0  50.06792  \n",
+       "1  QE_2017_001816_177.05449_217.0  50.44534  \n",
+       "2  QE_2017_001815_235.14398_226.0  50.48630  \n",
+       "3  QE_2017_001816_219.10153_382.0  50.49461  \n",
+       "4  QE_2017_001816_211.16916_405.0  50.49868  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -264,11 +265,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And finally, we can cluster the data using a `Tree` object.\n",
+    "\n",
+    "The interface to `Tree` is similar to `scikit-learn` objects, where first you initialise a model with parameters, then you fit it with some data."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Using the non-redundant dataframe, bin analytes on threshold=8e-4 and return a data matrix\n",
@@ -280,8 +288,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The threshold is the parameter that affects binning.\n",
+    "Increasing the threshold will reduce the number of bins, decreasing the threshold will make bins more granular.\n",
+    "\n",
+    "The tree object now contains all of our intermediate data.\n",
+    "\n",
+    "We can look at which samples have which bins in a [Pandas](https://pandas.pydata.org/) dataframe.\n",
+    "This is the matrix used to compute distances based on presence absence."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -306,23 +327,23 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th>bins</th>\n",
        "      <th>100.0246_100.0246_100.0246</th>\n",
-       "      <th>100.0394_100.0394_100.0394</th>\n",
-       "      <th>100.0759_100.0759_100.0759</th>\n",
-       "      <th>100.1122_100.1122_100.1122</th>\n",
+       "      <th>100.0395_100.0395_100.0395</th>\n",
+       "      <th>100.0759_100.0759_100.0760</th>\n",
+       "      <th>100.1123_100.1122_100.1123</th>\n",
        "      <th>100.1311_100.1311_100.1311</th>\n",
        "      <th>100.5562_100.5562_100.5562</th>\n",
        "      <th>100.6662_100.6662_100.6662</th>\n",
        "      <th>101.0235_101.0235_101.0235</th>\n",
        "      <th>101.0598_101.0596_101.0599</th>\n",
-       "      <th>101.0711_101.0711_101.0712</th>\n",
+       "      <th>101.0712_101.0711_101.0712</th>\n",
        "      <th>...</th>\n",
-       "      <th>98.5418_98.5418_98.5418</th>\n",
+       "      <th>98.0966_98.0964_98.0967</th>\n",
+       "      <th>98.5142_98.5142_98.5142</th>\n",
        "      <th>98.5942_98.5942_98.5942</th>\n",
        "      <th>98.8081_98.8081_98.8081</th>\n",
-       "      <th>98.9756_98.9755_98.9757</th>\n",
+       "      <th>98.9756_98.9755_98.9759</th>\n",
        "      <th>98.9844_98.9844_98.9845</th>\n",
        "      <th>99.0034_99.0034_99.0034</th>\n",
-       "      <th>99.0080_99.0080_99.0080</th>\n",
        "      <th>99.0443_99.0441_99.0445</th>\n",
        "      <th>99.0807_99.0804_99.0809</th>\n",
        "      <th>99.1172_99.1172_99.1172</th>\n",
@@ -354,55 +375,31 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>QE_2017_001814_129.12737_348.0</th>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>QE_2017_001814_171.14908_419.0</th>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>QE_2017_001814_177.05418_236.0</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>QE_2017_001814_182.08116_51.0</th>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -473,176 +470,192 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>QE_2017_001814_194.1174_244.0</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 1922 columns</p>\n",
+       "<p>5 rows × 1941 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "bins                           100.0246_100.0246_100.0246  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
-       "bins                           100.0394_100.0394_100.0394  \\\n",
+       "bins                           100.0395_100.0395_100.0395  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
-       "bins                           100.0759_100.0759_100.0759  \\\n",
+       "bins                           100.0759_100.0759_100.0760  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
-       "bins                           100.1122_100.1122_100.1122  \\\n",
+       "bins                           100.1123_100.1122_100.1123  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                       True   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
        "bins                           100.1311_100.1311_100.1311  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
        "bins                           100.5562_100.5562_100.5562  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
        "bins                           100.6662_100.6662_100.6662  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
        "bins                           101.0235_101.0235_101.0235  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
        "bins                           101.0598_101.0596_101.0599  \\\n",
        "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
        "QE_2017_001814_177.05418_236.0                      False   \n",
+       "QE_2017_001814_182.08116_51.0                       False   \n",
        "QE_2017_001814_191.14291_389.0                      False   \n",
        "QE_2017_001814_194.04424_237.0                      False   \n",
+       "QE_2017_001814_194.1174_244.0                       False   \n",
        "\n",
-       "bins                           101.0711_101.0711_101.0712  \\\n",
-       "sample                                                      \n",
-       "QE_2017_001814_129.12737_348.0                      False   \n",
-       "QE_2017_001814_171.14908_419.0                      False   \n",
-       "QE_2017_001814_177.05418_236.0                      False   \n",
-       "QE_2017_001814_191.14291_389.0                      False   \n",
-       "QE_2017_001814_194.04424_237.0                      False   \n",
+       "bins                           101.0712_101.0711_101.0712  ...  \\\n",
+       "sample                                                     ...   \n",
+       "QE_2017_001814_177.05418_236.0                      False  ...   \n",
+       "QE_2017_001814_182.08116_51.0                       False  ...   \n",
+       "QE_2017_001814_191.14291_389.0                      False  ...   \n",
+       "QE_2017_001814_194.04424_237.0                      False  ...   \n",
+       "QE_2017_001814_194.1174_244.0                       False  ...   \n",
        "\n",
-       "bins                                     ...            \\\n",
-       "sample                                   ...             \n",
-       "QE_2017_001814_129.12737_348.0           ...             \n",
-       "QE_2017_001814_171.14908_419.0           ...             \n",
-       "QE_2017_001814_177.05418_236.0           ...             \n",
-       "QE_2017_001814_191.14291_389.0           ...             \n",
-       "QE_2017_001814_194.04424_237.0           ...             \n",
-       "\n",
-       "bins                           98.5418_98.5418_98.5418  \\\n",
+       "bins                           98.0966_98.0964_98.0967  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
+       "\n",
+       "bins                           98.5142_98.5142_98.5142  \\\n",
+       "sample                                                   \n",
+       "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
+       "QE_2017_001814_191.14291_389.0                   False   \n",
+       "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
        "bins                           98.5942_98.5942_98.5942  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
        "bins                           98.8081_98.8081_98.8081  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
-       "bins                           98.9756_98.9755_98.9757  \\\n",
+       "bins                           98.9756_98.9755_98.9759  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
        "bins                           98.9844_98.9844_98.9845  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
        "bins                           99.0034_99.0034_99.0034  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
-       "\n",
-       "bins                           99.0080_99.0080_99.0080  \\\n",
-       "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
-       "QE_2017_001814_177.05418_236.0                   False   \n",
-       "QE_2017_001814_191.14291_389.0                   False   \n",
-       "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
        "bins                           99.0443_99.0441_99.0445  \\\n",
        "sample                                                   \n",
-       "QE_2017_001814_129.12737_348.0                   False   \n",
-       "QE_2017_001814_171.14908_419.0                   False   \n",
        "QE_2017_001814_177.05418_236.0                   False   \n",
+       "QE_2017_001814_182.08116_51.0                    False   \n",
        "QE_2017_001814_191.14291_389.0                   False   \n",
        "QE_2017_001814_194.04424_237.0                   False   \n",
+       "QE_2017_001814_194.1174_244.0                    False   \n",
        "\n",
        "bins                           99.0807_99.0804_99.0809 99.1172_99.1172_99.1172  \n",
        "sample                                                                          \n",
-       "QE_2017_001814_129.12737_348.0                   False                   False  \n",
-       "QE_2017_001814_171.14908_419.0                   False                   False  \n",
        "QE_2017_001814_177.05418_236.0                   False                   False  \n",
+       "QE_2017_001814_182.08116_51.0                    False                   False  \n",
        "QE_2017_001814_191.14291_389.0                   False                   False  \n",
        "QE_2017_001814_194.04424_237.0                   False                   False  \n",
+       "QE_2017_001814_194.1174_244.0                    False                   False  \n",
        "\n",
-       "[5 rows x 1922 columns]"
+       "[5 rows x 1941 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -653,32 +666,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NB. \"one-hot\" encoding is a common technique in ML/statistice where 1 (or True) denotes presence and 0 (or False) denotes absence.\n",
+    "It's related to the concept of Dummy coding.\n",
+    "\n",
+    "We can also look at the clusters derived from the computed tree."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 87,  88, 143,  69, 133, 134, 135, 144, 144,  85,  72,  81,  82,\n",
-       "        70,  70,  71, 117, 139,  78, 131, 131,  40,  38, 128, 150, 100,\n",
-       "       102,  75, 120, 118, 110, 116,   7,  19,  20,  75, 112,  76,  89,\n",
-       "       105, 103, 104,  97,  95,   9,   6,   6,   6,  14,  36,  53,  18,\n",
-       "         8,  62,  60,  57,  60,  61,  91,  12,  41,  31,  29,   4,  24,\n",
-       "        34,  22,  47,  26,   1, 153, 143,  80, 146,  67, 137, 138, 140,\n",
-       "       137, 136, 144, 145, 144,  65,  79,  81,  72,  81, 121, 141, 138,\n",
-       "       124, 122,  83, 109, 108, 108,  70,  98,  73,  39,  38, 129, 114,\n",
-       "       115, 151, 101,  15, 125, 120, 127, 152,   9, 154,  55, 111, 111,\n",
-       "        77, 112,  43, 106,  89,  96,  93,   6,   7,   9,  42,  54,   8,\n",
-       "        59,  63, 147,  64,  48,  11,  51,  35,  13,  10,  32,  30,  33,\n",
-       "       149,   2,  27, 148,   5, 155, 130,  84, 143,  80,  68, 145, 145,\n",
-       "       145, 145,  66,  86,  74,  72,  81, 142, 123,  78, 132, 128,  99,\n",
-       "       126, 127, 119,  56,  21, 113,  45,  44, 107,  92,  95,  94,   6,\n",
-       "        16,  16,  90,  37,  46,  18,  17,  49,  58,  50,  50,  52,  25,\n",
-       "        23,  47,   3,  28], dtype=int32)"
+       "array([151, 147,  97,  36, 103, 153,  99,  89,  93,  93,  92,  40,  86,\n",
+       "       145,  61, 137, 138, 143, 110, 111,  70,  82, 129, 126, 119, 136,\n",
+       "         7,  17,  82, 120,  85, 115,  73, 108, 105, 107, 114,   9,   6,\n",
+       "         6,   6,  14,  59,  46,  16,   8,  53,  75,  12,  69,  31,  29,\n",
+       "         4,  34,  22,  57,  26,  76, 158,  77, 151,  88,  95,  39,  38,\n",
+       "        41, 149,  37, 154, 153,  78,  87,  89,  80,  81,  80,  89, 130,\n",
+       "        42,  38, 133, 131,  90, 117, 118,  92, 141, 127,  83,  62,  61,\n",
+       "        63, 123,  15, 134, 129, 135, 125, 140,   9, 159,  48, 121, 121,\n",
+       "        18,  84,  65,  73, 106, 112, 101,   6,   7,   9,  64,  47,   8,\n",
+       "        52,  53,  56, 155,  55,  71,  11,  44,  35,  13,  32,  30,  33,\n",
+       "       157,  58,  27, 156,   5, 160, 139,  98, 151,  88, 148,  96, 104,\n",
+       "       152, 154, 154, 152, 154, 154,  79, 100,  80,  89, 150,  91, 132,\n",
+       "       117,  94,  86, 145, 146, 137, 124, 144, 142, 136, 128,  49,  21,\n",
+       "       120, 122,  67,  66, 116, 109, 113, 102,   6,  19,  19,  74,  60,\n",
+       "        68,  16,  50,  54,  54,  20,  72,  51,  43,  43,  45,  10,  25,\n",
+       "        23,  24,   1,   3,  28,   2], dtype=int32)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -689,32 +712,80 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a [numpy](https://www.numpy.org/) array.\n",
+    "The order of these is the same as the row index in the one-hot dataframe.\n",
+    "\n",
+    "So we can obtain clusters for each sample like so..."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "151"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dict(zip(tree.onehot_df.index, tree.clusters))['QE_2017_001814_177.05418_236.0']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with the python pipeline in the quick-start notebook, we can easily choose a new cutoff for clustering.\n",
+    "In fact, the pipeline function returns a tree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cutoff: 0.4 n clusters: 155\n",
-      "Cutoff: 0.6 n clusters: 110\n"
+      "BEFORE: Cutoff: 0.4 n clusters: 160\n",
+      "AFTER: Cutoff: 0.6 n clusters: 113\n"
      ]
     }
    ],
    "source": [
     "# To pick new clusters without computing a new tree...\n",
-    "print(\"Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))\n",
+    "print(\"BEFORE: Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))\n",
     "\n",
     "tree.cut_tree(cutoff=0.6)\n",
-    "print(\"Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))\n",
+    "print(\"AFTER: Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))\n",
     "\n",
     "# Note that the object's cutoff value is changed."
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get the cluster numbers along-side the presence absence data we can simply add a new colum to the dataframe, \n",
+    "since it's already in the correct order."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -740,22 +811,22 @@
        "      <th>bins</th>\n",
        "      <th>cluster</th>\n",
        "      <th>100.0246_100.0246_100.0246</th>\n",
-       "      <th>100.0394_100.0394_100.0394</th>\n",
-       "      <th>100.0759_100.0759_100.0759</th>\n",
-       "      <th>100.1122_100.1122_100.1122</th>\n",
+       "      <th>100.0395_100.0395_100.0395</th>\n",
+       "      <th>100.0759_100.0759_100.0760</th>\n",
+       "      <th>100.1123_100.1122_100.1123</th>\n",
        "      <th>100.1311_100.1311_100.1311</th>\n",
        "      <th>100.5562_100.5562_100.5562</th>\n",
        "      <th>100.6662_100.6662_100.6662</th>\n",
        "      <th>101.0235_101.0235_101.0235</th>\n",
        "      <th>101.0598_101.0596_101.0599</th>\n",
        "      <th>...</th>\n",
-       "      <th>98.5418_98.5418_98.5418</th>\n",
+       "      <th>98.0966_98.0964_98.0967</th>\n",
+       "      <th>98.5142_98.5142_98.5142</th>\n",
        "      <th>98.5942_98.5942_98.5942</th>\n",
        "      <th>98.8081_98.8081_98.8081</th>\n",
-       "      <th>98.9756_98.9755_98.9757</th>\n",
+       "      <th>98.9756_98.9755_98.9759</th>\n",
        "      <th>98.9844_98.9844_98.9845</th>\n",
        "      <th>99.0034_99.0034_99.0034</th>\n",
-       "      <th>99.0080_99.0080_99.0080</th>\n",
        "      <th>99.0443_99.0441_99.0445</th>\n",
        "      <th>99.0807_99.0804_99.0809</th>\n",
        "      <th>99.1172_99.1172_99.1172</th>\n",
@@ -787,31 +858,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>QE_2017_001815_613.4826_734.0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>QE_2017_001814_792.56207_723.0</th>\n",
+       "      <th>QE_2017_001816_792.56232_718.0</th>\n",
        "      <td>1</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -836,6 +883,30 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>QE_2017_001816_613.48218_838.0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>QE_2017_001816_613.4826_738.0</th>\n",
        "      <td>2</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -908,166 +979,158 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 1923 columns</p>\n",
+       "<p>5 rows × 1942 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "bins                            cluster 100.0246_100.0246_100.0246  \\\n",
        "sample                                                               \n",
-       "QE_2017_001815_613.4826_734.0         1                      False   \n",
-       "QE_2017_001814_792.56207_723.0        1                      False   \n",
-       "QE_2017_001816_613.48218_838.0        2                      False   \n",
+       "QE_2017_001816_792.56232_718.0        1                      False   \n",
+       "QE_2017_001816_613.48218_838.0        1                      False   \n",
+       "QE_2017_001816_613.4826_738.0         2                      False   \n",
        "QE_2017_001814_596.30963_602.0        3                      False   \n",
        "QE_2017_001815_792.5625_866.0         4                      False   \n",
        "\n",
-       "bins                           100.0394_100.0394_100.0394  \\\n",
+       "bins                           100.0395_100.0395_100.0395  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
-       "bins                           100.0759_100.0759_100.0759  \\\n",
+       "bins                           100.0759_100.0759_100.0760  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
-       "bins                           100.1122_100.1122_100.1122  \\\n",
+       "bins                           100.1123_100.1122_100.1123  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
        "bins                           100.1311_100.1311_100.1311  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
        "bins                           100.5562_100.5562_100.5562  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
        "bins                           100.6662_100.6662_100.6662  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
        "bins                           101.0235_101.0235_101.0235  \\\n",
        "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
+       "QE_2017_001816_792.56232_718.0                      False   \n",
        "QE_2017_001816_613.48218_838.0                      False   \n",
+       "QE_2017_001816_613.4826_738.0                       False   \n",
        "QE_2017_001814_596.30963_602.0                      False   \n",
        "QE_2017_001815_792.5625_866.0                       False   \n",
        "\n",
-       "bins                           101.0598_101.0596_101.0599  \\\n",
-       "sample                                                      \n",
-       "QE_2017_001815_613.4826_734.0                       False   \n",
-       "QE_2017_001814_792.56207_723.0                      False   \n",
-       "QE_2017_001816_613.48218_838.0                      False   \n",
-       "QE_2017_001814_596.30963_602.0                      False   \n",
-       "QE_2017_001815_792.5625_866.0                       False   \n",
+       "bins                           101.0598_101.0596_101.0599  ...  \\\n",
+       "sample                                                     ...   \n",
+       "QE_2017_001816_792.56232_718.0                      False  ...   \n",
+       "QE_2017_001816_613.48218_838.0                      False  ...   \n",
+       "QE_2017_001816_613.4826_738.0                       False  ...   \n",
+       "QE_2017_001814_596.30963_602.0                      False  ...   \n",
+       "QE_2017_001815_792.5625_866.0                       False  ...   \n",
        "\n",
-       "bins                                     ...            \\\n",
-       "sample                                   ...             \n",
-       "QE_2017_001815_613.4826_734.0            ...             \n",
-       "QE_2017_001814_792.56207_723.0           ...             \n",
-       "QE_2017_001816_613.48218_838.0           ...             \n",
-       "QE_2017_001814_596.30963_602.0           ...             \n",
-       "QE_2017_001815_792.5625_866.0            ...             \n",
-       "\n",
-       "bins                           98.5418_98.5418_98.5418  \\\n",
+       "bins                           98.0966_98.0964_98.0967  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
+       "QE_2017_001814_596.30963_602.0                   False   \n",
+       "QE_2017_001815_792.5625_866.0                    False   \n",
+       "\n",
+       "bins                           98.5142_98.5142_98.5142  \\\n",
+       "sample                                                   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
+       "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
        "bins                           98.5942_98.5942_98.5942  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
        "bins                           98.8081_98.8081_98.8081  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
-       "bins                           98.9756_98.9755_98.9757  \\\n",
+       "bins                           98.9756_98.9755_98.9759  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
        "bins                           98.9844_98.9844_98.9845  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
        "bins                           99.0034_99.0034_99.0034  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
-       "QE_2017_001814_596.30963_602.0                   False   \n",
-       "QE_2017_001815_792.5625_866.0                    False   \n",
-       "\n",
-       "bins                           99.0080_99.0080_99.0080  \\\n",
-       "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
-       "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
        "bins                           99.0443_99.0441_99.0445  \\\n",
        "sample                                                   \n",
-       "QE_2017_001815_613.4826_734.0                    False   \n",
-       "QE_2017_001814_792.56207_723.0                   False   \n",
+       "QE_2017_001816_792.56232_718.0                   False   \n",
        "QE_2017_001816_613.48218_838.0                   False   \n",
+       "QE_2017_001816_613.4826_738.0                    False   \n",
        "QE_2017_001814_596.30963_602.0                   False   \n",
        "QE_2017_001815_792.5625_866.0                    False   \n",
        "\n",
        "bins                           99.0807_99.0804_99.0809 99.1172_99.1172_99.1172  \n",
        "sample                                                                          \n",
-       "QE_2017_001815_613.4826_734.0                    False                   False  \n",
-       "QE_2017_001814_792.56207_723.0                   False                   False  \n",
+       "QE_2017_001816_792.56232_718.0                   False                   False  \n",
        "QE_2017_001816_613.48218_838.0                   False                   False  \n",
+       "QE_2017_001816_613.4826_738.0                    False                   False  \n",
        "QE_2017_001814_596.30963_602.0                   False                   False  \n",
        "QE_2017_001815_792.5625_866.0                    False                   False  \n",
        "\n",
-       "[5 rows x 1923 columns]"
+       "[5 rows x 1942 columns]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1087,22 +1150,85 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can write out the results of the clustering as we saw in the quick-start notebook.\n",
+    "Note that the `path` will be a directory where multiple files are written, and it must already exist.\n",
+    "\n",
+    "Also, any results already in the directory will be overwritten.\n",
+    "The default path will use a combination of the date and time to avoid overwriting data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the directory to store results.\n",
+    "os.makedirs(\"results\", exist_ok=True)\n",
+    "\n",
+    "# Generate the plots of clusters.\n",
+    "tree.write_summaries(path=\"results\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 21380\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones   61595 Apr 17 18:11 cluster_100_1.png\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones    5777 Apr 17 18:11 cluster_100_1.xlsx\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones   60178 Apr 17 18:11 cluster_101_1.png\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones    5754 Apr 17 18:11 cluster_101_1.xlsx\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones  212217 Apr 17 16:55 cluster_10_12.png\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones   10746 Apr 17 16:55 cluster_10_12.xlsx\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones   77106 Apr 17 18:11 cluster_102_2.png\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones    5993 Apr 17 18:11 cluster_102_2.xlsx\n",
+      "-rw-r--r--. 1 darcyabjones darcyabjones   60734 Apr 17 18:11 cluster_103_1.png\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "ls -l results | head"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can inspect the hierarchical clustering linkage map output from scipy.\n",
+    "Unfortunately, this lacks a bit of intuition.\n",
+    "The first two columns refer to two nodes in the tree.\n",
+    "The third column gives the distance between the two nodes.\n",
+    "And the fourth column gives the number of leaves that are in or beneath these nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "text/plain": [
-       "array([[8.10000000e+01, 1.57000000e+02, 1.81818182e-01, 2.00000000e+00],\n",
-       "       [1.10000000e+01, 8.70000000e+01, 1.92307692e-01, 2.00000000e+00],\n",
-       "       [8.50000000e+01, 2.00000000e+02, 2.11538462e-01, 3.00000000e+00],\n",
-       "       [5.10000000e+01, 1.87000000e+02, 2.37623762e-01, 2.00000000e+00],\n",
-       "       [4.60000000e+01, 1.81000000e+02, 2.60000000e-01, 2.00000000e+00],\n",
-       "       [3.60000000e+01, 1.18000000e+02, 2.60869565e-01, 2.00000000e+00]])"
+       "array([[6.80000000e+01, 1.48000000e+02, 1.81818182e-01, 2.00000000e+00],\n",
+       "       [7.00000000e+00, 7.60000000e+01, 1.92307692e-01, 2.00000000e+00],\n",
+       "       [7.20000000e+01, 2.02000000e+02, 2.11538462e-01, 3.00000000e+00],\n",
+       "       [4.40000000e+01, 1.83000000e+02, 2.37623762e-01, 2.00000000e+00],\n",
+       "       [1.45000000e+02, 1.47000000e+02, 2.50000000e-01, 2.00000000e+00],\n",
+       "       [1.00000000e+01, 8.50000000e+01, 2.50000000e-01, 2.00000000e+00]])"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1113,58 +1239,55 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# Generate the plots of clusters.\n",
-    "os.makedirs(\"results\", exist_ok=True)\n",
-    "\n",
-    "tree.write_summaries(path=\"results\")"
+    "The tree is probably more useful to you.\n",
+    "You can write an interactive tree to a file using the `plot` method on the `Tree` object."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "total 13760\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones    4493 Jun  4 13:02 cluster_100_9.csv\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones  140867 Jun  4 13:02 cluster_100_9.png\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones     877 Jun  4 13:02 cluster_101_1.csv\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones   74004 Jun  4 13:02 cluster_101_1.png\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones     614 Jun  4 13:02 cluster_102_1.csv\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones   57197 Jun  4 13:02 cluster_102_1.png\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones     759 Jun  4 13:02 cluster_103_1.csv\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones   72163 Jun  4 13:02 cluster_103_1.png\r\n",
-      "-rw-rw-r--. 1 darcyabjones darcyabjones    3491 Jun  4 13:02 cluster_10_3.csv\r\n",
-      "ls: write error: Broken pipe\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "! ls -l results | head"
+    "# To write out the tree.\n",
+    "# NB the results folder already exists from the previous step where we wrote summaries.\n",
+    "tree.plot(filename=\"results/simple_dendrogram.html\", width=1000, height=1000);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-rw-r--r--. 1 darcyabjones darcyabjones 3143386 Apr 17 18:12 results/simple_dendrogram.html\n"
+     ]
+    }
+   ],
    "source": [
-    "# To write out the tree.\n",
-    "#iplot = tree.iplot(filename=\"simple_dendrogram.html\")\n",
+    "%%bash\n",
+    "ls -la results/simple_dendrogram.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the width and height values are in pixels.\n",
+    "If your sample names are fairly long like ours are, you might like to fiddle with the height.\n",
+    "You can navigate to the .html file and open it in your favourite browser.\n",
     "\n",
-    "iplot = tree.iplot(width=900, height=500)"
+    "Since you're already using a Jupyter notebook you might like to plot the tree inline with your other analysis.\n",
+    "We can do that using some plotly functionality.\n",
+    "\n",
+    "The `plot` method returns a Plotly `Figure` object which you can use with normal plo`ly functions.\n",
+    "So we can use the `notebook_mode` to show it inline."
    ]
   },
   {
@@ -1175,10 +1298,22 @@
     {
      "data": {
       "text/html": [
-       "<script>requirejs.config({paths: { 'plotly': ['https://cdn.plot.ly/plotly-latest.min']},});if(!window.Plotly) {{require(['plotly'],function(plotly) {window.Plotly=plotly;});}}</script>"
-      ],
-      "text/vnd.plotly.v1+html": [
-       "<script>requirejs.config({paths: { 'plotly': ['https://cdn.plot.ly/plotly-latest.min']},});if(!window.Plotly) {{require(['plotly'],function(plotly) {window.Plotly=plotly;});}}</script>"
+       "        <script type=\"text/javascript\">\n",
+       "        window.PlotlyConfig = {MathJaxConfig: 'local'};\n",
+       "        if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}\n",
+       "        if (typeof require !== 'undefined') {\n",
+       "        require.undef(\"plotly\");\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': ['https://cdn.plot.ly/plotly-latest.min']\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(Plotly) {\n",
+       "            window._Plotly = Plotly;\n",
+       "        });\n",
+       "        }\n",
+       "        </script>\n",
+       "        "
       ]
      },
      "metadata": {},
@@ -1187,15 +1322,84 @@
     {
      "data": {
       "application/vnd.plotly.v1+json": {
+       "config": {
+        "linkText": "Export to plot.ly",
+        "plotlyServerURL": "https://plot.ly",
+        "showLink": false
+       },
        "data": [
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 1, component: QE_2017_001816_613.48218_838.0",
+          "cluster: 1, component: QE_2017_001816_613.48218_838.0",
+          "cluster: 1, component: QE_2017_001816_792.56232_718.0",
+          "cluster: 1, component: QE_2017_001816_792.56232_718.0"
+         ],
          "type": "scatter",
+         "uid": "fe2e9043-48a3-4de9-b50e-852cb32fd6de",
+         "x": [
+          15,
+          15,
+          25,
+          25
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5662650602409639,
+          0.5662650602409639,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001816_613.4826_738.0",
+          "cluster: 2, component: QE_2017_001816_613.4826_738.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4ec4b3df-9d48-46c5-ba46-7435579328e2",
+         "x": [
+          5,
+          5,
+          20,
+          20
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.676923076923077,
+          0.676923076923077,
+          0.5662650602409639
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 3, component: QE_2017_001814_596.30963_602.0",
+          "cluster: 3, component: QE_2017_001814_596.30963_602.0",
+          "cluster: 4, component: QE_2017_001815_792.5625_866.0",
+          "cluster: 4, component: QE_2017_001815_792.5625_866.0"
+         ],
+         "type": "scatter",
+         "uid": "899d5a37-2f9b-4b4f-aba3-3e31d6cf9316",
          "x": [
           35,
           35,
@@ -1205,89 +1409,55 @@
          "xaxis": "x",
          "y": [
           0,
-          0.5774647887323944,
-          0.5774647887323944,
+          0.7142857142857143,
+          0.7142857142857143,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "21709b3f-02c4-4b8a-8a0b-0d0fb0c8b3cc",
          "x": [
-          25,
-          25,
+          12.5,
+          12.5,
           40,
           40
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.6142857142857143,
-          0.6142857142857143,
-          0.5774647887323944
+          0.676923076923077,
+          0.7763157894736842,
+          0.7763157894736842,
+          0.7142857142857143
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          15,
-          15,
-          32.5,
-          32.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.7049180327868853,
-          0.7049180327868853,
-          0.6142857142857143
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          5,
-          5,
-          23.75,
-          23.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.7613636363636364,
-          0.7613636363636364,
-          0.7049180327868853
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25784_608.0",
+          "cluster: 5, component: QE_2017_001814_335.25784_608.0",
+          "cluster: 5, component: QE_2017_001816_335.25772_723.0",
+          "cluster: 5, component: QE_2017_001816_335.25772_723.0"
+         ],
          "type": "scatter",
+         "uid": "3627a961-3f93-468c-8c41-e9dffcb74211",
          "x": [
           105,
           105,
@@ -1297,20 +1467,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2549019607843137,
-          0.2549019607843137,
+          0.26,
+          0.26,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25772_725.0",
+          "cluster: 5, component: QE_2017_001814_335.25772_725.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "12b8ecff-b6f8-4332-9d26-4e354c2055c4",
          "x": [
           95,
           95,
@@ -1320,20 +1496,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2777777777777778,
-          0.2777777777777778,
-          0.2549019607843137
+          0.2830188679245283,
+          0.2830188679245283,
+          0.26
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25784_628.0",
+          "cluster: 5, component: QE_2017_001814_335.25784_628.0",
+          "cluster: 5, component: QE_2017_001815_335.25745_642.0",
+          "cluster: 5, component: QE_2017_001815_335.25745_642.0"
+         ],
          "type": "scatter",
+         "uid": "7b844d10-5e16-4db8-8d0a-9bbe37047ea7",
          "x": [
           125,
           125,
@@ -1343,20 +1525,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.28125,
-          0.28125,
+          0.2857142857142857,
+          0.2857142857142857,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "c7c73290-753d-4ac7-ba92-90996a326cb2",
          "x": [
           102.5,
           102.5,
@@ -1365,21 +1553,27 @@
          ],
          "xaxis": "x",
          "y": [
-          0.2777777777777778,
-          0.3333333333333333,
-          0.3333333333333333,
-          0.28125
+          0.2830188679245283,
+          0.3389830508474576,
+          0.3389830508474576,
+          0.2857142857142857
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_261.22073_634.0",
+          "cluster: 5, component: QE_2017_001814_261.22073_634.0",
+          "cluster: 5, component: QE_2017_001815_335.25784_587.0",
+          "cluster: 5, component: QE_2017_001815_335.25784_587.0"
+         ],
          "type": "scatter",
+         "uid": "80ebb1cd-26cc-48c9-9cf8-210889fae406",
          "x": [
           145,
           145,
@@ -1389,20 +1583,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.36923076923076925,
-          0.36923076923076925,
+          0.375,
+          0.375,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "d15fa381-f757-403b-b350-d01e4992f0d8",
          "x": [
           116.25,
           116.25,
@@ -1411,21 +1611,27 @@
          ],
          "xaxis": "x",
          "y": [
-          0.3333333333333333,
-          0.4057971014492754,
-          0.4057971014492754,
-          0.36923076923076925
+          0.3389830508474576,
+          0.4117647058823529,
+          0.4117647058823529,
+          0.375
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_353.26889_609.0",
+          "cluster: 5, component: QE_2017_001814_353.26889_609.0",
+          "cluster: 5, component: QE_2017_001815_353.26862_642.0",
+          "cluster: 5, component: QE_2017_001815_353.26862_642.0"
+         ],
          "type": "scatter",
+         "uid": "11c6054d-4f6d-4e64-b6a5-f8c0a303f124",
          "x": [
           165,
           165,
@@ -1435,20 +1641,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2698412698412698,
-          0.2698412698412698,
+          0.27419354838709675,
+          0.27419354838709675,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25772_638.0",
+          "cluster: 5, component: QE_2017_001814_335.25772_638.0",
+          "cluster: 5, component: QE_2017_001815_335.2579_601.0",
+          "cluster: 5, component: QE_2017_001815_335.2579_601.0"
+         ],
          "type": "scatter",
+         "uid": "cfbd419f-baf2-483d-9264-3304b2f4b398",
          "x": [
           195,
           195,
@@ -1458,20 +1670,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.28846153846153844,
-          0.28846153846153844,
+          0.29411764705882354,
+          0.29411764705882354,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001815_261.22073_643.0",
+          "cluster: 5, component: QE_2017_001815_261.22073_643.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f0f20e9f-e908-4305-872d-32a15ef5a39c",
          "x": [
           185,
           185,
@@ -1481,20 +1699,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.37735849056603776,
-          0.37735849056603776,
-          0.28846153846153844
+          0.38461538461538464,
+          0.38461538461538464,
+          0.29411764705882354
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "53820d74-36cd-44b5-a6df-66f18982cbb5",
          "x": [
           170,
           170,
@@ -1503,21 +1727,27 @@
          ],
          "xaxis": "x",
          "y": [
-          0.2698412698412698,
-          0.4262295081967213,
-          0.4262295081967213,
-          0.37735849056603776
+          0.27419354838709675,
+          0.43333333333333335,
+          0.43333333333333335,
+          0.38461538461538464
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9bf7922a-c8f3-4ae3-a5b5-7003f0be1ac2",
          "x": [
           133.125,
           133.125,
@@ -1526,21 +1756,27 @@
          ],
          "xaxis": "x",
          "y": [
-          0.4057971014492754,
-          0.45454545454545453,
-          0.45454545454545453,
-          0.4262295081967213
+          0.4117647058823529,
+          0.46153846153846156,
+          0.46153846153846156,
+          0.43333333333333335
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001816_571.47186_717.0",
+          "cluster: 5, component: QE_2017_001816_571.47186_717.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "50ce641e-9f18-4eb0-84d1-533eb1d1b560",
          "x": [
           85,
           85,
@@ -1550,20 +1786,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.4925373134328358,
-          0.4925373134328358,
-          0.45454545454545453
+          0.5538461538461539,
+          0.5538461538461539,
+          0.46153846153846156
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001815_507.27145_607.0",
+          "cluster: 5, component: QE_2017_001815_507.27145_607.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "cfe61509-49f4-4d21-9efd-1ef01b041863",
          "x": [
           75,
           75,
@@ -1573,20 +1815,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.5652173913043478,
-          0.5652173913043478,
-          0.4925373134328358
+          0.5737704918032787,
+          0.5737704918032787,
+          0.5538461538461539
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 6, component: QE_2017_001814_497.31033_643.0",
+          "cluster: 6, component: QE_2017_001814_497.31033_643.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "3db18220-8d96-40ab-a2d9-8ada4d972790",
          "x": [
           65,
           65,
@@ -1596,20 +1844,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.6904761904761905,
-          0.6904761904761905,
-          0.5652173913043478
+          0.6986301369863014,
+          0.6986301369863014,
+          0.5737704918032787
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 7, component: QE_2017_001815_571.4292_870.0",
+          "cluster: 7, component: QE_2017_001815_571.4292_870.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f32cfd81-314b-490e-a4fc-7fb5f7b7ca72",
          "x": [
           55,
           55,
@@ -1619,20 +1873,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.7981651376146789,
-          0.7981651376146789,
-          0.6904761904761905
+          0.7962962962962963,
+          0.7962962962962963,
+          0.6986301369863014
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 8, component: QE_2017_001814_338.34146_850.0",
+          "cluster: 8, component: QE_2017_001814_338.34146_850.0",
+          "cluster: 9, component: QE_2017_001815_244.19048_762.0",
+          "cluster: 9, component: QE_2017_001815_244.19048_762.0"
+         ],
          "type": "scatter",
+         "uid": "64090e7a-95a8-49e7-b755-ccf2b7af60ae",
          "x": [
           225,
           225,
@@ -1642,89 +1902,113 @@
          "xaxis": "x",
          "y": [
           0,
-          0.609375,
-          0.609375,
+          0.6031746031746031,
+          0.6031746031746031,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 10, component: QE_2017_001814_353.26868_633.0",
+          "cluster: 10, component: QE_2017_001814_353.26868_633.0",
+          "cluster: 10, component: QE_2017_001816_353.26892_600.0",
+          "cluster: 10, component: QE_2017_001816_353.26892_600.0"
+         ],
          "type": "scatter",
+         "uid": "246ad32f-9bda-4a57-890f-af549a172e63",
          "x": [
+          245,
+          245,
           255,
-          255,
+          255
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2376237623762376,
+          0.2376237623762376,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 10, component: QE_2017_001814_279.23157_719.0",
+          "cluster: 10, component: QE_2017_001814_279.23157_719.0",
+          "cluster: 10, component: QE_2017_001815_278.24762_684.0",
+          "cluster: 10, component: QE_2017_001815_278.24762_684.0"
+         ],
+         "type": "scatter",
+         "uid": "de3b63f1-1195-49f5-806b-d203de8ddfbd",
+         "x": [
           265,
-          265
+          265,
+          275,
+          275
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.36764705882352944,
-          0.36764705882352944,
+          0.43209876543209874,
+          0.43209876543209874,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e9d5e047-b59c-44de-8397-c05b7260d7a0",
          "x": [
-          245,
-          245,
-          260,
-          260
+          250,
+          250,
+          270,
+          270
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.5342465753424658,
-          0.5342465753424658,
-          0.36764705882352944
+          0.2376237623762376,
+          0.5229357798165137,
+          0.5229357798165137,
+          0.43209876543209874
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          275,
-          275,
-          285,
-          285
+         "text": [
+          "cluster: 11, component: QE_2017_001816_337.27338_826.0",
+          "cluster: 11, component: QE_2017_001816_337.27338_826.0",
+          "cluster: 11, component: QE_2017_001816_337.27341_632.0",
+          "cluster: 11, component: QE_2017_001816_337.27341_632.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.23529411764705882,
-          0.23529411764705882,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "950144a6-5a22-4dcd-9fec-7f9c793f9bf1",
          "x": [
           295,
           295,
@@ -1734,158 +2018,200 @@
          "xaxis": "x",
          "y": [
           0,
-          0.4444444444444444,
-          0.4444444444444444,
+          0.373134328358209,
+          0.373134328358209,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 11, component: QE_2017_001816_435.25037_666.0",
+          "cluster: 11, component: QE_2017_001816_435.25037_666.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "4c4796df-78e2-4238-b0ac-86ee2d05f09a",
          "x": [
-          280,
-          280,
+          285,
+          285,
           300,
           300
          ],
          "xaxis": "x",
          "y": [
-          0.23529411764705882,
-          0.5585585585585585,
-          0.5585585585585585,
-          0.4444444444444444
+          0,
+          0.5416666666666666,
+          0.5416666666666666,
+          0.373134328358209
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "cdfd0e35-7d3a-4ced-90f0-f05c6446dab0",
          "x": [
-          252.5,
-          252.5,
-          290,
-          290
+          260,
+          260,
+          292.5,
+          292.5
          ],
          "xaxis": "x",
          "y": [
-          0.5342465753424658,
-          0.6902654867256637,
-          0.6902654867256637,
-          0.5585585585585585
+          0.5229357798165137,
+          0.6875,
+          0.6875,
+          0.5416666666666666
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "cfb29e8c-07e6-494f-a2e5-4859ea0a22e3",
          "x": [
           230,
           230,
-          271.25,
-          271.25
+          276.25,
+          276.25
          ],
          "xaxis": "x",
          "y": [
-          0.609375,
-          0.7619047619047619,
-          0.7619047619047619,
-          0.6902654867256637
+          0.6031746031746031,
+          0.7590361445783133,
+          0.7590361445783133,
+          0.6875
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 12, component: QE_2017_001816_272.25824_582.0",
+          "cluster: 12, component: QE_2017_001816_272.25824_582.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "719fc6d1-8a24-455e-bc11-4d8eea2ff8e2",
          "x": [
           215,
           215,
-          250.625,
-          250.625
+          253.125,
+          253.125
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.8266666666666667,
-          0.8266666666666667,
-          0.7619047619047619
+          0.8243243243243243,
+          0.8243243243243243,
+          0.7590361445783133
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f9f08107-2e6d-4c93-9bec-289fbbd1787b",
          "x": [
           68.26171875,
           68.26171875,
-          232.8125,
-          232.8125
+          234.0625,
+          234.0625
          ],
          "xaxis": "x",
          "y": [
-          0.7981651376146789,
-          0.8712871287128713,
-          0.8712871287128713,
-          0.8266666666666667
+          0.7962962962962963,
+          0.87,
+          0.87,
+          0.8243243243243243
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e15deeb8-e467-4135-8d2e-9cb14961b48b",
          "x": [
-          14.375,
-          14.375,
-          150.537109375,
-          150.537109375
+          26.25,
+          26.25,
+          151.162109375,
+          151.162109375
          ],
          "xaxis": "x",
          "y": [
-          0.7613636363636364,
-          0.9014084507042254,
-          0.9014084507042254,
-          0.8712871287128713
+          0.7763157894736842,
+          0.9130434782608695,
+          0.9130434782608695,
+          0.87
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 13, component: QE_2017_001814_601.42426_706.0",
+          "cluster: 13, component: QE_2017_001814_601.42426_706.0",
+          "cluster: 14, component: QE_2017_001816_599.40869_793.0",
+          "cluster: 14, component: QE_2017_001816_599.40869_793.0"
+         ],
          "type": "scatter",
+         "uid": "a1eefb31-cf46-40c7-9d7f-11301e6ff350",
          "x": [
           345,
           345,
@@ -1895,20 +2221,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.6336633663366337,
-          0.6336633663366337,
+          0.63,
+          0.63,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 15, component: QE_2017_001816_599.40948_660.0",
+          "cluster: 15, component: QE_2017_001816_599.40948_660.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9826c0aa-cbe8-4625-90a3-5010fb1adbd7",
          "x": [
           335,
           335,
@@ -1918,20 +2250,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.6629213483146067,
-          0.6629213483146067,
-          0.6336633663366337
+          0.6710526315789473,
+          0.6710526315789473,
+          0.63
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001816_583.41382_731.0",
+          "cluster: 16, component: QE_2017_001816_583.41382_731.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "fae2a85e-eaa9-40ec-bdba-bbc9a05472d2",
          "x": [
           325,
           325,
@@ -1941,20 +2279,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.7604166666666666,
-          0.7604166666666666,
-          0.6629213483146067
+          0.7578947368421053,
+          0.7578947368421053,
+          0.6710526315789473
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 17, component: QE_2017_001814_618.42633_695.0",
+          "cluster: 17, component: QE_2017_001814_618.42633_695.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "21cec3c1-2c75-4732-af2b-f912f6b1b71e",
          "x": [
           315,
           315,
@@ -1964,20 +2308,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.8023255813953488,
-          0.8023255813953488,
-          0.7604166666666666
+          0.8,
+          0.8,
+          0.7578947368421053
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 18, component: QE_2017_001815_618.42773_646.0",
+          "cluster: 18, component: QE_2017_001815_618.42773_646.0",
+          "cluster: 18, component: QE_2017_001816_618.427_682.0",
+          "cluster: 18, component: QE_2017_001816_618.427_682.0"
+         ],
          "type": "scatter",
+         "uid": "bf206eab-e670-4c3b-8630-a9693aca4c4c",
          "x": [
           365,
           365,
@@ -1987,20 +2337,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.4713114754098361,
-          0.4713114754098361,
+          0.4732510288065844,
+          0.4732510288065844,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 19, component: QE_2017_001814_583.41406_682.0",
+          "cluster: 19, component: QE_2017_001814_583.41406_682.0",
+          "cluster: 19, component: QE_2017_001815_583.41406_707.0",
+          "cluster: 19, component: QE_2017_001815_583.41406_707.0"
+         ],
          "type": "scatter",
+         "uid": "0dd77d61-992d-478c-a2da-e06542bc1d94",
          "x": [
           405,
           405,
@@ -2010,20 +2366,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.5222222222222223,
-          0.5222222222222223,
+          0.5280898876404494,
+          0.5280898876404494,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 20, component: QE_2017_001814_565.4035_722.0",
+          "cluster: 20, component: QE_2017_001814_565.4035_722.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "38f5dd10-97b3-42cd-ad15-6c9afc9986af",
          "x": [
           395,
           395,
@@ -2033,20 +2395,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.6097560975609756,
-          0.6097560975609756,
-          0.5222222222222223
+          0.6049382716049383,
+          0.6049382716049383,
+          0.5280898876404494
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 21, component: QE_2017_001815_583.41388_735.0",
+          "cluster: 21, component: QE_2017_001815_583.41388_735.0",
+          "cluster: 21, component: QE_2017_001815_583.41418_647.0",
+          "cluster: 21, component: QE_2017_001815_583.41418_647.0"
+         ],
          "type": "scatter",
+         "uid": "e11a4a09-ecf6-447c-adbf-01cd8ca14e80",
          "x": [
           435,
           435,
@@ -2056,20 +2424,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.524822695035461,
-          0.524822695035461,
+          0.5285714285714286,
+          0.5285714285714286,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 22, component: QE_2017_001814_601.42334_783.0",
+          "cluster: 22, component: QE_2017_001814_601.42334_783.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "7d1def72-4e9c-438d-9aef-a53f3b765fa5",
          "x": [
           425,
           425,
@@ -2079,20 +2453,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.6983240223463687,
-          0.6983240223463687,
-          0.524822695035461
+          0.6966292134831461,
+          0.6966292134831461,
+          0.5285714285714286
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e3394474-ab4f-40c0-868f-15891004ff32",
          "x": [
           402.5,
           402.5,
@@ -2101,21 +2481,27 @@
          ],
          "xaxis": "x",
          "y": [
-          0.6097560975609756,
-          0.7364341085271318,
-          0.7364341085271318,
-          0.6983240223463687
+          0.6049382716049383,
+          0.734375,
+          0.734375,
+          0.6966292134831461
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 23, component: QE_2017_001815_568.42627_841.0",
+          "cluster: 23, component: QE_2017_001815_568.42627_841.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "8aafa39f-081e-4356-abc0-7e3e874d6166",
          "x": [
           385,
           385,
@@ -2125,20 +2511,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.7661290322580645,
-          0.7661290322580645,
-          0.7364341085271318
+          0.7642276422764228,
+          0.7642276422764228,
+          0.734375
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "4ef364db-d144-4001-a973-9c3f79f7a777",
          "x": [
           370,
           370,
@@ -2147,21 +2539,27 @@
          ],
          "xaxis": "x",
          "y": [
-          0.4713114754098361,
-          0.8212765957446808,
-          0.8212765957446808,
-          0.7661290322580645
+          0.4732510288065844,
+          0.8205128205128205,
+          0.8205128205128205,
+          0.7642276422764228
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "a64c984a-0dec-4632-bae5-0e0febd36cfc",
          "x": [
           324.375,
           324.375,
@@ -2170,297 +2568,433 @@
          ],
          "xaxis": "x",
          "y": [
-          0.8023255813953488,
-          0.9403973509933775,
-          0.9403973509933775,
-          0.8212765957446808
+          0.8,
+          0.94,
+          0.94,
+          0.8205128205128205
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "68db51f6-e747-4343-9609-71256dc3b3b5",
          "x": [
-          82.4560546875,
-          82.4560546875,
+          88.7060546875,
+          88.7060546875,
           355,
           355
          ],
          "xaxis": "x",
          "y": [
-          0.9014084507042254,
-          0.9705882352941176,
-          0.9705882352941176,
-          0.9403973509933775
+          0.9130434782608695,
+          0.9625,
+          0.9625,
+          0.94
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 24, component: QE_2017_001814_194.04424_237.0",
+          "cluster: 24, component: QE_2017_001814_194.04424_237.0",
+          "cluster: 25, component: QE_2017_001815_194.11751_218.0",
+          "cluster: 25, component: QE_2017_001815_194.11751_218.0"
+         ],
+         "type": "scatter",
+         "uid": "ce956580-abcd-4f68-9f3a-240025d7974a",
+         "x": [
+          455,
+          455,
+          465,
+          465
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6206896551724138,
+          0.6206896551724138,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 26, component: QE_2017_001815_194.04471_314.0",
+          "cluster: 26, component: QE_2017_001815_194.04471_314.0",
+          "cluster: 26, component: QE_2017_001815_212.05513_328.0",
+          "cluster: 26, component: QE_2017_001815_212.05513_328.0"
+         ],
          "type": "scatter",
+         "uid": "8994ad5f-0fac-4261-a623-8de062197c05",
          "x": [
-          465,
-          465,
+          485,
+          485,
+          495,
+          495
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.35135135135135137,
+          0.35135135135135137,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 26, component: QE_2017_001815_194.04469_299.0",
+          "cluster: 26, component: QE_2017_001815_194.04469_299.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "50343f53-474b-4da9-b8b0-8f995a509046",
+         "x": [
           475,
-          475
+          475,
+          490,
+          490
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.4230769230769231,
-          0.4230769230769231,
-          0
+          0.5573770491803278,
+          0.5573770491803278,
+          0.35135135135135137
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(35,205,205)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 27, component: QE_2017_001814_226.07077_397.0",
+          "cluster: 27, component: QE_2017_001814_226.07077_397.0",
+          "cluster: 28, component: QE_2017_001815_194.04471_397.0",
+          "cluster: 28, component: QE_2017_001815_194.04471_397.0"
+         ],
          "type": "scatter",
+         "uid": "04d58eb3-cb21-45b6-b0aa-c4bf4e58bb54",
          "x": [
-          505,
-          505,
           515,
-          515
+          515,
+          525,
+          525
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.375,
-          0.375,
+          0.6285714285714286,
+          0.6285714285714286,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          495,
-          495,
-          510,
-          510
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.391304347826087,
-          0.391304347826087,
-          0.375
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          485,
-          485,
-          502.5,
-          502.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.5,
-          0.5,
-          0.391304347826087
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 29, component: QE_2017_001815_212.05505_267.0",
+          "cluster: 29, component: QE_2017_001815_212.05505_267.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "1791c40d-b7f9-4b43-ab28-11ca24474eff",
          "x": [
-          470,
-          470,
-          493.75,
-          493.75
+          505,
+          505,
+          520,
+          520
          ],
          "xaxis": "x",
          "y": [
-          0.4230769230769231,
-          0.7878787878787878,
-          0.7878787878787878,
-          0.5
+          0,
+          0.7,
+          0.7,
+          0.6285714285714286
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9ab76b59-7dd1-49be-9679-66ac15d3d54f",
          "x": [
-          525,
-          525,
+          482.5,
+          482.5,
+          512.5,
+          512.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5573770491803278,
+          0.8360655737704918,
+          0.8360655737704918,
+          0.7
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9e2e2d2d-d299-4573-a8d0-19eb164a7d4c",
+         "x": [
+          460,
+          460,
+          497.5,
+          497.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6206896551724138,
+          0.8548387096774194,
+          0.8548387096774194,
+          0.8360655737704918
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 30, component: QE_2017_001816_533.15442_247.0",
+          "cluster: 30, component: QE_2017_001816_533.15442_247.0",
+          "cluster: 30, component: QE_2017_001816_533.15466_222.0",
+          "cluster: 30, component: QE_2017_001816_533.15466_222.0"
+         ],
+         "type": "scatter",
+         "uid": "45613927-cf80-45dd-a695-e6a612fd2185",
+         "x": [
           535,
-          535
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.6981132075471698,
-          0.6981132075471698,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          545,
-          545,
-          555,
-          555
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.4074074074074074,
-          0.4074074074074074,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          565,
-          565,
-          575,
-          575
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.6896551724137931,
-          0.6896551724137931,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          550,
-          550,
-          570,
-          570
-         ],
-         "xaxis": "x",
-         "y": [
-          0.4074074074074074,
-          0.7567567567567568,
-          0.7567567567567568,
-          0.6896551724137931
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          530,
-          530,
-          560,
-          560
-         ],
-         "xaxis": "x",
-         "y": [
-          0.6981132075471698,
-          0.8604651162790697,
-          0.8604651162790697,
-          0.7567567567567568
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          481.875,
-          481.875,
+          535,
           545,
           545
          ],
          "xaxis": "x",
          "y": [
-          0.7878787878787878,
-          0.88,
-          0.88,
-          0.8604651162790697
+          0,
+          0.36764705882352944,
+          0.36764705882352944,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 30, component: QE_2017_001815_533.1546_207.0",
+          "cluster: 30, component: QE_2017_001815_533.1546_207.0",
+          "cluster: 30, component: QE_2017_001816_533.1546_271.0",
+          "cluster: 30, component: QE_2017_001816_533.1546_271.0"
+         ],
+         "type": "scatter",
+         "uid": "3d491818-d4e4-43f4-9d22-87136c51f25e",
+         "x": [
+          555,
+          555,
+          565,
+          565
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.45454545454545453,
+          0.45454545454545453,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1160198c-a1c3-4eb9-a5e8-e1bac4adb8c3",
+         "x": [
+          540,
+          540,
+          560,
+          560
+         ],
+         "xaxis": "x",
+         "y": [
+          0.36764705882352944,
+          0.5,
+          0.5,
+          0.45454545454545453
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 31, component: QE_2017_001814_347.09097_122.0",
+          "cluster: 31, component: QE_2017_001814_347.09097_122.0",
+          "cluster: 31, component: QE_2017_001815_347.09067_204.0",
+          "cluster: 31, component: QE_2017_001815_347.09067_204.0"
+         ],
+         "type": "scatter",
+         "uid": "ee6c1da5-042a-4523-9a0f-3a95ed53d94f",
+         "x": [
+          575,
+          575,
+          585,
+          585
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5098039215686274,
+          0.5098039215686274,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "219facf5-8537-45f0-bfa7-a1c25d9b8e7a",
+         "x": [
+          550,
+          550,
+          580,
+          580
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5,
+          0.8804347826086957,
+          0.8804347826086957,
+          0.5098039215686274
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "cafa81d8-baa1-41ca-bd84-82c82527fc3d",
+         "x": [
+          478.75,
+          478.75,
+          565,
+          565
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8548387096774194,
+          0.9857142857142858,
+          0.9857142857142858,
+          0.8804347826086957
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 32, component: QE_2017_001815_268.10373_58.0",
+          "cluster: 32, component: QE_2017_001815_268.10373_58.0",
+          "cluster: 32, component: QE_2017_001816_269.16055_60.0",
+          "cluster: 32, component: QE_2017_001816_269.16055_60.0"
+         ],
          "type": "scatter",
+         "uid": "ac503229-1ad9-40f3-bcf0-d5bd6f0f4d96",
          "x": [
           595,
           595,
@@ -2470,457 +3004,461 @@
          "xaxis": "x",
          "y": [
           0,
-          0.36363636363636365,
-          0.36363636363636365,
+          0.42424242424242425,
+          0.42424242424242425,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          585,
-          585,
-          600,
-          600
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.926829268292683,
-          0.926829268292683,
-          0.36363636363636365
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          513.4375,
-          513.4375,
-          592.5,
-          592.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.88,
-          0.9473684210526315,
-          0.9473684210526315,
-          0.926829268292683
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          455,
-          455,
-          552.96875,
-          552.96875
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.9705882352941176,
-          0.9705882352941176,
-          0.9473684210526315
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 33, component: QE_2017_001816_408.36832_704.0",
+          "cluster: 33, component: QE_2017_001816_408.36832_704.0",
+          "cluster: 33, component: QE_2017_001816_466.40979_731.0",
+          "cluster: 33, component: QE_2017_001816_466.40979_731.0"
+         ],
          "type": "scatter",
+         "uid": "a5f5ad9b-aaf6-43b1-9685-eaf29a3c29ff",
          "x": [
-          615,
-          615,
           625,
-          625
+          625,
+          635,
+          635
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.36231884057971014,
-          0.36231884057971014,
+          0.5882352941176471,
+          0.5882352941176471,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 34, component: QE_2017_001815_364.34189_705.0",
+          "cluster: 34, component: QE_2017_001815_364.34189_705.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f64ddb6a-6fdd-4368-b7a3-feb8ae94f66f",
          "x": [
-          635,
-          635,
-          645,
-          645
+          615,
+          615,
+          630,
+          630
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.44776119402985076,
-          0.44776119402985076,
-          0
+          0.6875,
+          0.6875,
+          0.5882352941176471
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(40,35,35)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          620,
-          620,
-          640,
-          640
-         ],
-         "xaxis": "x",
-         "y": [
-          0.36231884057971014,
-          0.4931506849315068,
-          0.4931506849315068,
-          0.44776119402985076
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 35, component: QE_2017_001814_364.34244_761.0",
+          "cluster: 35, component: QE_2017_001814_364.34244_761.0",
+          "cluster: 35, component: QE_2017_001815_364.34253_752.0",
+          "cluster: 35, component: QE_2017_001815_364.34253_752.0"
+         ],
          "type": "scatter",
+         "uid": "f53d6a02-7cce-4498-b9fa-ea2b4d22bb9f",
          "x": [
-          655,
-          655,
           665,
-          665
+          665,
+          675,
+          675
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.5,
-          0.5,
+          0.36363636363636365,
+          0.36363636363636365,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          630,
-          630,
-          660,
-          660
-         ],
-         "xaxis": "x",
-         "y": [
-          0.4931506849315068,
-          0.8817204301075269,
-          0.8817204301075269,
-          0.5
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 36, component: QE_2017_001816_421.35226_731.0",
+          "cluster: 36, component: QE_2017_001816_421.35226_731.0",
+          "cluster: 36, component: QE_2017_001816_424.36325_712.0",
+          "cluster: 36, component: QE_2017_001816_424.36325_712.0"
+         ],
          "type": "scatter",
+         "uid": "d21bb2ec-94f9-4b94-9bb7-0bc1db20692a",
          "x": [
-          675,
-          675,
           685,
-          685
+          685,
+          695,
+          695
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.4117647058823529,
-          0.4117647058823529,
+          0.3888888888888889,
+          0.3888888888888889,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4dd16b05-dfcb-4b59-8f33-f99a001ea849",
+         "x": [
+          670,
+          670,
+          690,
+          690
+         ],
+         "xaxis": "x",
+         "y": [
+          0.36363636363636365,
+          0.6111111111111112,
+          0.6111111111111112,
+          0.3888888888888889
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 37, component: QE_2017_001815_482.40488_739.0",
+          "cluster: 37, component: QE_2017_001815_482.40488_739.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ff0d75e5-b99b-4610-a50f-03497c8da5f6",
+         "x": [
+          655,
+          655,
+          680,
+          680
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7037037037037037,
+          0.7037037037037037,
+          0.6111111111111112
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 38, component: QE_2017_001815_408.36853_717.0",
+          "cluster: 38, component: QE_2017_001815_408.36853_717.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b8bef84e-e298-4fe7-a08a-3869a282fbb4",
+         "x": [
+          645,
+          645,
+          667.5,
+          667.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7307692307692307,
+          0.7307692307692307,
+          0.7037037037037037
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1c01de1a-5fea-4f99-819e-defdaab01b0a",
+         "x": [
+          622.5,
+          622.5,
+          656.25,
+          656.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6875,
+          0.8387096774193549,
+          0.8387096774193549,
+          0.7307692307692307
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0eb9c3bf-13ee-4815-9108-df90e89844f5",
+         "x": [
+          600,
+          600,
+          639.375,
+          639.375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.42424242424242425,
+          0.9814814814814815,
+          0.9814814814814815,
+          0.8387096774193549
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 39, component: QE_2017_001814_611.15997_285.0",
+          "cluster: 39, component: QE_2017_001814_611.15997_285.0",
+          "cluster: 39, component: QE_2017_001815_611.16046_309.0",
+          "cluster: 39, component: QE_2017_001815_611.16046_309.0"
+         ],
          "type": "scatter",
+         "uid": "9852d4c2-fc8c-4e2e-8c95-2b73e541bc1f",
          "x": [
-          705,
-          705,
           715,
-          715
+          715,
+          725,
+          725
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.42857142857142855,
-          0.42857142857142855,
+          0.4583333333333333,
+          0.4583333333333333,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          695,
-          695,
-          710,
-          710
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.7058823529411765,
-          0.7058823529411765,
-          0.42857142857142855
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 40, component: QE_2017_001814_339.10742_366.0",
+          "cluster: 40, component: QE_2017_001814_339.10742_366.0",
+          "cluster: 40, component: QE_2017_001816_339.10733_298.0",
+          "cluster: 40, component: QE_2017_001816_339.10733_298.0"
+         ],
          "type": "scatter",
+         "uid": "2d0e3ca1-6139-4872-a3f7-6aec26e3277f",
          "x": [
+          735,
+          735,
           745,
-          745,
-          755,
-          755
+          745
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.35714285714285715,
-          0.35714285714285715,
+          0.44,
+          0.44,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          735,
-          735,
-          750,
-          750
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.47058823529411764,
-          0.47058823529411764,
-          0.35714285714285715
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          725,
-          725,
-          742.5,
-          742.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.631578947368421,
-          0.631578947368421,
-          0.47058823529411764
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          765,
-          765,
-          775,
-          775
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.725,
-          0.725,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          733.75,
-          733.75,
-          770,
-          770
-         ],
-         "xaxis": "x",
-         "y": [
-          0.631578947368421,
-          0.7407407407407407,
-          0.7407407407407407,
-          0.725
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          702.5,
-          702.5,
-          751.875,
-          751.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.7058823529411765,
-          0.85,
-          0.85,
-          0.7407407407407407
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          680,
-          680,
-          727.1875,
-          727.1875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.4117647058823529,
-          0.9818181818181818,
-          0.9818181818181818,
-          0.85
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 41, component: QE_2017_001814_231.04971_516.0",
+          "cluster: 41, component: QE_2017_001814_231.04971_516.0",
+          "cluster: 41, component: QE_2017_001815_231.04971_369.0",
+          "cluster: 41, component: QE_2017_001815_231.04971_369.0"
+         ],
          "type": "scatter",
+         "uid": "80e057b9-9481-4a25-ad63-0559de666a83",
          "x": [
-          785,
-          785,
           795,
-          795
+          795,
+          805,
+          805
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.47540983606557374,
-          0.47540983606557374,
+          0.391304347826087,
+          0.391304347826087,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001815_231.04968_315.0",
+          "cluster: 41, component: QE_2017_001815_231.04968_315.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "2f9b9d16-9c5f-4138-abcf-596597427774",
+         "x": [
+          785,
+          785,
+          800,
+          800
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4090909090909091,
+          0.4090909090909091,
+          0.391304347826087
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001815_231.04973_403.0",
+          "cluster: 41, component: QE_2017_001815_231.04973_403.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ddd19b4a-416c-4f90-9966-ad040bd5471a",
+         "x": [
+          775,
+          775,
+          792.5,
+          792.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.52,
+          0.52,
+          0.4090909090909091
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 42, component: QE_2017_001815_340.16019_314.0",
+          "cluster: 42, component: QE_2017_001815_340.16019_314.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "04bc5402-283b-4fa9-a3ce-e03f9a81b5fd",
+         "x": [
+          765,
+          765,
+          783.75,
+          783.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6904761904761905,
+          0.6904761904761905,
+          0.52
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 43, component: QE_2017_001815_314.14453_76.0",
+          "cluster: 43, component: QE_2017_001815_314.14453_76.0",
+          "cluster: 43, component: QE_2017_001816_314.14462_79.0",
+          "cluster: 43, component: QE_2017_001816_314.14462_79.0"
+         ],
          "type": "scatter",
+         "uid": "f9dc101d-c866-4550-b6b1-f8a42a4b2f25",
          "x": [
           815,
           815,
@@ -2930,43 +3468,171 @@
          "xaxis": "x",
          "y": [
           0,
-          0.423728813559322,
-          0.423728813559322,
+          0.4230769230769231,
+          0.4230769230769231,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 44, component: QE_2017_001816_310.14957_134.0",
+          "cluster: 44, component: QE_2017_001816_310.14957_134.0",
+          "cluster: 45, component: QE_2017_001816_342.17584_257.0",
+          "cluster: 45, component: QE_2017_001816_342.17584_257.0"
+         ],
          "type": "scatter",
+         "uid": "086d062c-2718-457c-8e96-e9b43fda1597",
          "x": [
-          805,
-          805,
-          820,
-          820
+          835,
+          835,
+          845,
+          845
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.49019607843137253,
-          0.49019607843137253,
-          0.423728813559322
+          0.6785714285714286,
+          0.6785714285714286,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "1ddbb6c2-353f-4880-aeab-2394a333d5b0",
+         "x": [
+          820,
+          820,
+          840,
+          840
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4230769230769231,
+          0.75,
+          0.75,
+          0.6785714285714286
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b8d14918-a462-463c-a726-1368f9112a95",
+         "x": [
+          774.375,
+          774.375,
+          830,
+          830
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6904761904761905,
+          0.8,
+          0.8,
+          0.75
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 46, component: QE_2017_001814_498.2543_475.0",
+          "cluster: 46, component: QE_2017_001814_498.2543_475.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "264793d6-f7a3-4ce1-8fb1-71bc691ec60d",
+         "x": [
+          755,
+          755,
+          802.1875,
+          802.1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8571428571428571,
+          0.8571428571428571,
+          0.8
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c2829b5f-ae39-41fb-9105-e60f3299fffc",
+         "x": [
+          740,
+          740,
+          778.59375,
+          778.59375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.44,
+          0.8775510204081632,
+          0.8775510204081632,
+          0.8571428571428571
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 47, component: QE_2017_001814_241.15466_73.0",
+          "cluster: 47, component: QE_2017_001814_241.15466_73.0",
+          "cluster: 48, component: QE_2017_001815_507.18192_178.0",
+          "cluster: 48, component: QE_2017_001815_507.18192_178.0"
+         ],
+         "type": "scatter",
+         "uid": "808c0129-c220-41d0-87ab-2c8715905eca",
          "x": [
           855,
           855,
@@ -2976,112 +3642,113 @@
          "xaxis": "x",
          "y": [
           0,
-          0.30612244897959184,
-          0.30612244897959184,
+          0.9152542372881356,
+          0.9152542372881356,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "82bbcd80-4e87-4102-9842-161b24328142",
          "x": [
-          845,
-          845,
+          759.296875,
+          759.296875,
           860,
           860
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.3728813559322034,
-          0.3728813559322034,
-          0.30612244897959184
+          0.8775510204081632,
+          0.9302325581395349,
+          0.9302325581395349,
+          0.9152542372881356
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8af2f31b-1a1e-43ca-b6c9-6ff5499d06dd",
+         "x": [
+          720,
+          720,
+          809.6484375,
+          809.6484375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4583333333333333,
+          0.9622641509433962,
+          0.9622641509433962,
+          0.9302325581395349
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 49, component: QE_2017_001816_463.12311_410.0",
+          "cluster: 49, component: QE_2017_001816_463.12311_410.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5efbd3dd-cff0-4c4f-a2f7-02d1310a9992",
+         "x": [
+          705,
+          705,
+          764.82421875,
+          764.82421875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9696969696969697,
+          0.9696969696969697,
+          0.9622641509433962
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 50, component: QE_2017_001814_320.29456_577.0",
+          "cluster: 50, component: QE_2017_001814_320.29456_577.0",
+          "cluster: 50, component: QE_2017_001815_320.29471_563.0",
+          "cluster: 50, component: QE_2017_001815_320.29471_563.0"
+         ],
          "type": "scatter",
-         "x": [
-          835,
-          835,
-          852.5,
-          852.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.5,
-          0.5,
-          0.3728813559322034
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          812.5,
-          812.5,
-          843.75,
-          843.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.49019607843137253,
-          0.6862745098039216,
-          0.6862745098039216,
-          0.5
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          790,
-          790,
-          828.125,
-          828.125
-         ],
-         "xaxis": "x",
-         "y": [
-          0.47540983606557374,
-          0.7857142857142857,
-          0.7857142857142857,
-          0.6862745098039216
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "3711f9be-bb3f-42f2-8dbb-7e2b4373bf74",
          "x": [
           895,
           895,
@@ -3091,20 +3758,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2876712328767123,
-          0.2876712328767123,
+          0.36,
+          0.36,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 51, component: QE_2017_001816_338.26062_643.0",
+          "cluster: 51, component: QE_2017_001816_338.26062_643.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "45934d5b-a8c1-417a-8cc3-a3f339dd0506",
          "x": [
           885,
           885,
@@ -3114,20 +3787,55 @@
          "xaxis": "x",
          "y": [
           0,
-          0.39473684210526316,
-          0.39473684210526316,
-          0.2876712328767123
+          0.6153846153846154,
+          0.6153846153846154,
+          0.36
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 52, component: QE_2017_001814_483.27118_651.0",
+          "cluster: 52, component: QE_2017_001814_483.27118_651.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "1e67d49a-2b34-4ccc-8bdf-c9f588fc8935",
+         "x": [
+          875,
+          875,
+          892.5,
+          892.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8636363636363636,
+          0.8636363636363636,
+          0.6153846153846154
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 53, component: QE_2017_001815_129.12741_349.0",
+          "cluster: 53, component: QE_2017_001815_129.12741_349.0",
+          "cluster: 54, component: QE_2017_001815_171.14914_420.0",
+          "cluster: 54, component: QE_2017_001815_171.14914_420.0"
+         ],
+         "type": "scatter",
+         "uid": "e0405825-2421-4833-a077-5e6b91b227b9",
          "x": [
           915,
           915,
@@ -3137,43 +3845,55 @@
          "xaxis": "x",
          "y": [
           0,
-          0.45569620253164556,
-          0.45569620253164556,
+          0.8666666666666667,
+          0.8666666666666667,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "1b12dd71-6641-43d9-b20f-4903f4dbb312",
          "x": [
-          892.5,
-          892.5,
+          883.75,
+          883.75,
           920,
           920
          ],
          "xaxis": "x",
          "y": [
-          0.39473684210526316,
-          0.5119047619047619,
-          0.5119047619047619,
-          0.45569620253164556
+          0.8636363636363636,
+          0.9032258064516129,
+          0.9032258064516129,
+          0.8666666666666667
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(35,205,205)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 55, component: QE_2017_001815_201.16367_442.0",
+          "cluster: 55, component: QE_2017_001815_201.16367_442.0",
+          "cluster: 55, component: QE_2017_001816_201.16362_435.0",
+          "cluster: 55, component: QE_2017_001816_201.16362_435.0"
+         ],
          "type": "scatter",
+         "uid": "aba61f7d-ccbc-4c06-a6b8-3abdb92dd5f1",
          "x": [
           935,
           935,
@@ -3183,434 +3903,374 @@
          "xaxis": "x",
          "y": [
           0,
-          0.35384615384615387,
-          0.35384615384615387,
+          0.48333333333333334,
+          0.48333333333333334,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 56, component: QE_2017_001815_209.1535_312.0",
+          "cluster: 56, component: QE_2017_001815_209.1535_312.0",
+          "cluster: 56, component: QE_2017_001816_209.15344_311.0",
+          "cluster: 56, component: QE_2017_001816_209.15344_311.0"
+         ],
          "type": "scatter",
+         "uid": "72238ae2-dd6b-423e-b9db-7a3059d5df90",
          "x": [
-          955,
-          955,
-          965,
-          965
+          975,
+          975,
+          985,
+          985
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.54,
-          0.54,
+          0.2916666666666667,
+          0.2916666666666667,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 56, component: QE_2017_001815_209.15349_295.0",
+          "cluster: 56, component: QE_2017_001815_209.15349_295.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "d158c307-3de8-4ff8-9898-d24c1c4cf816",
          "x": [
-          940,
-          940,
-          960,
-          960
+          965,
+          965,
+          980,
+          980
          ],
          "xaxis": "x",
          "y": [
-          0.35384615384615387,
-          0.5934065934065934,
-          0.5934065934065934,
-          0.54
+          0,
+          0.3835616438356164,
+          0.3835616438356164,
+          0.2916666666666667
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 56, component: QE_2017_001815_209.15352_479.0",
+          "cluster: 56, component: QE_2017_001815_209.15352_479.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9f22cc41-e729-4257-a110-347721183a93",
          "x": [
-          906.25,
-          906.25,
-          950,
-          950
+          955,
+          955,
+          972.5,
+          972.5
          ],
          "xaxis": "x",
          "y": [
-          0.5119047619047619,
-          0.6530612244897959,
-          0.6530612244897959,
-          0.5934065934065934
+          0,
+          0.4473684210526316,
+          0.4473684210526316,
+          0.3835616438356164
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 57, component: QE_2017_001814_243.15892_533.0",
+          "cluster: 57, component: QE_2017_001814_243.15892_533.0",
+          "cluster: 57, component: QE_2017_001814_281.1745_492.0",
+          "cluster: 57, component: QE_2017_001814_281.1745_492.0"
+         ],
          "type": "scatter",
+         "uid": "899481f0-5460-4f73-8f57-a1fd432e0439",
          "x": [
-          985,
-          985,
           995,
-          995
+          995,
+          1005,
+          1005
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.3333333333333333,
-          0.3333333333333333,
+          0.359375,
+          0.359375,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          975,
-          975,
-          990,
-          990
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.6753246753246753,
-          0.6753246753246753,
-          0.3333333333333333
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          928.125,
-          928.125,
-          982.5,
-          982.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.6530612244897959,
-          0.7093023255813954,
-          0.7093023255813954,
-          0.6753246753246753
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 57, component: QE_2017_001815_227.16408_344.0",
+          "cluster: 57, component: QE_2017_001815_227.16408_344.0",
+          "cluster: 57, component: QE_2017_001815_283.19009_564.0",
+          "cluster: 57, component: QE_2017_001815_283.19009_564.0"
+         ],
          "type": "scatter",
+         "uid": "28a23556-76a0-488d-bec8-3ec8f688e184",
          "x": [
-          1005,
-          1005,
+          1025,
+          1025,
+          1035,
+          1035
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.47191011235955055,
+          0.47191011235955055,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 57, component: QE_2017_001814_293.2106_579.0",
+          "cluster: 57, component: QE_2017_001814_293.2106_579.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0a178f72-94c5-4dfa-91b7-3ae55be2d523",
+         "x": [
           1015,
-          1015
+          1015,
+          1030,
+          1030
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.2777777777777778,
-          0.2777777777777778,
-          0
+          0.5454545454545454,
+          0.5454545454545454,
+          0.47191011235955055
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "31088d8a-792f-41a9-b216-fcbdb9118710",
+         "x": [
+          1000,
+          1000,
+          1022.5,
+          1022.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.359375,
+          0.6,
+          0.6,
+          0.5454545454545454
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "dd8e0b4a-e6cd-4bc6-aa3e-22680cd02540",
+         "x": [
+          963.75,
+          963.75,
+          1011.25,
+          1011.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4473684210526316,
+          0.6494845360824743,
+          0.6494845360824743,
+          0.6
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 58, component: QE_2017_001814_227.1275_293.0",
+          "cluster: 58, component: QE_2017_001814_227.1275_293.0",
+          "cluster: 58, component: QE_2017_001816_227.12766_295.0",
+          "cluster: 58, component: QE_2017_001816_227.12766_295.0"
+         ],
          "type": "scatter",
+         "uid": "0f9c6b5b-812e-469f-a25f-221cb0122210",
          "x": [
-          1045,
-          1045,
           1055,
-          1055
+          1055,
+          1065,
+          1065
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.18867924528301888,
-          0.18867924528301888,
+          0.3382352941176471,
+          0.3382352941176471,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 59, component: QE_2017_001815_207.13785_297.0",
+          "cluster: 59, component: QE_2017_001815_207.13785_297.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "bdd7344b-6d81-4a79-9919-65371a346f56",
          "x": [
-          1035,
-          1035,
-          1050,
-          1050
+          1045,
+          1045,
+          1060,
+          1060
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.20754716981132076,
-          0.20754716981132076,
-          0.18867924528301888
+          0.6710526315789473,
+          0.6710526315789473,
+          0.3382352941176471
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9424e53d-4ed4-49b6-bfe3-e4d75e48f780",
          "x": [
-          1025,
-          1025,
-          1042.5,
-          1042.5
+          987.5,
+          987.5,
+          1052.5,
+          1052.5
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.29508196721311475,
-          0.29508196721311475,
-          0.20754716981132076
+          0.6494845360824743,
+          0.7058823529411765,
+          0.7058823529411765,
+          0.6710526315789473
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 60, component: QE_2017_001815_181.1221_767.0",
+          "cluster: 60, component: QE_2017_001815_181.1221_767.0",
+          "cluster: 60, component: QE_2017_001816_181.12199_794.0",
+          "cluster: 60, component: QE_2017_001816_181.12199_794.0"
+         ],
          "type": "scatter",
+         "uid": "f43711cd-f5bf-4821-ab01-83825b340a82",
          "x": [
-          1065,
-          1065,
           1075,
-          1075
+          1075,
+          1085,
+          1085
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.54,
-          0.54,
+          0.2857142857142857,
+          0.2857142857142857,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 61, component: QE_2017_001814_211.16902_440.0",
+          "cluster: 61, component: QE_2017_001814_211.16902_440.0",
+          "cluster: 61, component: QE_2017_001815_211.16913_450.0",
+          "cluster: 61, component: QE_2017_001815_211.16913_450.0"
+         ],
          "type": "scatter",
-         "x": [
-          1033.75,
-          1033.75,
-          1070,
-          1070
-         ],
-         "xaxis": "x",
-         "y": [
-          0.29508196721311475,
-          0.5714285714285714,
-          0.5714285714285714,
-          0.54
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1010,
-          1010,
-          1051.875,
-          1051.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.2777777777777778,
-          0.75,
-          0.75,
-          0.5714285714285714
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          955.3125,
-          955.3125,
-          1030.9375,
-          1030.9375
-         ],
-         "xaxis": "x",
-         "y": [
-          0.7093023255813954,
-          0.7662337662337663,
-          0.7662337662337663,
-          0.75
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          875,
-          875,
-          993.125,
-          993.125
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.8192771084337349,
-          0.8192771084337349,
-          0.7662337662337663
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          809.0625,
-          809.0625,
-          934.0625,
-          934.0625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.7857142857142857,
-          0.8448275862068966,
-          0.8448275862068966,
-          0.8192771084337349
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1085,
-          1085,
-          1095,
-          1095
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.8571428571428571,
-          0.8571428571428571,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          871.5625,
-          871.5625,
-          1090,
-          1090
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8448275862068966,
-          0.9146341463414634,
-          0.9146341463414634,
-          0.8571428571428571
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "c656f1f8-55a7-4474-afb7-c5d3f881dac8",
          "x": [
           1115,
           1115,
@@ -3620,273 +4280,577 @@
          "xaxis": "x",
          "y": [
           0,
-          0.8333333333333334,
-          0.8333333333333334,
+          0.19230769230769232,
+          0.19230769230769232,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1155,
-          1155,
-          1165,
-          1165
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.34615384615384615,
-          0.34615384615384615,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1145,
-          1145,
-          1160,
-          1160
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.6296296296296297,
-          0.6296296296296297,
-          0.34615384615384615
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1135,
-          1135,
-          1152.5,
-          1152.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.8666666666666667,
-          0.8666666666666667,
-          0.6296296296296297
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1120,
-          1120,
-          1143.75,
-          1143.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8333333333333334,
-          0.9111111111111111,
-          0.9111111111111111,
-          0.8666666666666667
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1105,
-          1105,
-          1131.875,
-          1131.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.9298245614035088,
-          0.9298245614035088,
-          0.9111111111111111
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          980.78125,
-          980.78125,
-          1118.4375,
-          1118.4375
-         ],
-         "xaxis": "x",
-         "y": [
-          0.9146341463414634,
-          0.9883720930232558,
-          0.9883720930232558,
-          0.9298245614035088
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1175,
-          1175,
-          1185,
-          1185
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.8571428571428571,
-          0.8571428571428571,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 61, component: QE_2017_001815_209.0807_405.0",
+          "cluster: 61, component: QE_2017_001815_209.0807_405.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e2258958-5b72-410a-8522-d2b4b914f08f",
          "x": [
-          1215,
-          1215,
-          1225,
-          1225
+          1105,
+          1105,
+          1120,
+          1120
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.38461538461538464,
-          0.38461538461538464,
+          0.21153846153846154,
+          0.21153846153846154,
+          0.19230769230769232
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 61, component: QE_2017_001816_211.16916_405.0",
+          "cluster: 61, component: QE_2017_001816_211.16916_405.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0b3dab15-3165-4939-b6d8-f0e1f3d30eb5",
+         "x": [
+          1095,
+          1095,
+          1112.5,
+          1112.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3,
+          0.3,
+          0.21153846153846154
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 61, component: QE_2017_001815_215.164_550.0",
+          "cluster: 61, component: QE_2017_001815_215.164_550.0",
+          "cluster: 61, component: QE_2017_001816_215.16411_482.0",
+          "cluster: 61, component: QE_2017_001816_215.16411_482.0"
+         ],
+         "type": "scatter",
+         "uid": "0c4201c0-7869-4a81-87f0-8fa4420f7ac9",
+         "x": [
+          1135,
+          1135,
+          1145,
+          1145
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.48717948717948717,
+          0.48717948717948717,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "5c119f6e-1225-4d50-b837-a40a5738c965",
          "x": [
-          1205,
-          1205,
-          1220,
-          1220
+          1103.75,
+          1103.75,
+          1140,
+          1140
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.6904761904761905,
-          0.6904761904761905,
-          0.38461538461538464
+          0.3,
+          0.5818181818181818,
+          0.5818181818181818,
+          0.48717948717948717
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "19738828-8f63-4987-870a-29571560c9ec",
          "x": [
-          1195,
-          1195,
-          1212.5,
-          1212.5
+          1080,
+          1080,
+          1121.875,
+          1121.875
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.8095238095238095,
-          0.8095238095238095,
-          0.6904761904761905
+          0.2857142857142857,
+          0.7446808510638298,
+          0.7446808510638298,
+          0.5818181818181818
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "6317fdff-e671-45cf-ac98-e80cad977604",
          "x": [
-          1235,
-          1235,
-          1245,
-          1245
+          1020,
+          1020,
+          1100.9375,
+          1100.9375
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.7222222222222222,
-          0.7222222222222222,
-          0
+          0.7058823529411765,
+          0.7631578947368421,
+          0.7631578947368421,
+          0.7446808510638298
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 62, component: QE_2017_001814_219.17416_517.0",
+          "cluster: 62, component: QE_2017_001814_219.17416_517.0",
+          "cluster: 62, component: QE_2017_001815_219.17421_516.0",
+          "cluster: 62, component: QE_2017_001815_219.17421_516.0"
+         ],
          "type": "scatter",
+         "uid": "53e029f4-6023-46b3-9c78-f530ad4be5e0",
+         "x": [
+          1165,
+          1165,
+          1175,
+          1175
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.25,
+          0.25,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 62, component: QE_2017_001814_219.17401_452.0",
+          "cluster: 62, component: QE_2017_001814_219.17401_452.0",
+          "cluster: 62, component: QE_2017_001814_219.17409_442.0",
+          "cluster: 62, component: QE_2017_001814_219.17409_442.0"
+         ],
+         "type": "scatter",
+         "uid": "d5217628-c628-45a6-a0e8-2ebaa638ccb7",
+         "x": [
+          1195,
+          1195,
+          1205,
+          1205
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3125,
+          0.3125,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 62, component: QE_2017_001816_219.17438_502.0",
+          "cluster: 62, component: QE_2017_001816_219.17438_502.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "29cd04c7-ff53-4f28-9568-b25f26c486cf",
+         "x": [
+          1185,
+          1185,
+          1200,
+          1200
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4074074074074074,
+          0.4074074074074074,
+          0.3125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1b6f1ab0-8621-4840-879e-c9e718ea0826",
+         "x": [
+          1170,
+          1170,
+          1192.5,
+          1192.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.25,
+          0.4583333333333333,
+          0.4583333333333333,
+          0.4074074074074074
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 63, component: QE_2017_001815_191.14287_312.0",
+          "cluster: 63, component: QE_2017_001815_191.14287_312.0",
+          "cluster: 63, component: QE_2017_001816_191.14291_404.0",
+          "cluster: 63, component: QE_2017_001816_191.14291_404.0"
+         ],
+         "type": "scatter",
+         "uid": "21607f2a-6a28-46e2-bc98-b97ad9f1621f",
+         "x": [
+          1225,
+          1225,
+          1235,
+          1235
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.43103448275862066,
+          0.43103448275862066,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 63, component: QE_2017_001814_191.14291_389.0",
+          "cluster: 63, component: QE_2017_001814_191.14291_389.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "bbb4c1f1-3913-489e-a340-d3103041c966",
+         "x": [
+          1215,
+          1215,
+          1230,
+          1230
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5,
+          0.5,
+          0.43103448275862066
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a912f293-e8ee-41cc-aa46-d548ea38fa50",
+         "x": [
+          1181.25,
+          1181.25,
+          1222.5,
+          1222.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4583333333333333,
+          0.68,
+          0.68,
+          0.5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 64, component: QE_2017_001816_137.09584_445.0",
+          "cluster: 64, component: QE_2017_001816_137.09584_445.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "228eaae2-ffab-4fab-ac6a-d4340cfda856",
+         "x": [
+          1155,
+          1155,
+          1201.875,
+          1201.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.782608695652174,
+          0.782608695652174,
+          0.68
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e9305d60-29bb-4fd9-be3f-5cc0f3e5baf8",
+         "x": [
+          1060.46875,
+          1060.46875,
+          1178.4375,
+          1178.4375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7631578947368421,
+          0.8170731707317073,
+          0.8170731707317073,
+          0.782608695652174
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6bda9da1-48ae-470a-a45a-758000f609db",
+         "x": [
+          940,
+          940,
+          1119.453125,
+          1119.453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.48333333333333334,
+          0.8421052631578947,
+          0.8421052631578947,
+          0.8170731707317073
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 65, component: QE_2017_001814_209.08058_363.0",
+          "cluster: 65, component: QE_2017_001814_209.08058_363.0",
+          "cluster: 66, component: QE_2017_001816_207.13779_561.0",
+          "cluster: 66, component: QE_2017_001816_207.13779_561.0"
+         ],
+         "type": "scatter",
+         "uid": "323ca4f3-7728-4ebf-bc8e-1660ecef1dac",
+         "x": [
+          1245,
+          1245,
+          1255,
+          1255
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8556701030927835,
+          0.8556701030927835,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "398c08c9-bec9-4232-8a45-ba373e013899",
+         "x": [
+          1029.7265625,
+          1029.7265625,
+          1250,
+          1250
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8421052631578947,
+          0.9135802469135802,
+          0.9135802469135802,
+          0.8556701030927835
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1cca8632-4845-4af1-9a8a-c8d2a45ef838",
+         "x": [
+          901.875,
+          901.875,
+          1139.86328125,
+          1139.86328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9032258064516129,
+          0.9882352941176471,
+          0.9882352941176471,
+          0.9135802469135802
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 67, component: QE_2017_001815_333.15173_245.0",
+          "cluster: 67, component: QE_2017_001815_333.15173_245.0",
+          "cluster: 68, component: QE_2017_001816_333.15204_235.0",
+          "cluster: 68, component: QE_2017_001816_333.15204_235.0"
+         ],
+         "type": "scatter",
+         "uid": "9bce28e9-3faa-495e-9674-6a24178a0858",
          "x": [
           1265,
           1265,
@@ -3896,163 +4860,60 @@
          "xaxis": "x",
          "y": [
           0,
-          0.4,
-          0.4,
+          0.8461538461538461,
+          0.8461538461538461,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 69, component: QE_2017_001814_194.1174_244.0",
+          "cluster: 69, component: QE_2017_001814_194.1174_244.0",
+          "cluster: 70, component: QE_2017_001816_194.11746_133.0",
+          "cluster: 70, component: QE_2017_001816_194.11746_133.0"
+         ],
          "type": "scatter",
+         "uid": "53517189-f2b6-4198-9d3a-9087d4cd1374",
          "x": [
-          1255,
-          1255,
-          1270,
-          1270
+          1285,
+          1285,
+          1295,
+          1295
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.6521739130434783,
-          0.6521739130434783,
-          0.4
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1295,
-          1295,
-          1305,
-          1305
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.5384615384615384,
-          0.5384615384615384,
+          0.7142857142857143,
+          0.7142857142857143,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1285,
-          1285,
-          1300,
-          1300
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.8,
-          0.8,
-          0.5384615384615384
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1262.5,
-          1262.5,
-          1292.5,
-          1292.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.6521739130434783,
-          0.9629629629629629,
-          0.9629629629629629,
-          0.8
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1240,
-          1240,
-          1277.5,
-          1277.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.7222222222222222,
-          0.975609756097561,
-          0.975609756097561,
-          0.9629629629629629
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1203.75,
-          1203.75,
-          1258.75,
-          1258.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8095238095238095,
-          0.9821428571428571,
-          0.9821428571428571,
-          0.975609756097561
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 71, component: QE_2017_001814_320.29471_529.0",
+          "cluster: 71, component: QE_2017_001814_320.29471_529.0",
+          "cluster: 71, component: QE_2017_001815_320.29486_538.0",
+          "cluster: 71, component: QE_2017_001815_320.29486_538.0"
+         ],
          "type": "scatter",
+         "uid": "17f267e6-5c56-4c20-91a7-6740483dbf16",
          "x": [
-          1315,
-          1315,
-          1325,
-          1325
+          1335,
+          1335,
+          1345,
+          1345
          ],
          "xaxis": "x",
          "y": [
@@ -4064,13 +4925,135 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 71, component: QE_2017_001814_320.29477_539.0",
+          "cluster: 71, component: QE_2017_001814_320.29477_539.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "1b14f954-94a6-42d8-ad4f-e212a72a56d2",
+         "x": [
+          1325,
+          1325,
+          1340,
+          1340
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5833333333333334,
+          0.5833333333333334,
+          0.4444444444444444
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 72, component: QE_2017_001814_320.29468_638.0",
+          "cluster: 72, component: QE_2017_001814_320.29468_638.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f5affeb4-f8a4-4951-baf7-e2b0d75212ee",
+         "x": [
+          1315,
+          1315,
+          1332.5,
+          1332.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7857142857142857,
+          0.7857142857142857,
+          0.5833333333333334
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 73, component: QE_2017_001816_320.29483_548.0",
+          "cluster: 73, component: QE_2017_001816_320.29483_548.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "2a9b9699-8eac-472d-8742-9179c92ffcc8",
+         "x": [
+          1305,
+          1305,
+          1323.75,
+          1323.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9393939393939394,
+          0.9393939393939394,
+          0.7857142857142857
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "522609d3-8889-40cf-b1c6-8ec636f69b00",
+         "x": [
+          1290,
+          1290,
+          1314.375,
+          1314.375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7142857142857143,
+          0.9523809523809523,
+          0.9523809523809523,
+          0.9393939393939394
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 74, component: QE_2017_001814_241.15384_47.0",
+          "cluster: 74, component: QE_2017_001814_241.15384_47.0",
+          "cluster: 75, component: QE_2017_001814_241.15446_57.0",
+          "cluster: 75, component: QE_2017_001814_241.15446_57.0"
+         ],
+         "type": "scatter",
+         "uid": "75031473-69eb-4d1b-8b2e-f15e6309728b",
          "x": [
           1355,
           1355,
@@ -4080,89 +5063,142 @@
          "xaxis": "x",
          "y": [
           0,
-          0.35064935064935066,
-          0.35064935064935066,
+          0.6363636363636364,
+          0.6363636363636364,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(40,35,35)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1345,
-          1345,
-          1360,
-          1360
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.43661971830985913,
-          0.43661971830985913,
-          0.35064935064935066
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1335,
-          1335,
-          1352.5,
-          1352.5
+         "text": [
+          "cluster: 76, component: QE_2017_001815_332.25827_508.0",
+          "cluster: 76, component: QE_2017_001815_332.25827_508.0",
+          "cluster: 77, component: QE_2017_001816_332.25842_487.0",
+          "cluster: 77, component: QE_2017_001816_332.25842_487.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.6521739130434783,
-          0.6521739130434783,
-          0.43661971830985913
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "26bcf586-cbb8-444b-9454-dca681dce168",
          "x": [
-          1375,
-          1375,
           1385,
-          1385
+          1385,
+          1395,
+          1395
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.32142857142857145,
-          0.32142857142857145,
+          0.6829268292682927,
+          0.6829268292682927,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 78, component: QE_2017_001814_332.25827_467.0",
+          "cluster: 78, component: QE_2017_001814_332.25827_467.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "7538b6d0-6ce7-4736-a28d-7b776fbb550e",
+         "x": [
+          1375,
+          1375,
+          1390,
+          1390
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8,
+          0.8,
+          0.6829268292682927
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4b66fe18-2149-4014-97f2-877f50ed0a51",
+         "x": [
+          1360,
+          1360,
+          1382.5,
+          1382.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6363636363636364,
+          0.9666666666666667,
+          0.9666666666666667,
+          0.8
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "869398db-6333-4802-88f8-40905bdc205b",
+         "x": [
+          1302.1875,
+          1302.1875,
+          1371.25,
+          1371.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9523809523809523,
+          0.9772727272727273,
+          0.9772727272727273,
+          0.9666666666666667
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 79, component: QE_2017_001814_319.13638_117.0",
+          "cluster: 79, component: QE_2017_001814_319.13638_117.0",
+          "cluster: 80, component: QE_2017_001816_319.13614_143.0",
+          "cluster: 80, component: QE_2017_001816_319.13614_143.0"
+         ],
+         "type": "scatter",
+         "uid": "0acd9a58-c94e-4b05-94ad-ae75ec7c22f0",
          "x": [
           1405,
           1405,
@@ -4172,204 +5208,142 @@
          "xaxis": "x",
          "y": [
           0,
-          0.25,
-          0.25,
+          0.75,
+          0.75,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 81, component: QE_2017_001815_219.10139_360.0",
+          "cluster: 81, component: QE_2017_001815_219.10139_360.0",
+          "cluster: 81, component: QE_2017_001816_219.10153_382.0",
+          "cluster: 81, component: QE_2017_001816_219.10153_382.0"
+         ],
          "type": "scatter",
+         "uid": "c78179aa-c4d8-4596-a5a1-d7b9bc6f8278",
          "x": [
-          1395,
-          1395,
-          1410,
-          1410
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.4,
-          0.4,
-          0.25
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1380,
-          1380,
-          1402.5,
-          1402.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.32142857142857145,
-          0.42857142857142855,
-          0.42857142857142855,
-          0.4
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1435,
-          1435,
           1445,
-          1445
+          1445,
+          1455,
+          1455
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.3888888888888889,
-          0.3888888888888889,
+          0.38181818181818183,
+          0.38181818181818183,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 81, component: QE_2017_001815_219.10159_438.0",
+          "cluster: 81, component: QE_2017_001815_219.10159_438.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "fb3dfaec-9021-4c27-8e70-16daffdb1bd6",
          "x": [
-          1425,
-          1425,
-          1440,
-          1440
+          1435,
+          1435,
+          1450,
+          1450
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.88,
-          0.88,
-          0.3888888888888889
+          0.4647887323943662,
+          0.4647887323943662,
+          0.38181818181818183
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 82, component: QE_2017_001814_251.09117_393.0",
+          "cluster: 82, component: QE_2017_001814_251.09117_393.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "3e7baeb6-e9d7-4495-8e4f-38284d7f4113",
          "x": [
-          1391.25,
-          1391.25,
-          1432.5,
-          1432.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.42857142857142855,
-          0.918918918918919,
-          0.918918918918919,
-          0.88
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1343.75,
-          1343.75,
-          1411.875,
-          1411.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.6521739130434783,
-          0.9891304347826086,
-          0.9891304347826086,
-          0.918918918918919
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1475,
-          1475,
-          1485,
-          1485
+          1425,
+          1425,
+          1442.5,
+          1442.5
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.4626865671641791,
-          0.4626865671641791,
+          0.6527777777777778,
+          0.6527777777777778,
+          0.4647887323943662
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 83, component: QE_2017_001814_291.1442_241.0",
+          "cluster: 83, component: QE_2017_001814_291.1442_241.0",
+          "cluster: 83, component: QE_2017_001816_291.14493_243.0",
+          "cluster: 83, component: QE_2017_001816_291.14493_243.0"
+         ],
+         "type": "scatter",
+         "uid": "76806a84-065c-4f4b-ab08-7eed82d786ec",
+         "x": [
+          1465,
+          1465,
+          1475,
+          1475
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.37037037037037035,
+          0.37037037037037035,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1465,
-          1465,
-          1480,
-          1480
+         "text": [
+          "cluster: 83, component: QE_2017_001815_273.13425_199.0",
+          "cluster: 83, component: QE_2017_001815_273.13425_199.0",
+          "cluster: 83, component: QE_2017_001815_273.13434_243.0",
+          "cluster: 83, component: QE_2017_001815_273.13434_243.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.7444444444444445,
-          0.7444444444444445,
-          0.4626865671641791
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "49c5d831-b985-44fe-b090-3dd3351a12a7",
          "x": [
           1495,
           1495,
@@ -4379,20 +5353,84 @@
          "xaxis": "x",
          "y": [
           0,
-          0.34285714285714286,
-          0.34285714285714286,
+          0.3333333333333333,
+          0.3333333333333333,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 83, component: QE_2017_001816_291.14499_200.0",
+          "cluster: 83, component: QE_2017_001816_291.14499_200.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "27499876-30f1-4ceb-af30-4d796f95e2d4",
+         "x": [
+          1485,
+          1485,
+          1500,
+          1500
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.41935483870967744,
+          0.41935483870967744,
+          0.3333333333333333
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a217c3db-7a4b-4222-9507-7f66eb329b82",
+         "x": [
+          1470,
+          1470,
+          1492.5,
+          1492.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.37037037037037035,
+          0.5161290322580645,
+          0.5161290322580645,
+          0.41935483870967744
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 84, component: QE_2017_001815_235.14398_226.0",
+          "cluster: 84, component: QE_2017_001815_235.14398_226.0",
+          "cluster: 84, component: QE_2017_001816_235.14397_183.0",
+          "cluster: 84, component: QE_2017_001816_235.14397_183.0"
+         ],
+         "type": "scatter",
+         "uid": "473ad74f-c0ba-46cd-afae-6d212363fd75",
          "x": [
           1525,
           1525,
@@ -4402,20 +5440,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.7857142857142857,
-          0.7857142857142857,
+          0.5263157894736842,
+          0.5263157894736842,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 85, component: QE_2017_001815_251.13873_202.0",
+          "cluster: 85, component: QE_2017_001815_251.13873_202.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f9b4c4c7-4d36-43b8-95b4-1547fbcc2c14",
          "x": [
           1515,
           1515,
@@ -4425,296 +5469,316 @@
          "xaxis": "x",
          "y": [
           0,
-          0.8181818181818182,
-          0.8181818181818182,
-          0.7857142857142857
+          0.8636363636363636,
+          0.8636363636363636,
+          0.5263157894736842
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "104b1c0f-0b7a-4985-ad18-afca47c8bc33",
          "x": [
-          1500,
-          1500,
+          1481.25,
+          1481.25,
           1522.5,
           1522.5
          ],
          "xaxis": "x",
          "y": [
-          0.34285714285714286,
-          0.8604651162790697,
-          0.8604651162790697,
-          0.8181818181818182
+          0.5161290322580645,
+          0.9166666666666666,
+          0.9166666666666666,
+          0.8636363636363636
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "7c6ccb3d-abfa-4ca3-9d29-15d861303830",
          "x": [
-          1472.5,
-          1472.5,
-          1511.25,
-          1511.25
+          1433.75,
+          1433.75,
+          1501.875,
+          1501.875
          ],
          "xaxis": "x",
          "y": [
-          0.7444444444444445,
-          0.9210526315789473,
-          0.9210526315789473,
-          0.8604651162790697
+          0.6527777777777778,
+          0.9891304347826086,
+          0.9891304347826086,
+          0.9166666666666666
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1455,
-          1455,
-          1491.875,
-          1491.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.9540229885057471,
-          0.9540229885057471,
-          0.9210526315789473
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1555,
-          1555,
-          1565,
-          1565
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.47058823529411764,
-          0.47058823529411764,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(40,35,35)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1575,
-          1575,
-          1585,
-          1585
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.2857142857142857,
-          0.2857142857142857,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1605,
-          1605,
-          1615,
-          1615
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.25,
-          0.25,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1595,
-          1595,
-          1610,
-          1610
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.4,
-          0.4,
-          0.25
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1580,
-          1580,
-          1602.5,
-          1602.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.2857142857142857,
-          0.8717948717948718,
-          0.8717948717948718,
-          0.4
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1560,
-          1560,
-          1591.25,
-          1591.25
-         ],
-         "xaxis": "x",
-         "y": [
-          0.47058823529411764,
-          0.96,
-          0.96,
-          0.8717948717948718
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1545,
-          1545,
-          1575.625,
-          1575.625
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.9795918367346939,
-          0.9795918367346939,
-          0.96
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1635,
-          1635,
-          1645,
-          1645
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.25,
-          0.25,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1625,
-          1625,
-          1640,
-          1640
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.8787878787878788,
-          0.8787878787878788,
-          0.25
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 86, component: QE_2017_001814_250.10149_516.0",
+          "cluster: 86, component: QE_2017_001814_250.10149_516.0",
+          "cluster: 86, component: QE_2017_001815_222.07033_315.0",
+          "cluster: 86, component: QE_2017_001815_222.07033_315.0"
+         ],
          "type": "scatter",
+         "uid": "72d0f9aa-b2d2-4962-844d-34e25e663ee8",
+         "x": [
+          1565,
+          1565,
+          1575,
+          1575
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5081967213114754,
+          0.5081967213114754,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 87, component: QE_2017_001816_268.59351_445.0",
+          "cluster: 87, component: QE_2017_001816_268.59351_445.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e5b23019-2353-49a2-8ec3-b0031fb43c41",
+         "x": [
+          1555,
+          1555,
+          1570,
+          1570
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6923076923076923,
+          0.6923076923076923,
+          0.5081967213114754
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 88, component: QE_2017_001814_247.05975_245.0",
+          "cluster: 88, component: QE_2017_001814_247.05975_245.0",
+          "cluster: 88, component: QE_2017_001815_247.0598_242.0",
+          "cluster: 88, component: QE_2017_001815_247.0598_242.0"
+         ],
+         "type": "scatter",
+         "uid": "0ecaee29-6ac3-416b-a6f9-153439b498e6",
+         "x": [
+          1585,
+          1585,
+          1595,
+          1595
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.35294117647058826,
+          0.35294117647058826,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 89, component: QE_2017_001815_212.03883_181.0",
+          "cluster: 89, component: QE_2017_001815_212.03883_181.0",
+          "cluster: 90, component: QE_2017_001815_214.56488_409.0",
+          "cluster: 90, component: QE_2017_001815_214.56488_409.0"
+         ],
+         "type": "scatter",
+         "uid": "c33c9d92-d2f7-4727-b8dc-7c6708f5c737",
+         "x": [
+          1615,
+          1615,
+          1625,
+          1625
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7777777777777778,
+          0.7777777777777778,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 91, component: QE_2017_001816_219.04672_291.0",
+          "cluster: 91, component: QE_2017_001816_219.04672_291.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "fc1e7633-9f1f-44d7-b16e-57acab558a36",
+         "x": [
+          1605,
+          1605,
+          1620,
+          1620
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8125,
+          0.8125,
+          0.7777777777777778
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "34d067ff-819a-47aa-9dd1-da58bbf4606d",
+         "x": [
+          1590,
+          1590,
+          1612.5,
+          1612.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.35294117647058826,
+          0.8571428571428571,
+          0.8571428571428571,
+          0.8125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "163f112c-262f-4646-9e64-d67dce9a5b8c",
+         "x": [
+          1562.5,
+          1562.5,
+          1601.25,
+          1601.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6923076923076923,
+          0.9178082191780822,
+          0.9178082191780822,
+          0.8571428571428571
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 92, component: QE_2017_001815_214.51021_60.0",
+          "cluster: 92, component: QE_2017_001815_214.51021_60.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c5f92512-6395-4d36-89c0-855f3e786f0b",
+         "x": [
+          1545,
+          1545,
+          1581.875,
+          1581.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9534883720930233,
+          0.9534883720930233,
+          0.9178082191780822
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 93, component: QE_2017_001815_246.14465_137.0",
+          "cluster: 93, component: QE_2017_001815_246.14465_137.0",
+          "cluster: 93, component: QE_2017_001815_247.12865_158.0",
+          "cluster: 93, component: QE_2017_001815_247.12865_158.0"
+         ],
+         "type": "scatter",
+         "uid": "2cbfcdbb-0115-40ba-b716-6e52b9a73bcd",
          "x": [
           1655,
           1655,
@@ -4724,20 +5788,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.5806451612903226,
-          0.5806451612903226,
+          0.5,
+          0.5,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 94, component: QE_2017_001814_260.16037_143.0",
+          "cluster: 94, component: QE_2017_001814_260.16037_143.0",
+          "cluster: 94, component: QE_2017_001816_260.16022_145.0",
+          "cluster: 94, component: QE_2017_001816_260.16022_145.0"
+         ],
          "type": "scatter",
+         "uid": "4c15c21e-3084-4fa2-b1d4-287c2f81ef35",
          "x": [
           1675,
           1675,
@@ -4747,227 +5817,345 @@
          "xaxis": "x",
          "y": [
           0,
-          0.6521739130434783,
-          0.6521739130434783,
+          0.2857142857142857,
+          0.2857142857142857,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1660,
-          1660,
-          1680,
-          1680
+         "text": [
+          "cluster: 95, component: QE_2017_001814_233.14948_126.0",
+          "cluster: 95, component: QE_2017_001814_233.14948_126.0",
+          "cluster: 95, component: QE_2017_001816_233.14955_129.0",
+          "cluster: 95, component: QE_2017_001816_233.14955_129.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.5806451612903226,
-          0.8125,
-          0.8125,
-          0.6521739130434783
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "f05c105e-58b5-4cea-a5ea-8914c34ec137",
          "x": [
-          1695,
-          1695,
           1705,
-          1705
+          1705,
+          1715,
+          1715
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.296875,
-          0.296875,
+          0.2631578947368421,
+          0.2631578947368421,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(133,20,75)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 95, component: QE_2017_001814_233.14957_152.0",
+          "cluster: 95, component: QE_2017_001814_233.14957_152.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "ef9a9a57-3ff3-49f4-961d-5542a15c9fbc",
          "x": [
-          1715,
-          1715,
+          1695,
+          1695,
+          1710,
+          1710
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5416666666666666,
+          0.5416666666666666,
+          0.2631578947368421
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4e4673a4-f6aa-4d50-aeaf-922c05e06c45",
+         "x": [
+          1680,
+          1680,
+          1702.5,
+          1702.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2857142857142857,
+          0.8648648648648649,
+          0.8648648648648649,
+          0.5416666666666666
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a5594250-89ac-4d55-b1c1-102f04245a1d",
+         "x": [
+          1660,
+          1660,
+          1691.25,
+          1691.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5,
+          0.9574468085106383,
+          0.9574468085106383,
+          0.8648648648648649
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 96, component: QE_2017_001816_132.04436_283.0",
+          "cluster: 96, component: QE_2017_001816_132.04436_283.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f2cebb6a-4de9-4b08-b902-41ecbf3c4e11",
+         "x": [
+          1645,
+          1645,
+          1675.625,
+          1675.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.98,
+          0.98,
+          0.9574468085106383
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 97, component: QE_2017_001815_260.16016_64.0",
+          "cluster: 97, component: QE_2017_001815_260.16016_64.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8447fce9-e5da-44dc-8b1d-1c1d6a376eee",
+         "x": [
+          1635,
+          1635,
+          1660.3125,
+          1660.3125
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9846153846153847,
+          0.9846153846153847,
+          0.98
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 98, component: QE_2017_001815_221.12837_99.0",
+          "cluster: 98, component: QE_2017_001815_221.12837_99.0",
+          "cluster: 99, component: QE_2017_001816_237.12325_171.0",
+          "cluster: 99, component: QE_2017_001816_237.12325_171.0"
+         ],
+         "type": "scatter",
+         "uid": "00447cb6-bd2b-469a-9e04-1affc62cebc4",
+         "x": [
           1725,
-          1725
+          1725,
+          1735,
+          1735
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.34210526315789475,
-          0.34210526315789475,
+          0.7142857142857143,
+          0.7142857142857143,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1700,
-          1700,
-          1720,
-          1720
-         ],
-         "xaxis": "x",
-         "y": [
-          0.296875,
-          0.5483870967741935,
-          0.5483870967741935,
-          0.34210526315789475
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 100, component: QE_2017_001814_237.12305_220.0",
+          "cluster: 100, component: QE_2017_001814_237.12305_220.0",
+          "cluster: 101, component: QE_2017_001816_237.12323_53.0",
+          "cluster: 101, component: QE_2017_001816_237.12323_53.0"
+         ],
          "type": "scatter",
+         "uid": "a459ecc6-c14f-4937-bb2c-b951a94c17fd",
          "x": [
+          1745,
+          1745,
           1755,
-          1755,
+          1755
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9444444444444444,
+          0.9444444444444444,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "cb2fb1a7-aceb-4c2d-9530-e9f4f4db2234",
+         "x": [
+          1730,
+          1730,
+          1750,
+          1750
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7142857142857143,
+          0.9761904761904762,
+          0.9761904761904762,
+          0.9444444444444444
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 102, component: QE_2017_001814_229.15399_46.0",
+          "cluster: 102, component: QE_2017_001814_229.15399_46.0",
+          "cluster: 102, component: QE_2017_001816_229.15451_66.0",
+          "cluster: 102, component: QE_2017_001816_229.15451_66.0"
+         ],
+         "type": "scatter",
+         "uid": "4182f857-7073-4d49-a044-83b9dd4014f3",
+         "x": [
+          1775,
+          1775,
+          1785,
+          1785
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.38461538461538464,
+          0.38461538461538464,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 103, component: QE_2017_001816_229.15469_52.0",
+          "cluster: 103, component: QE_2017_001816_229.15469_52.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0cdbed3f-6be3-4a2c-848f-1850dfebf2a2",
+         "x": [
           1765,
-          1765
+          1765,
+          1780,
+          1780
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.6388888888888888,
-          0.6388888888888888,
-          0
+          0.875,
+          0.875,
+          0.38461538461538464
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 104, component: QE_2017_001814_182.08116_51.0",
+          "cluster: 104, component: QE_2017_001814_182.08116_51.0",
+          "cluster: 104, component: QE_2017_001816_182.08116_55.0",
+          "cluster: 104, component: QE_2017_001816_182.08116_55.0"
+         ],
          "type": "scatter",
-         "x": [
-          1745,
-          1745,
-          1760,
-          1760
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.7096774193548387,
-          0.7096774193548387,
-          0.6388888888888888
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1735,
-          1735,
-          1752.5,
-          1752.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.7948717948717948,
-          0.7948717948717948,
-          0.7096774193548387
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1710,
-          1710,
-          1743.75,
-          1743.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.5483870967741935,
-          0.8571428571428571,
-          0.8571428571428571,
-          0.7948717948717948
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1670,
-          1670,
-          1726.875,
-          1726.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8125,
-          0.9767441860465116,
-          0.9767441860465116,
-          0.8571428571428571
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "c5ceb980-6ccc-4e08-a7be-12061e2fbef2",
          "x": [
           1795,
           1795,
@@ -4977,43 +6165,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.34146341463414637,
-          0.34146341463414637,
+          0.4375,
+          0.4375,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1785,
-          1785,
-          1800,
-          1800
+         "text": [
+          "cluster: 105, component: QE_2017_001815_194.04474_330.0",
+          "cluster: 105, component: QE_2017_001815_194.04474_330.0",
+          "cluster: 105, component: QE_2017_001816_212.05518_300.0",
+          "cluster: 105, component: QE_2017_001816_212.05518_300.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3829787234042553,
-          0.3829787234042553,
-          0.34146341463414637
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(40,35,35)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "23cc6fc7-c801-461d-9e9b-1bf6ab1e3cf1",
          "x": [
           1815,
           1815,
@@ -5023,66 +6194,113 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2903225806451613,
-          0.2903225806451613,
+          0.5370370370370371,
+          0.5370370370370371,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "500dc1ce-1b88-4862-b498-0ade3b4e4493",
          "x": [
-          1835,
-          1835,
+          1800,
+          1800,
+          1820,
+          1820
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4375,
+          0.921875,
+          0.921875,
+          0.5370370370370371
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 106, component: QE_2017_001814_177.05418_236.0",
+          "cluster: 106, component: QE_2017_001814_177.05418_236.0",
+          "cluster: 106, component: QE_2017_001815_177.05444_307.0",
+          "cluster: 106, component: QE_2017_001815_177.05444_307.0"
+         ],
+         "type": "scatter",
+         "uid": "45c3246d-3e56-49b0-8b5d-e750eb83ead9",
+         "x": [
           1845,
-          1845
+          1845,
+          1855,
+          1855
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.3142857142857143,
-          0.3142857142857143,
+          0.35,
+          0.35,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(40,35,35)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 106, component: QE_2017_001816_177.05449_217.0",
+          "cluster: 106, component: QE_2017_001816_177.05449_217.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "4ef7e37e-b13f-47e1-b891-48ff1b177d10",
          "x": [
-          1820,
-          1820,
-          1840,
-          1840
+          1835,
+          1835,
+          1850,
+          1850
          ],
          "xaxis": "x",
          "y": [
-          0.2903225806451613,
-          0.34375,
-          0.34375,
-          0.3142857142857143
+          0,
+          0.391304347826087,
+          0.391304347826087,
+          0.35
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 107, component: QE_2017_001816_199.98769_294.0",
+          "cluster: 107, component: QE_2017_001816_199.98769_294.0",
+          "cluster: 107, component: QE_2017_001816_199.98776_304.0",
+          "cluster: 107, component: QE_2017_001816_199.98776_304.0"
+         ],
          "type": "scatter",
+         "uid": "1e3a717b-d049-4e61-b70c-d455a4ad33d7",
          "x": [
           1865,
           1865,
@@ -5092,20 +6310,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.17647058823529413,
-          0.17647058823529413,
+          0.34146341463414637,
+          0.34146341463414637,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 107, component: QE_2017_001814_199.98778_290.0",
+          "cluster: 107, component: QE_2017_001814_199.98778_290.0",
+          "cluster: 107, component: QE_2017_001815_199.98779_30.0",
+          "cluster: 107, component: QE_2017_001815_199.98779_30.0"
+         ],
          "type": "scatter",
+         "uid": "633ef141-a5d5-450d-a6b2-f6be9e6bc68c",
          "x": [
           1885,
           1885,
@@ -5115,181 +6339,229 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2727272727272727,
-          0.2727272727272727,
+          0.3,
+          0.3,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1870,
-          1870,
-          1890,
-          1890
+         "text": [
+          "cluster: 107, component: QE_2017_001815_199.98772_326.0",
+          "cluster: 107, component: QE_2017_001815_199.98772_326.0",
+          "cluster: 107, component: QE_2017_001816_199.98781_313.0",
+          "cluster: 107, component: QE_2017_001816_199.98781_313.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.17647058823529413,
-          0.35294117647058826,
-          0.35294117647058826,
-          0.2727272727272727
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(40,35,35)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "e720be4e-855a-44c6-9a0d-a6baf2f79b74",
          "x": [
-          1855,
-          1855,
-          1880,
-          1880
+          1905,
+          1905,
+          1915,
+          1915
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.3783783783783784,
-          0.3783783783783784,
-          0.35294117647058826
+          0.18181818181818182,
+          0.18181818181818182,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 107, component: QE_2017_001816_199.98776_254.0",
+          "cluster: 107, component: QE_2017_001816_199.98776_254.0",
+          "cluster: 107, component: QE_2017_001816_199.98779_335.0",
+          "cluster: 107, component: QE_2017_001816_199.98779_335.0"
+         ],
          "type": "scatter",
+         "uid": "cf29a807-5c35-4ab8-9dc2-fffd52499878",
          "x": [
-          1830,
-          1830,
-          1867.5,
-          1867.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.34375,
-          0.4117647058823529,
-          0.4117647058823529,
-          0.3783783783783784
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1792.5,
-          1792.5,
-          1848.75,
-          1848.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3829787234042553,
-          0.8181818181818182,
-          0.8181818181818182,
-          0.4117647058823529
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1775,
-          1775,
-          1820.625,
-          1820.625
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.9482758620689655,
-          0.9482758620689655,
-          0.8181818181818182
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1925,
-          1925,
           1935,
-          1935
+          1935,
+          1945,
+          1945
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.6875,
-          0.6875,
+          0.25,
+          0.25,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(0,116,217)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 107, component: QE_2017_001816_199.98772_359.0",
+          "cluster: 107, component: QE_2017_001816_199.98772_359.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "61afc3c8-dd54-4216-b777-1ac1369e3096",
          "x": [
-          1915,
-          1915,
-          1930,
-          1930
+          1925,
+          1925,
+          1940,
+          1940
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.8974358974358975,
-          0.8974358974358975,
-          0.6875
+          0.3125,
+          0.3125,
+          0.25
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "fd1bc068-abba-43ea-bc8b-75687f1a7218",
+         "x": [
+          1910,
+          1910,
+          1932.5,
+          1932.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.18181818181818182,
+          0.36363636363636365,
+          0.36363636363636365,
+          0.3125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7486c6cb-4155-4773-9bbe-cdd58ffc5386",
+         "x": [
+          1890,
+          1890,
+          1921.25,
+          1921.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.3,
+          0.42424242424242425,
+          0.42424242424242425,
+          0.36363636363636365
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "74f259a2-d531-43ba-af9d-c70384ad0ac7",
+         "x": [
+          1870,
+          1870,
+          1905.625,
+          1905.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.34146341463414637,
+          0.47368421052631576,
+          0.47368421052631576,
+          0.42424242424242425
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "a7a1eb16-01fc-456d-b683-d9d4386dc633",
+         "x": [
+          1842.5,
+          1842.5,
+          1887.8125,
+          1887.8125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.391304347826087,
+          0.8214285714285714,
+          0.8214285714285714,
+          0.47368421052631576
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 108, component: QE_2017_001815_463.12268_358.0",
+          "cluster: 108, component: QE_2017_001815_463.12268_358.0",
+          "cluster: 109, component: QE_2017_001815_625.17633_345.0",
+          "cluster: 109, component: QE_2017_001815_625.17633_345.0"
+         ],
+         "type": "scatter",
+         "uid": "875b717a-5b42-4783-874d-c0a3d76c1160",
          "x": [
           1975,
           1975,
@@ -5299,20 +6571,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.9302325581395349,
-          0.9302325581395349,
+          0.6774193548387096,
+          0.6774193548387096,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 110, component: QE_2017_001815_595.16559_315.0",
+          "cluster: 110, component: QE_2017_001815_595.16559_315.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "419bfa96-9d48-4d63-ab8b-dcec35f41678",
          "x": [
           1965,
           1965,
@@ -5322,52 +6600,64 @@
          "xaxis": "x",
          "y": [
           0,
-          0.984375,
-          0.984375,
-          0.9302325581395349
+          0.8947368421052632,
+          0.8947368421052632,
+          0.6774193548387096
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 111, component: QE_2017_001815_141.0508_33.0",
+          "cluster: 111, component: QE_2017_001815_141.0508_33.0",
+          "cluster: 112, component: QE_2017_001815_265.01532_33.0",
+          "cluster: 112, component: QE_2017_001815_265.01532_33.0"
+         ],
          "type": "scatter",
+         "uid": "a8044a75-d770-4fdd-8c31-9708e992c4b2",
          "x": [
-          1955,
-          1955,
+          1995,
+          1995,
+          2005,
+          2005
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          1,
+          1,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "966504c9-4761-4558-a632-e4e0a34967d7",
+         "x": [
           1972.5,
-          1972.5
+          1972.5,
+          2000,
+          2000
          ],
          "xaxis": "x",
          "y": [
-          0,
-          1,
-          1,
-          0.984375
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1945,
-          1945,
-          1963.75,
-          1963.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
+          0.8947368421052632,
           1,
           1,
           1
@@ -5375,41 +6665,24 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1922.5,
-          1922.5,
-          1954.375,
-          1954.375
+         "text": [
+          "cluster: 113, component: QE_2017_001815_797.51746_866.0",
+          "cluster: 113, component: QE_2017_001815_797.51746_866.0",
+          null,
+          null
          ],
-         "xaxis": "x",
-         "y": [
-          0.8974358974358975,
-          1,
-          1,
-          1
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(0,116,217)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "0fc34731-3a8a-4742-a929-759b9b3bd0c7",
          "x": [
-          1905,
-          1905,
-          1938.4375,
-          1938.4375
+          1955,
+          1955,
+          1986.25,
+          1986.25
          ],
          "xaxis": "x",
          "y": [
@@ -5421,22 +6694,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9d1a245d-a9ca-4315-a26c-38e9f5fce075",
          "x": [
-          1797.8125,
-          1797.8125,
-          1921.71875,
-          1921.71875
+          1865.15625,
+          1865.15625,
+          1970.625,
+          1970.625
          ],
          "xaxis": "x",
          "y": [
-          0.9482758620689655,
+          0.8214285714285714,
           1,
           1,
           1
@@ -5444,22 +6723,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9ba3e172-fe80-4bf5-b5ec-819a2bb68f79",
          "x": [
-          1698.4375,
-          1698.4375,
-          1859.765625,
-          1859.765625
+          1810,
+          1810,
+          1917.890625,
+          1917.890625
          ],
          "xaxis": "x",
          "y": [
-          0.9767441860465116,
+          0.921875,
           1,
           1,
           1
@@ -5467,22 +6752,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "3a31c81f-d51c-4e6d-81bb-72a56eedf91a",
          "x": [
-          1632.5,
-          1632.5,
-          1779.1015625,
-          1779.1015625
+          1772.5,
+          1772.5,
+          1863.9453125,
+          1863.9453125
          ],
          "xaxis": "x",
          "y": [
-          0.8787878787878788,
+          0.875,
           1,
           1,
           1
@@ -5490,22 +6781,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "12861f75-bda5-4239-b32b-c771e84907aa",
          "x": [
-          1560.3125,
-          1560.3125,
-          1705.80078125,
-          1705.80078125
+          1740,
+          1740,
+          1818.22265625,
+          1818.22265625
          ],
          "xaxis": "x",
          "y": [
-          0.9795918367346939,
+          0.9761904761904762,
           1,
           1,
           1
@@ -5513,22 +6810,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "513ef3a1-9914-41da-8ab0-ae6ac129cde7",
          "x": [
-          1473.4375,
-          1473.4375,
-          1633.056640625,
-          1633.056640625
+          1647.65625,
+          1647.65625,
+          1779.111328125,
+          1779.111328125
          ],
          "xaxis": "x",
          "y": [
-          0.9540229885057471,
+          0.9846153846153847,
           1,
           1,
           1
@@ -5536,18 +6839,53 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f9e31886-0c43-4bed-a856-0d4a8b956f6d",
          "x": [
-          1377.8125,
-          1377.8125,
-          1553.2470703125,
-          1553.2470703125
+          1563.4375,
+          1563.4375,
+          1713.3837890625,
+          1713.3837890625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9534883720930233,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a5952ae5-defa-4a8f-861c-0d8cc0df2c44",
+         "x": [
+          1467.8125,
+          1467.8125,
+          1638.41064453125,
+          1638.41064453125
          ],
          "xaxis": "x",
          "y": [
@@ -5559,22 +6897,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e51126a8-a429-4443-896b-b69b91ae67b6",
          "x": [
-          1320,
-          1320,
-          1465.52978515625,
-          1465.52978515625
+          1410,
+          1410,
+          1553.111572265625,
+          1553.111572265625
          ],
          "xaxis": "x",
          "y": [
-          0.4444444444444444,
+          0.75,
           1,
           1,
           1
@@ -5582,22 +6926,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "a245ce22-fa1d-4c2e-8240-6e060837534a",
          "x": [
-          1231.25,
-          1231.25,
-          1392.764892578125,
-          1392.764892578125
+          1336.71875,
+          1336.71875,
+          1481.5557861328125,
+          1481.5557861328125
          ],
          "xaxis": "x",
          "y": [
-          0.9821428571428571,
+          0.9772727272727273,
           1,
           1,
           1
@@ -5605,22 +6955,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "82c54120-6c9c-4d05-86db-1c597c2b2717",
          "x": [
-          1180,
-          1180,
-          1312.0074462890625,
-          1312.0074462890625
+          1270,
+          1270,
+          1409.1372680664062,
+          1409.1372680664062
          ],
          "xaxis": "x",
          "y": [
-          0.8571428571428571,
+          0.8461538461538461,
           1,
           1,
           1
@@ -5628,22 +6984,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "0a3a8aec-8acc-48bc-a825-92f8d1cc181c",
          "x": [
-          1049.609375,
-          1049.609375,
-          1246.0037231445312,
-          1246.0037231445312
+          1020.869140625,
+          1020.869140625,
+          1339.5686340332031,
+          1339.5686340332031
          ],
          "xaxis": "x",
          "y": [
-          0.9883720930232558,
+          0.9882352941176471,
           1,
           1,
           1
@@ -5651,22 +7013,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "795aa515-b019-4287-ad73-e1da31b0856d",
          "x": [
-          703.59375,
-          703.59375,
-          1147.8065490722656,
-          1147.8065490722656
+          734.912109375,
+          734.912109375,
+          1180.2188873291016,
+          1180.2188873291016
          ],
          "xaxis": "x",
          "y": [
-          0.9818181818181818,
+          0.9696969696969697,
           1,
           1,
           1
@@ -5674,22 +7042,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "82cbd365-5549-40c0-82c6-b0cd1c3f3a84",
          "x": [
-          645,
-          645,
-          925.7001495361328,
-          925.7001495361328
+          619.6875,
+          619.6875,
+          957.5654983520508,
+          957.5654983520508
          ],
          "xaxis": "x",
          "y": [
-          0.8817204301075269,
+          0.9814814814814815,
           1,
           1,
           1
@@ -5697,22 +7071,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "87aae4c7-e27c-4128-a0dd-1d89c19c8281",
          "x": [
-          503.984375,
-          503.984375,
-          785.3500747680664,
-          785.3500747680664
+          521.875,
+          521.875,
+          788.6264991760254,
+          788.6264991760254
          ],
          "xaxis": "x",
          "y": [
-          0.9705882352941176,
+          0.9857142857142858,
           1,
           1,
           1
@@ -5720,22 +7100,28 @@
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "08b7ae77-18e6-40ee-8eef-110d9b1f2d6d",
          "x": [
-          218.72802734375,
-          218.72802734375,
-          644.6672248840332,
-          644.6672248840332
+          221.85302734375,
+          221.85302734375,
+          655.2507495880127,
+          655.2507495880127
          ],
          "xaxis": "x",
          "y": [
-          0.9705882352941176,
+          0.9625,
           1,
           1,
           1
@@ -5745,11 +7131,16 @@
        ],
        "layout": {
         "autosize": false,
-        "height": 500,
+        "height": 700,
         "hovermode": "closest",
+        "margin": {
+         "b": 372
+        },
         "showlegend": false,
-        "title": "BioDendro",
-        "width": 900,
+        "title": {
+         "text": "Component clusters. method = jaccard, cutoff = 0.6, threshold = 0.0008"
+        },
+        "width": 800,
         "xaxis": {
          "mirror": "allticks",
          "rangemode": "tozero",
@@ -5759,15 +7150,15 @@
          "tickmode": "array",
          "ticks": "outside",
          "ticktext": [
-          "QE_2017_001815_792.5625_866.0",
-          "QE_2017_001814_596.30963_602.0",
+          "QE_2017_001816_613.4826_738.0",
           "QE_2017_001816_613.48218_838.0",
-          "QE_2017_001814_792.56207_723.0",
-          "QE_2017_001815_613.4826_734.0",
+          "QE_2017_001816_792.56232_718.0",
+          "QE_2017_001814_596.30963_602.0",
+          "QE_2017_001815_792.5625_866.0",
           "QE_2017_001815_571.4292_870.0",
           "QE_2017_001814_497.31033_643.0",
           "QE_2017_001815_507.27145_607.0",
-          "QE_2017_001815_571.47168_711.0",
+          "QE_2017_001816_571.47186_717.0",
           "QE_2017_001814_335.25772_725.0",
           "QE_2017_001814_335.25784_608.0",
           "QE_2017_001816_335.25772_723.0",
@@ -5783,16 +7174,16 @@
           "QE_2017_001816_272.25824_582.0",
           "QE_2017_001814_338.34146_850.0",
           "QE_2017_001815_244.19048_762.0",
+          "QE_2017_001814_353.26868_633.0",
+          "QE_2017_001816_353.26892_600.0",
+          "QE_2017_001814_279.23157_719.0",
+          "QE_2017_001815_278.24762_684.0",
           "QE_2017_001816_435.25037_666.0",
           "QE_2017_001816_337.27338_826.0",
           "QE_2017_001816_337.27341_632.0",
-          "QE_2017_001814_353.26868_633.0",
-          "QE_2017_001816_353.26892_600.0",
-          "QE_2017_001814_278.24756_683.0",
-          "QE_2017_001814_279.23157_719.0",
           "QE_2017_001814_618.42633_695.0",
           "QE_2017_001816_583.41382_731.0",
-          "QE_2017_001814_599.40918_659.0",
+          "QE_2017_001816_599.40948_660.0",
           "QE_2017_001814_601.42426_706.0",
           "QE_2017_001816_599.40869_793.0",
           "QE_2017_001815_618.42773_646.0",
@@ -5804,22 +7195,14 @@
           "QE_2017_001814_601.42334_783.0",
           "QE_2017_001815_583.41388_735.0",
           "QE_2017_001815_583.41418_647.0",
-          "QE_2017_001816_463.12311_410.0",
-          "QE_2017_001814_339.10742_366.0",
-          "QE_2017_001816_339.10733_298.0",
-          "QE_2017_001814_231.04967_404.0",
-          "QE_2017_001815_231.04968_315.0",
-          "QE_2017_001814_231.04971_516.0",
-          "QE_2017_001815_231.04971_369.0",
-          "QE_2017_001814_498.2543_475.0",
-          "QE_2017_001815_340.16019_314.0",
-          "QE_2017_001815_314.14453_76.0",
-          "QE_2017_001816_314.14462_79.0",
-          "QE_2017_001816_310.14957_134.0",
-          "QE_2017_001816_342.17584_257.0",
-          "QE_2017_001815_507.18192_178.0",
-          "QE_2017_001814_611.15997_285.0",
-          "QE_2017_001816_611.16064_309.0",
+          "QE_2017_001814_194.04424_237.0",
+          "QE_2017_001815_194.11751_218.0",
+          "QE_2017_001815_194.04469_299.0",
+          "QE_2017_001815_194.04471_314.0",
+          "QE_2017_001815_212.05513_328.0",
+          "QE_2017_001815_212.05505_267.0",
+          "QE_2017_001814_226.07077_397.0",
+          "QE_2017_001815_194.04471_397.0",
           "QE_2017_001816_533.15442_247.0",
           "QE_2017_001816_533.15466_222.0",
           "QE_2017_001815_533.1546_207.0",
@@ -5829,32 +7212,47 @@
           "QE_2017_001815_268.10373_58.0",
           "QE_2017_001816_269.16055_60.0",
           "QE_2017_001815_364.34189_705.0",
-          "QE_2017_001814_408.3681_703.0",
+          "QE_2017_001816_408.36832_704.0",
           "QE_2017_001816_466.40979_731.0",
-          "QE_2017_001814_364.34241_751.0",
-          "QE_2017_001814_424.36325_711.0",
-          "QE_2017_001814_364.34244_761.0",
-          "QE_2017_001814_421.35211_732.0",
           "QE_2017_001815_408.36853_717.0",
           "QE_2017_001815_482.40488_739.0",
+          "QE_2017_001814_364.34244_761.0",
+          "QE_2017_001815_364.34253_752.0",
+          "QE_2017_001816_421.35226_731.0",
+          "QE_2017_001816_424.36325_712.0",
+          "QE_2017_001816_463.12311_410.0",
+          "QE_2017_001814_611.15997_285.0",
+          "QE_2017_001815_611.16046_309.0",
+          "QE_2017_001814_339.10742_366.0",
+          "QE_2017_001816_339.10733_298.0",
+          "QE_2017_001814_498.2543_475.0",
+          "QE_2017_001815_340.16019_314.0",
+          "QE_2017_001815_231.04973_403.0",
+          "QE_2017_001815_231.04968_315.0",
+          "QE_2017_001814_231.04971_516.0",
+          "QE_2017_001815_231.04971_369.0",
+          "QE_2017_001815_314.14453_76.0",
+          "QE_2017_001816_314.14462_79.0",
+          "QE_2017_001816_310.14957_134.0",
+          "QE_2017_001816_342.17584_257.0",
+          "QE_2017_001814_241.15466_73.0",
+          "QE_2017_001815_507.18192_178.0",
+          "QE_2017_001814_483.27118_651.0",
+          "QE_2017_001816_338.26062_643.0",
+          "QE_2017_001814_320.29456_577.0",
+          "QE_2017_001815_320.29471_563.0",
+          "QE_2017_001815_129.12741_349.0",
+          "QE_2017_001815_171.14914_420.0",
           "QE_2017_001815_201.16367_442.0",
           "QE_2017_001816_201.16362_435.0",
-          "QE_2017_001814_191.14291_389.0",
-          "QE_2017_001815_191.14287_312.0",
-          "QE_2017_001816_191.14291_404.0",
-          "QE_2017_001814_219.17416_517.0",
-          "QE_2017_001815_219.17426_497.0",
-          "QE_2017_001814_219.17401_452.0",
-          "QE_2017_001814_219.17409_442.0",
-          "QE_2017_001816_137.09584_445.0",
-          "QE_2017_001814_209.15335_478.0",
+          "QE_2017_001815_209.15352_479.0",
+          "QE_2017_001815_209.15349_295.0",
           "QE_2017_001815_209.1535_312.0",
           "QE_2017_001816_209.15344_311.0",
-          "QE_2017_001815_227.16408_344.0",
-          "QE_2017_001816_209.15341_296.0",
           "QE_2017_001814_243.15892_533.0",
           "QE_2017_001814_281.1745_492.0",
           "QE_2017_001814_293.2106_579.0",
+          "QE_2017_001815_227.16408_344.0",
           "QE_2017_001815_283.19009_564.0",
           "QE_2017_001815_207.13785_297.0",
           "QE_2017_001814_227.1275_293.0",
@@ -5865,99 +7263,94 @@
           "QE_2017_001815_209.0807_405.0",
           "QE_2017_001814_211.16902_440.0",
           "QE_2017_001815_211.16913_450.0",
-          "QE_2017_001814_215.16406_483.0",
           "QE_2017_001815_215.164_550.0",
+          "QE_2017_001816_215.16411_482.0",
+          "QE_2017_001816_137.09584_445.0",
+          "QE_2017_001814_219.17416_517.0",
+          "QE_2017_001815_219.17421_516.0",
+          "QE_2017_001816_219.17438_502.0",
+          "QE_2017_001814_219.17401_452.0",
+          "QE_2017_001814_219.17409_442.0",
+          "QE_2017_001814_191.14291_389.0",
+          "QE_2017_001815_191.14287_312.0",
+          "QE_2017_001816_191.14291_404.0",
           "QE_2017_001814_209.08058_363.0",
           "QE_2017_001816_207.13779_561.0",
-          "QE_2017_001816_320.29483_548.0",
-          "QE_2017_001814_129.12737_348.0",
-          "QE_2017_001814_171.14908_419.0",
-          "QE_2017_001814_483.27118_651.0",
-          "QE_2017_001816_338.26062_643.0",
-          "QE_2017_001814_320.29456_577.0",
-          "QE_2017_001815_320.29471_563.0",
           "QE_2017_001815_333.15173_245.0",
           "QE_2017_001816_333.15204_235.0",
+          "QE_2017_001814_194.1174_244.0",
+          "QE_2017_001816_194.11746_133.0",
+          "QE_2017_001816_320.29483_548.0",
+          "QE_2017_001814_320.29468_638.0",
+          "QE_2017_001814_320.29477_539.0",
+          "QE_2017_001814_320.29471_529.0",
+          "QE_2017_001815_320.29486_538.0",
+          "QE_2017_001814_241.15384_47.0",
+          "QE_2017_001814_241.15446_57.0",
           "QE_2017_001814_332.25827_467.0",
           "QE_2017_001815_332.25827_508.0",
-          "QE_2017_001814_332.25842_486.0",
           "QE_2017_001816_332.25842_487.0",
-          "QE_2017_001815_221.12837_99.0",
-          "QE_2017_001816_237.12325_171.0",
-          "QE_2017_001814_241.15446_57.0",
-          "QE_2017_001814_241.15384_47.0",
-          "QE_2017_001815_241.15437_67.0",
-          "QE_2017_001814_320.29468_638.0",
-          "QE_2017_001814_320.29471_529.0",
-          "QE_2017_001814_320.29477_539.0",
-          "QE_2017_001815_319.13623_118.0",
+          "QE_2017_001814_319.13638_117.0",
           "QE_2017_001816_319.13614_143.0",
           "QE_2017_001814_251.09117_393.0",
-          "QE_2017_001815_219.10139_360.0",
-          "QE_2017_001815_219.10146_381.0",
           "QE_2017_001815_219.10159_438.0",
+          "QE_2017_001815_219.10139_360.0",
+          "QE_2017_001816_219.10153_382.0",
+          "QE_2017_001814_291.1442_241.0",
+          "QE_2017_001816_291.14493_243.0",
+          "QE_2017_001816_291.14499_200.0",
           "QE_2017_001815_273.13425_199.0",
           "QE_2017_001815_273.13434_243.0",
-          "QE_2017_001816_291.14499_200.0",
-          "QE_2017_001814_291.1442_241.0",
-          "QE_2017_001815_291.14493_242.0",
-          "QE_2017_001814_251.13872_201.0",
-          "QE_2017_001815_235.14388_180.0",
+          "QE_2017_001815_251.13873_202.0",
           "QE_2017_001815_235.14398_226.0",
+          "QE_2017_001816_235.14397_183.0",
           "QE_2017_001815_214.51021_60.0",
           "QE_2017_001816_268.59351_445.0",
-          "QE_2017_001814_222.07031_314.0",
           "QE_2017_001814_250.10149_516.0",
+          "QE_2017_001815_222.07033_315.0",
           "QE_2017_001814_247.05975_245.0",
           "QE_2017_001815_247.0598_242.0",
           "QE_2017_001816_219.04672_291.0",
           "QE_2017_001815_212.03883_181.0",
           "QE_2017_001815_214.56488_409.0",
+          "QE_2017_001815_260.16016_64.0",
           "QE_2017_001816_132.04436_283.0",
           "QE_2017_001815_246.14465_137.0",
-          "QE_2017_001816_247.12863_162.0",
-          "QE_2017_001815_260.16016_140.0",
+          "QE_2017_001815_247.12865_158.0",
+          "QE_2017_001814_260.16037_143.0",
           "QE_2017_001816_260.16022_145.0",
-          "QE_2017_001815_233.14944_150.0",
+          "QE_2017_001814_233.14957_152.0",
           "QE_2017_001814_233.14948_126.0",
           "QE_2017_001816_233.14955_129.0",
+          "QE_2017_001815_221.12837_99.0",
+          "QE_2017_001816_237.12325_171.0",
+          "QE_2017_001814_237.12305_220.0",
+          "QE_2017_001816_237.12323_53.0",
           "QE_2017_001816_229.15469_52.0",
           "QE_2017_001814_229.15399_46.0",
-          "QE_2017_001814_229.15451_65.0",
-          "QE_2017_001814_194.04424_237.0",
-          "QE_2017_001814_194.1174_217.0",
-          "QE_2017_001814_194.1174_244.0",
-          "QE_2017_001815_194.11745_132.0",
-          "QE_2017_001815_194.04469_299.0",
-          "QE_2017_001815_194.04474_327.0",
-          "QE_2017_001815_194.04471_314.0",
-          "QE_2017_001815_212.05513_328.0",
+          "QE_2017_001816_229.15451_66.0",
+          "QE_2017_001814_182.08116_51.0",
+          "QE_2017_001816_182.08116_55.0",
+          "QE_2017_001815_194.04474_330.0",
           "QE_2017_001816_212.05518_300.0",
-          "QE_2017_001815_212.05505_267.0",
-          "QE_2017_001814_226.07077_397.0",
-          "QE_2017_001815_194.04471_397.0",
-          "QE_2017_001815_182.08109_52.0",
           "QE_2017_001816_177.05449_217.0",
           "QE_2017_001814_177.05418_236.0",
           "QE_2017_001815_177.05444_307.0",
+          "QE_2017_001816_199.98769_294.0",
+          "QE_2017_001816_199.98776_304.0",
           "QE_2017_001814_199.98778_290.0",
           "QE_2017_001815_199.98779_30.0",
-          "QE_2017_001814_199.98772_303.0",
-          "QE_2017_001815_199.98772_253.0",
-          "QE_2017_001816_199.98769_294.0",
           "QE_2017_001815_199.98772_326.0",
           "QE_2017_001816_199.98781_313.0",
           "QE_2017_001816_199.98772_359.0",
+          "QE_2017_001816_199.98776_254.0",
           "QE_2017_001816_199.98779_335.0",
           "QE_2017_001815_797.51746_866.0",
           "QE_2017_001815_595.16559_315.0",
           "QE_2017_001815_463.12268_358.0",
           "QE_2017_001815_625.17633_345.0",
-          "QE_2017_001815_265.01532_33.0",
           "QE_2017_001815_141.0508_33.0",
-          "QE_2017_001815_260.16016_64.0",
-          "QE_2017_001814_237.12305_220.0",
-          "QE_2017_001815_237.12315_52.0"
+          "QE_2017_001815_265.01532_33.0"
          ],
          "tickvals": [
           5,
@@ -6158,9 +7551,13 @@
           1955,
           1965,
           1975,
-          1985
+          1985,
+          1995,
+          2005
          ],
-         "title": "sample",
+         "title": {
+          "text": "Components"
+         },
          "type": "linear",
          "zeroline": false
         },
@@ -6171,17 +7568,35 @@
          "showline": true,
          "showticklabels": true,
          "ticks": "outside",
-         "title": "distance",
+         "title": {
+          "text": "Distance"
+         },
          "type": "linear",
          "zeroline": false
         }
        }
       },
       "text/html": [
-       "<div id=\"c319c635-3010-4df9-9b91-45fcfdb2c5f3\" style=\"height: 500px; width: 900px;\" class=\"plotly-graph-div\"></div><script type=\"text/javascript\">require([\"plotly\"], function(Plotly) { window.PLOTLYENV=window.PLOTLYENV || {};window.PLOTLYENV.BASE_URL=\"https://plot.ly\";Plotly.newPlot(\"c319c635-3010-4df9-9b91-45fcfdb2c5f3\", [{\"type\": \"scatter\", \"x\": [35.0, 35.0, 45.0, 45.0], \"y\": [0.0, 0.5774647887323944, 0.5774647887323944, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [25.0, 25.0, 40.0, 40.0], \"y\": [0.0, 0.6142857142857143, 0.6142857142857143, 0.5774647887323944], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [15.0, 15.0, 32.5, 32.5], \"y\": [0.0, 0.7049180327868853, 0.7049180327868853, 0.6142857142857143], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [5.0, 5.0, 23.75, 23.75], \"y\": [0.0, 0.7613636363636364, 0.7613636363636364, 0.7049180327868853], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [105.0, 105.0, 115.0, 115.0], \"y\": [0.0, 0.2549019607843137, 0.2549019607843137, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [95.0, 95.0, 110.0, 110.0], \"y\": [0.0, 0.2777777777777778, 0.2777777777777778, 0.2549019607843137], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [125.0, 125.0, 135.0, 135.0], \"y\": [0.0, 0.28125, 0.28125, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [102.5, 102.5, 130.0, 130.0], \"y\": [0.2777777777777778, 0.3333333333333333, 0.3333333333333333, 0.28125], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [145.0, 145.0, 155.0, 155.0], \"y\": [0.0, 0.36923076923076925, 0.36923076923076925, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [116.25, 116.25, 150.0, 150.0], \"y\": [0.3333333333333333, 0.4057971014492754, 0.4057971014492754, 0.36923076923076925], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [165.0, 165.0, 175.0, 175.0], \"y\": [0.0, 0.2698412698412698, 0.2698412698412698, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [195.0, 195.0, 205.0, 205.0], \"y\": [0.0, 0.28846153846153844, 0.28846153846153844, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [185.0, 185.0, 200.0, 200.0], \"y\": [0.0, 0.37735849056603776, 0.37735849056603776, 0.28846153846153844], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [170.0, 170.0, 192.5, 192.5], \"y\": [0.2698412698412698, 0.4262295081967213, 0.4262295081967213, 0.37735849056603776], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [133.125, 133.125, 181.25, 181.25], \"y\": [0.4057971014492754, 0.45454545454545453, 0.45454545454545453, 0.4262295081967213], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [85.0, 85.0, 157.1875, 157.1875], \"y\": [0.0, 0.4925373134328358, 0.4925373134328358, 0.45454545454545453], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [75.0, 75.0, 121.09375, 121.09375], \"y\": [0.0, 0.5652173913043478, 0.5652173913043478, 0.4925373134328358], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [65.0, 65.0, 98.046875, 98.046875], \"y\": [0.0, 0.6904761904761905, 0.6904761904761905, 0.5652173913043478], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [55.0, 55.0, 81.5234375, 81.5234375], \"y\": [0.0, 0.7981651376146789, 0.7981651376146789, 0.6904761904761905], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [225.0, 225.0, 235.0, 235.0], \"y\": [0.0, 0.609375, 0.609375, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [255.0, 255.0, 265.0, 265.0], \"y\": [0.0, 0.36764705882352944, 0.36764705882352944, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [245.0, 245.0, 260.0, 260.0], \"y\": [0.0, 0.5342465753424658, 0.5342465753424658, 0.36764705882352944], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [275.0, 275.0, 285.0, 285.0], \"y\": [0.0, 0.23529411764705882, 0.23529411764705882, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [295.0, 295.0, 305.0, 305.0], \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [280.0, 280.0, 300.0, 300.0], \"y\": [0.23529411764705882, 0.5585585585585585, 0.5585585585585585, 0.4444444444444444], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [252.5, 252.5, 290.0, 290.0], \"y\": [0.5342465753424658, 0.6902654867256637, 0.6902654867256637, 0.5585585585585585], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [230.0, 230.0, 271.25, 271.25], \"y\": [0.609375, 0.7619047619047619, 0.7619047619047619, 0.6902654867256637], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [215.0, 215.0, 250.625, 250.625], \"y\": [0.0, 0.8266666666666667, 0.8266666666666667, 0.7619047619047619], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [68.26171875, 68.26171875, 232.8125, 232.8125], \"y\": [0.7981651376146789, 0.8712871287128713, 0.8712871287128713, 0.8266666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [14.375, 14.375, 150.537109375, 150.537109375], \"y\": [0.7613636363636364, 0.9014084507042254, 0.9014084507042254, 0.8712871287128713], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [345.0, 345.0, 355.0, 355.0], \"y\": [0.0, 0.6336633663366337, 0.6336633663366337, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [335.0, 335.0, 350.0, 350.0], \"y\": [0.0, 0.6629213483146067, 0.6629213483146067, 0.6336633663366337], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [325.0, 325.0, 342.5, 342.5], \"y\": [0.0, 0.7604166666666666, 0.7604166666666666, 0.6629213483146067], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [315.0, 315.0, 333.75, 333.75], \"y\": [0.0, 0.8023255813953488, 0.8023255813953488, 0.7604166666666666], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [365.0, 365.0, 375.0, 375.0], \"y\": [0.0, 0.4713114754098361, 0.4713114754098361, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [405.0, 405.0, 415.0, 415.0], \"y\": [0.0, 0.5222222222222223, 0.5222222222222223, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [395.0, 395.0, 410.0, 410.0], \"y\": [0.0, 0.6097560975609756, 0.6097560975609756, 0.5222222222222223], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [435.0, 435.0, 445.0, 445.0], \"y\": [0.0, 0.524822695035461, 0.524822695035461, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [425.0, 425.0, 440.0, 440.0], \"y\": [0.0, 0.6983240223463687, 0.6983240223463687, 0.524822695035461], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [402.5, 402.5, 432.5, 432.5], \"y\": [0.6097560975609756, 0.7364341085271318, 0.7364341085271318, 0.6983240223463687], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [385.0, 385.0, 417.5, 417.5], \"y\": [0.0, 0.7661290322580645, 0.7661290322580645, 0.7364341085271318], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [370.0, 370.0, 401.25, 401.25], \"y\": [0.4713114754098361, 0.8212765957446808, 0.8212765957446808, 0.7661290322580645], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [324.375, 324.375, 385.625, 385.625], \"y\": [0.8023255813953488, 0.9403973509933775, 0.9403973509933775, 0.8212765957446808], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [82.4560546875, 82.4560546875, 355.0, 355.0], \"y\": [0.9014084507042254, 0.9705882352941176, 0.9705882352941176, 0.9403973509933775], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [465.0, 465.0, 475.0, 475.0], \"y\": [0.0, 0.4230769230769231, 0.4230769230769231, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [505.0, 505.0, 515.0, 515.0], \"y\": [0.0, 0.375, 0.375, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [495.0, 495.0, 510.0, 510.0], \"y\": [0.0, 0.391304347826087, 0.391304347826087, 0.375], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [485.0, 485.0, 502.5, 502.5], \"y\": [0.0, 0.5, 0.5, 0.391304347826087], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [470.0, 470.0, 493.75, 493.75], \"y\": [0.4230769230769231, 0.7878787878787878, 0.7878787878787878, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [525.0, 525.0, 535.0, 535.0], \"y\": [0.0, 0.6981132075471698, 0.6981132075471698, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [545.0, 545.0, 555.0, 555.0], \"y\": [0.0, 0.4074074074074074, 0.4074074074074074, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [565.0, 565.0, 575.0, 575.0], \"y\": [0.0, 0.6896551724137931, 0.6896551724137931, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [550.0, 550.0, 570.0, 570.0], \"y\": [0.4074074074074074, 0.7567567567567568, 0.7567567567567568, 0.6896551724137931], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [530.0, 530.0, 560.0, 560.0], \"y\": [0.6981132075471698, 0.8604651162790697, 0.8604651162790697, 0.7567567567567568], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [481.875, 481.875, 545.0, 545.0], \"y\": [0.7878787878787878, 0.88, 0.88, 0.8604651162790697], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [595.0, 595.0, 605.0, 605.0], \"y\": [0.0, 0.36363636363636365, 0.36363636363636365, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [585.0, 585.0, 600.0, 600.0], \"y\": [0.0, 0.926829268292683, 0.926829268292683, 0.36363636363636365], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [513.4375, 513.4375, 592.5, 592.5], \"y\": [0.88, 0.9473684210526315, 0.9473684210526315, 0.926829268292683], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [455.0, 455.0, 552.96875, 552.96875], \"y\": [0.0, 0.9705882352941176, 0.9705882352941176, 0.9473684210526315], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [615.0, 615.0, 625.0, 625.0], \"y\": [0.0, 0.36231884057971014, 0.36231884057971014, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [635.0, 635.0, 645.0, 645.0], \"y\": [0.0, 0.44776119402985076, 0.44776119402985076, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [620.0, 620.0, 640.0, 640.0], \"y\": [0.36231884057971014, 0.4931506849315068, 0.4931506849315068, 0.44776119402985076], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [655.0, 655.0, 665.0, 665.0], \"y\": [0.0, 0.5, 0.5, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [630.0, 630.0, 660.0, 660.0], \"y\": [0.4931506849315068, 0.8817204301075269, 0.8817204301075269, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [675.0, 675.0, 685.0, 685.0], \"y\": [0.0, 0.4117647058823529, 0.4117647058823529, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [705.0, 705.0, 715.0, 715.0], \"y\": [0.0, 0.42857142857142855, 0.42857142857142855, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [695.0, 695.0, 710.0, 710.0], \"y\": [0.0, 0.7058823529411765, 0.7058823529411765, 0.42857142857142855], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [745.0, 745.0, 755.0, 755.0], \"y\": [0.0, 0.35714285714285715, 0.35714285714285715, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [735.0, 735.0, 750.0, 750.0], \"y\": [0.0, 0.47058823529411764, 0.47058823529411764, 0.35714285714285715], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [725.0, 725.0, 742.5, 742.5], \"y\": [0.0, 0.631578947368421, 0.631578947368421, 0.47058823529411764], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [765.0, 765.0, 775.0, 775.0], \"y\": [0.0, 0.725, 0.725, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [733.75, 733.75, 770.0, 770.0], \"y\": [0.631578947368421, 0.7407407407407407, 0.7407407407407407, 0.725], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [702.5, 702.5, 751.875, 751.875], \"y\": [0.7058823529411765, 0.85, 0.85, 0.7407407407407407], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [680.0, 680.0, 727.1875, 727.1875], \"y\": [0.4117647058823529, 0.9818181818181818, 0.9818181818181818, 0.85], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [785.0, 785.0, 795.0, 795.0], \"y\": [0.0, 0.47540983606557374, 0.47540983606557374, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [815.0, 815.0, 825.0, 825.0], \"y\": [0.0, 0.423728813559322, 0.423728813559322, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [805.0, 805.0, 820.0, 820.0], \"y\": [0.0, 0.49019607843137253, 0.49019607843137253, 0.423728813559322], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [855.0, 855.0, 865.0, 865.0], \"y\": [0.0, 0.30612244897959184, 0.30612244897959184, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [845.0, 845.0, 860.0, 860.0], \"y\": [0.0, 0.3728813559322034, 0.3728813559322034, 0.30612244897959184], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [835.0, 835.0, 852.5, 852.5], \"y\": [0.0, 0.5, 0.5, 0.3728813559322034], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [812.5, 812.5, 843.75, 843.75], \"y\": [0.49019607843137253, 0.6862745098039216, 0.6862745098039216, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [790.0, 790.0, 828.125, 828.125], \"y\": [0.47540983606557374, 0.7857142857142857, 0.7857142857142857, 0.6862745098039216], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [895.0, 895.0, 905.0, 905.0], \"y\": [0.0, 0.2876712328767123, 0.2876712328767123, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [885.0, 885.0, 900.0, 900.0], \"y\": [0.0, 0.39473684210526316, 0.39473684210526316, 0.2876712328767123], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [915.0, 915.0, 925.0, 925.0], \"y\": [0.0, 0.45569620253164556, 0.45569620253164556, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [892.5, 892.5, 920.0, 920.0], \"y\": [0.39473684210526316, 0.5119047619047619, 0.5119047619047619, 0.45569620253164556], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [935.0, 935.0, 945.0, 945.0], \"y\": [0.0, 0.35384615384615387, 0.35384615384615387, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [955.0, 955.0, 965.0, 965.0], \"y\": [0.0, 0.54, 0.54, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [940.0, 940.0, 960.0, 960.0], \"y\": [0.35384615384615387, 0.5934065934065934, 0.5934065934065934, 0.54], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [906.25, 906.25, 950.0, 950.0], \"y\": [0.5119047619047619, 0.6530612244897959, 0.6530612244897959, 0.5934065934065934], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [985.0, 985.0, 995.0, 995.0], \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [975.0, 975.0, 990.0, 990.0], \"y\": [0.0, 0.6753246753246753, 0.6753246753246753, 0.3333333333333333], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [928.125, 928.125, 982.5, 982.5], \"y\": [0.6530612244897959, 0.7093023255813954, 0.7093023255813954, 0.6753246753246753], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1005.0, 1005.0, 1015.0, 1015.0], \"y\": [0.0, 0.2777777777777778, 0.2777777777777778, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1045.0, 1045.0, 1055.0, 1055.0], \"y\": [0.0, 0.18867924528301888, 0.18867924528301888, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1035.0, 1035.0, 1050.0, 1050.0], \"y\": [0.0, 0.20754716981132076, 0.20754716981132076, 0.18867924528301888], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1025.0, 1025.0, 1042.5, 1042.5], \"y\": [0.0, 0.29508196721311475, 0.29508196721311475, 0.20754716981132076], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1065.0, 1065.0, 1075.0, 1075.0], \"y\": [0.0, 0.54, 0.54, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1033.75, 1033.75, 1070.0, 1070.0], \"y\": [0.29508196721311475, 0.5714285714285714, 0.5714285714285714, 0.54], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1010.0, 1010.0, 1051.875, 1051.875], \"y\": [0.2777777777777778, 0.75, 0.75, 0.5714285714285714], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [955.3125, 955.3125, 1030.9375, 1030.9375], \"y\": [0.7093023255813954, 0.7662337662337663, 0.7662337662337663, 0.75], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [875.0, 875.0, 993.125, 993.125], \"y\": [0.0, 0.8192771084337349, 0.8192771084337349, 0.7662337662337663], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [809.0625, 809.0625, 934.0625, 934.0625], \"y\": [0.7857142857142857, 0.8448275862068966, 0.8448275862068966, 0.8192771084337349], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1085.0, 1085.0, 1095.0, 1095.0], \"y\": [0.0, 0.8571428571428571, 0.8571428571428571, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [871.5625, 871.5625, 1090.0, 1090.0], \"y\": [0.8448275862068966, 0.9146341463414634, 0.9146341463414634, 0.8571428571428571], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"y\": [0.0, 0.8333333333333334, 0.8333333333333334, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1155.0, 1155.0, 1165.0, 1165.0], \"y\": [0.0, 0.34615384615384615, 0.34615384615384615, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1145.0, 1145.0, 1160.0, 1160.0], \"y\": [0.0, 0.6296296296296297, 0.6296296296296297, 0.34615384615384615], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1135.0, 1135.0, 1152.5, 1152.5], \"y\": [0.0, 0.8666666666666667, 0.8666666666666667, 0.6296296296296297], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1120.0, 1120.0, 1143.75, 1143.75], \"y\": [0.8333333333333334, 0.9111111111111111, 0.9111111111111111, 0.8666666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1105.0, 1105.0, 1131.875, 1131.875], \"y\": [0.0, 0.9298245614035088, 0.9298245614035088, 0.9111111111111111], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [980.78125, 980.78125, 1118.4375, 1118.4375], \"y\": [0.9146341463414634, 0.9883720930232558, 0.9883720930232558, 0.9298245614035088], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1175.0, 1175.0, 1185.0, 1185.0], \"y\": [0.0, 0.8571428571428571, 0.8571428571428571, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1215.0, 1215.0, 1225.0, 1225.0], \"y\": [0.0, 0.38461538461538464, 0.38461538461538464, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1205.0, 1205.0, 1220.0, 1220.0], \"y\": [0.0, 0.6904761904761905, 0.6904761904761905, 0.38461538461538464], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1195.0, 1195.0, 1212.5, 1212.5], \"y\": [0.0, 0.8095238095238095, 0.8095238095238095, 0.6904761904761905], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1235.0, 1235.0, 1245.0, 1245.0], \"y\": [0.0, 0.7222222222222222, 0.7222222222222222, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1265.0, 1265.0, 1275.0, 1275.0], \"y\": [0.0, 0.4, 0.4, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1255.0, 1255.0, 1270.0, 1270.0], \"y\": [0.0, 0.6521739130434783, 0.6521739130434783, 0.4], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1295.0, 1295.0, 1305.0, 1305.0], \"y\": [0.0, 0.5384615384615384, 0.5384615384615384, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1285.0, 1285.0, 1300.0, 1300.0], \"y\": [0.0, 0.8, 0.8, 0.5384615384615384], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1262.5, 1262.5, 1292.5, 1292.5], \"y\": [0.6521739130434783, 0.9629629629629629, 0.9629629629629629, 0.8], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1240.0, 1240.0, 1277.5, 1277.5], \"y\": [0.7222222222222222, 0.975609756097561, 0.975609756097561, 0.9629629629629629], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1203.75, 1203.75, 1258.75, 1258.75], \"y\": [0.8095238095238095, 0.9821428571428571, 0.9821428571428571, 0.975609756097561], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1315.0, 1315.0, 1325.0, 1325.0], \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1355.0, 1355.0, 1365.0, 1365.0], \"y\": [0.0, 0.35064935064935066, 0.35064935064935066, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1345.0, 1345.0, 1360.0, 1360.0], \"y\": [0.0, 0.43661971830985913, 0.43661971830985913, 0.35064935064935066], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1335.0, 1335.0, 1352.5, 1352.5], \"y\": [0.0, 0.6521739130434783, 0.6521739130434783, 0.43661971830985913], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1375.0, 1375.0, 1385.0, 1385.0], \"y\": [0.0, 0.32142857142857145, 0.32142857142857145, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"y\": [0.0, 0.25, 0.25, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1395.0, 1395.0, 1410.0, 1410.0], \"y\": [0.0, 0.4, 0.4, 0.25], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1380.0, 1380.0, 1402.5, 1402.5], \"y\": [0.32142857142857145, 0.42857142857142855, 0.42857142857142855, 0.4], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1435.0, 1435.0, 1445.0, 1445.0], \"y\": [0.0, 0.3888888888888889, 0.3888888888888889, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1425.0, 1425.0, 1440.0, 1440.0], \"y\": [0.0, 0.88, 0.88, 0.3888888888888889], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1391.25, 1391.25, 1432.5, 1432.5], \"y\": [0.42857142857142855, 0.918918918918919, 0.918918918918919, 0.88], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1343.75, 1343.75, 1411.875, 1411.875], \"y\": [0.6521739130434783, 0.9891304347826086, 0.9891304347826086, 0.918918918918919], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1475.0, 1475.0, 1485.0, 1485.0], \"y\": [0.0, 0.4626865671641791, 0.4626865671641791, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1465.0, 1465.0, 1480.0, 1480.0], \"y\": [0.0, 0.7444444444444445, 0.7444444444444445, 0.4626865671641791], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1495.0, 1495.0, 1505.0, 1505.0], \"y\": [0.0, 0.34285714285714286, 0.34285714285714286, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"y\": [0.0, 0.7857142857142857, 0.7857142857142857, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1515.0, 1515.0, 1530.0, 1530.0], \"y\": [0.0, 0.8181818181818182, 0.8181818181818182, 0.7857142857142857], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1500.0, 1500.0, 1522.5, 1522.5], \"y\": [0.34285714285714286, 0.8604651162790697, 0.8604651162790697, 0.8181818181818182], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1472.5, 1472.5, 1511.25, 1511.25], \"y\": [0.7444444444444445, 0.9210526315789473, 0.9210526315789473, 0.8604651162790697], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1455.0, 1455.0, 1491.875, 1491.875], \"y\": [0.0, 0.9540229885057471, 0.9540229885057471, 0.9210526315789473], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1555.0, 1555.0, 1565.0, 1565.0], \"y\": [0.0, 0.47058823529411764, 0.47058823529411764, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1575.0, 1575.0, 1585.0, 1585.0], \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1605.0, 1605.0, 1615.0, 1615.0], \"y\": [0.0, 0.25, 0.25, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1595.0, 1595.0, 1610.0, 1610.0], \"y\": [0.0, 0.4, 0.4, 0.25], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1580.0, 1580.0, 1602.5, 1602.5], \"y\": [0.2857142857142857, 0.8717948717948718, 0.8717948717948718, 0.4], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1560.0, 1560.0, 1591.25, 1591.25], \"y\": [0.47058823529411764, 0.96, 0.96, 0.8717948717948718], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1545.0, 1545.0, 1575.625, 1575.625], \"y\": [0.0, 0.9795918367346939, 0.9795918367346939, 0.96], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1635.0, 1635.0, 1645.0, 1645.0], \"y\": [0.0, 0.25, 0.25, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1625.0, 1625.0, 1640.0, 1640.0], \"y\": [0.0, 0.8787878787878788, 0.8787878787878788, 0.25], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1655.0, 1655.0, 1665.0, 1665.0], \"y\": [0.0, 0.5806451612903226, 0.5806451612903226, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1675.0, 1675.0, 1685.0, 1685.0], \"y\": [0.0, 0.6521739130434783, 0.6521739130434783, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1660.0, 1660.0, 1680.0, 1680.0], \"y\": [0.5806451612903226, 0.8125, 0.8125, 0.6521739130434783], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1695.0, 1695.0, 1705.0, 1705.0], \"y\": [0.0, 0.296875, 0.296875, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1715.0, 1715.0, 1725.0, 1725.0], \"y\": [0.0, 0.34210526315789475, 0.34210526315789475, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1700.0, 1700.0, 1720.0, 1720.0], \"y\": [0.296875, 0.5483870967741935, 0.5483870967741935, 0.34210526315789475], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1755.0, 1755.0, 1765.0, 1765.0], \"y\": [0.0, 0.6388888888888888, 0.6388888888888888, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1745.0, 1745.0, 1760.0, 1760.0], \"y\": [0.0, 0.7096774193548387, 0.7096774193548387, 0.6388888888888888], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1735.0, 1735.0, 1752.5, 1752.5], \"y\": [0.0, 0.7948717948717948, 0.7948717948717948, 0.7096774193548387], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1710.0, 1710.0, 1743.75, 1743.75], \"y\": [0.5483870967741935, 0.8571428571428571, 0.8571428571428571, 0.7948717948717948], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1670.0, 1670.0, 1726.875, 1726.875], \"y\": [0.8125, 0.9767441860465116, 0.9767441860465116, 0.8571428571428571], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"y\": [0.0, 0.34146341463414637, 0.34146341463414637, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1785.0, 1785.0, 1800.0, 1800.0], \"y\": [0.0, 0.3829787234042553, 0.3829787234042553, 0.34146341463414637], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"y\": [0.0, 0.2903225806451613, 0.2903225806451613, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1835.0, 1835.0, 1845.0, 1845.0], \"y\": [0.0, 0.3142857142857143, 0.3142857142857143, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1820.0, 1820.0, 1840.0, 1840.0], \"y\": [0.2903225806451613, 0.34375, 0.34375, 0.3142857142857143], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1865.0, 1865.0, 1875.0, 1875.0], \"y\": [0.0, 0.17647058823529413, 0.17647058823529413, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"y\": [0.0, 0.2727272727272727, 0.2727272727272727, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1870.0, 1870.0, 1890.0, 1890.0], \"y\": [0.17647058823529413, 0.35294117647058826, 0.35294117647058826, 0.2727272727272727], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1855.0, 1855.0, 1880.0, 1880.0], \"y\": [0.0, 0.3783783783783784, 0.3783783783783784, 0.35294117647058826], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1830.0, 1830.0, 1867.5, 1867.5], \"y\": [0.34375, 0.4117647058823529, 0.4117647058823529, 0.3783783783783784], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1792.5, 1792.5, 1848.75, 1848.75], \"y\": [0.3829787234042553, 0.8181818181818182, 0.8181818181818182, 0.4117647058823529], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1775.0, 1775.0, 1820.625, 1820.625], \"y\": [0.0, 0.9482758620689655, 0.9482758620689655, 0.8181818181818182], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1925.0, 1925.0, 1935.0, 1935.0], \"y\": [0.0, 0.6875, 0.6875, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1915.0, 1915.0, 1930.0, 1930.0], \"y\": [0.0, 0.8974358974358975, 0.8974358974358975, 0.6875], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"y\": [0.0, 0.9302325581395349, 0.9302325581395349, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"y\": [0.0, 0.984375, 0.984375, 0.9302325581395349], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1955.0, 1955.0, 1972.5, 1972.5], \"y\": [0.0, 1.0, 1.0, 0.984375], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1945.0, 1945.0, 1963.75, 1963.75], \"y\": [0.0, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1922.5, 1922.5, 1954.375, 1954.375], \"y\": [0.8974358974358975, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1905.0, 1905.0, 1938.4375, 1938.4375], \"y\": [0.0, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1797.8125, 1797.8125, 1921.71875, 1921.71875], \"y\": [0.9482758620689655, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1698.4375, 1698.4375, 1859.765625, 1859.765625], \"y\": [0.9767441860465116, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1632.5, 1632.5, 1779.1015625, 1779.1015625], \"y\": [0.8787878787878788, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1560.3125, 1560.3125, 1705.80078125, 1705.80078125], \"y\": [0.9795918367346939, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1473.4375, 1473.4375, 1633.056640625, 1633.056640625], \"y\": [0.9540229885057471, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1377.8125, 1377.8125, 1553.2470703125, 1553.2470703125], \"y\": [0.9891304347826086, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1320.0, 1320.0, 1465.52978515625, 1465.52978515625], \"y\": [0.4444444444444444, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1231.25, 1231.25, 1392.764892578125, 1392.764892578125], \"y\": [0.9821428571428571, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1180.0, 1180.0, 1312.0074462890625, 1312.0074462890625], \"y\": [0.8571428571428571, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1049.609375, 1049.609375, 1246.0037231445312, 1246.0037231445312], \"y\": [0.9883720930232558, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [703.59375, 703.59375, 1147.8065490722656, 1147.8065490722656], \"y\": [0.9818181818181818, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [645.0, 645.0, 925.7001495361328, 925.7001495361328], \"y\": [0.8817204301075269, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [503.984375, 503.984375, 785.3500747680664, 785.3500747680664], \"y\": [0.9705882352941176, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [218.72802734375, 218.72802734375, 644.6672248840332, 644.6672248840332], \"y\": [0.9705882352941176, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}], {\"xaxis\": {\"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0], \"ticktext\": [\"QE_2017_001815_792.5625_866.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001814_792.56207_723.0\", \"QE_2017_001815_613.4826_734.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001815_571.47168_711.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_278.24756_683.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001814_599.40918_659.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_231.04967_404.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001816_611.16064_309.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001814_408.3681_703.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001814_364.34241_751.0\", \"QE_2017_001814_424.36325_711.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001814_421.35211_732.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17426_497.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_209.15335_478.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001816_209.15341_296.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001814_215.16406_483.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001814_129.12737_348.0\", \"QE_2017_001814_171.14908_419.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001814_332.25842_486.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001815_241.15437_67.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001815_319.13623_118.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001815_219.10146_381.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001815_291.14493_242.0\", \"QE_2017_001814_251.13872_201.0\", \"QE_2017_001815_235.14388_180.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_222.07031_314.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001816_247.12863_162.0\", \"QE_2017_001815_260.16016_140.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001815_233.14944_150.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001814_229.15451_65.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001814_194.1174_217.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001815_194.11745_132.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04474_327.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001815_182.08109_52.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001814_199.98772_303.0\", \"QE_2017_001815_199.98772_253.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_265.01532_33.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001815_237.12315_52.0\"], \"tickmode\": \"array\", \"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"sample\"}, \"yaxis\": {\"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"distance\"}, \"showlegend\": false, \"autosize\": false, \"hovermode\": \"closest\", \"width\": 900, \"height\": 500, \"title\": \"BioDendro\"}, {\"showLink\": true, \"linkText\": \"Export to plot.ly\"})});</script>"
-      ],
-      "text/vnd.plotly.v1+html": [
-       "<div id=\"c319c635-3010-4df9-9b91-45fcfdb2c5f3\" style=\"height: 500px; width: 900px;\" class=\"plotly-graph-div\"></div><script type=\"text/javascript\">require([\"plotly\"], function(Plotly) { window.PLOTLYENV=window.PLOTLYENV || {};window.PLOTLYENV.BASE_URL=\"https://plot.ly\";Plotly.newPlot(\"c319c635-3010-4df9-9b91-45fcfdb2c5f3\", [{\"type\": \"scatter\", \"x\": [35.0, 35.0, 45.0, 45.0], \"y\": [0.0, 0.5774647887323944, 0.5774647887323944, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [25.0, 25.0, 40.0, 40.0], \"y\": [0.0, 0.6142857142857143, 0.6142857142857143, 0.5774647887323944], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [15.0, 15.0, 32.5, 32.5], \"y\": [0.0, 0.7049180327868853, 0.7049180327868853, 0.6142857142857143], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [5.0, 5.0, 23.75, 23.75], \"y\": [0.0, 0.7613636363636364, 0.7613636363636364, 0.7049180327868853], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [105.0, 105.0, 115.0, 115.0], \"y\": [0.0, 0.2549019607843137, 0.2549019607843137, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [95.0, 95.0, 110.0, 110.0], \"y\": [0.0, 0.2777777777777778, 0.2777777777777778, 0.2549019607843137], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [125.0, 125.0, 135.0, 135.0], \"y\": [0.0, 0.28125, 0.28125, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [102.5, 102.5, 130.0, 130.0], \"y\": [0.2777777777777778, 0.3333333333333333, 0.3333333333333333, 0.28125], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [145.0, 145.0, 155.0, 155.0], \"y\": [0.0, 0.36923076923076925, 0.36923076923076925, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [116.25, 116.25, 150.0, 150.0], \"y\": [0.3333333333333333, 0.4057971014492754, 0.4057971014492754, 0.36923076923076925], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [165.0, 165.0, 175.0, 175.0], \"y\": [0.0, 0.2698412698412698, 0.2698412698412698, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [195.0, 195.0, 205.0, 205.0], \"y\": [0.0, 0.28846153846153844, 0.28846153846153844, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [185.0, 185.0, 200.0, 200.0], \"y\": [0.0, 0.37735849056603776, 0.37735849056603776, 0.28846153846153844], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [170.0, 170.0, 192.5, 192.5], \"y\": [0.2698412698412698, 0.4262295081967213, 0.4262295081967213, 0.37735849056603776], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [133.125, 133.125, 181.25, 181.25], \"y\": [0.4057971014492754, 0.45454545454545453, 0.45454545454545453, 0.4262295081967213], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [85.0, 85.0, 157.1875, 157.1875], \"y\": [0.0, 0.4925373134328358, 0.4925373134328358, 0.45454545454545453], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [75.0, 75.0, 121.09375, 121.09375], \"y\": [0.0, 0.5652173913043478, 0.5652173913043478, 0.4925373134328358], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [65.0, 65.0, 98.046875, 98.046875], \"y\": [0.0, 0.6904761904761905, 0.6904761904761905, 0.5652173913043478], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [55.0, 55.0, 81.5234375, 81.5234375], \"y\": [0.0, 0.7981651376146789, 0.7981651376146789, 0.6904761904761905], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [225.0, 225.0, 235.0, 235.0], \"y\": [0.0, 0.609375, 0.609375, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [255.0, 255.0, 265.0, 265.0], \"y\": [0.0, 0.36764705882352944, 0.36764705882352944, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [245.0, 245.0, 260.0, 260.0], \"y\": [0.0, 0.5342465753424658, 0.5342465753424658, 0.36764705882352944], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [275.0, 275.0, 285.0, 285.0], \"y\": [0.0, 0.23529411764705882, 0.23529411764705882, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [295.0, 295.0, 305.0, 305.0], \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [280.0, 280.0, 300.0, 300.0], \"y\": [0.23529411764705882, 0.5585585585585585, 0.5585585585585585, 0.4444444444444444], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [252.5, 252.5, 290.0, 290.0], \"y\": [0.5342465753424658, 0.6902654867256637, 0.6902654867256637, 0.5585585585585585], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [230.0, 230.0, 271.25, 271.25], \"y\": [0.609375, 0.7619047619047619, 0.7619047619047619, 0.6902654867256637], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [215.0, 215.0, 250.625, 250.625], \"y\": [0.0, 0.8266666666666667, 0.8266666666666667, 0.7619047619047619], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [68.26171875, 68.26171875, 232.8125, 232.8125], \"y\": [0.7981651376146789, 0.8712871287128713, 0.8712871287128713, 0.8266666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [14.375, 14.375, 150.537109375, 150.537109375], \"y\": [0.7613636363636364, 0.9014084507042254, 0.9014084507042254, 0.8712871287128713], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [345.0, 345.0, 355.0, 355.0], \"y\": [0.0, 0.6336633663366337, 0.6336633663366337, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [335.0, 335.0, 350.0, 350.0], \"y\": [0.0, 0.6629213483146067, 0.6629213483146067, 0.6336633663366337], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [325.0, 325.0, 342.5, 342.5], \"y\": [0.0, 0.7604166666666666, 0.7604166666666666, 0.6629213483146067], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [315.0, 315.0, 333.75, 333.75], \"y\": [0.0, 0.8023255813953488, 0.8023255813953488, 0.7604166666666666], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [365.0, 365.0, 375.0, 375.0], \"y\": [0.0, 0.4713114754098361, 0.4713114754098361, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [405.0, 405.0, 415.0, 415.0], \"y\": [0.0, 0.5222222222222223, 0.5222222222222223, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [395.0, 395.0, 410.0, 410.0], \"y\": [0.0, 0.6097560975609756, 0.6097560975609756, 0.5222222222222223], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [435.0, 435.0, 445.0, 445.0], \"y\": [0.0, 0.524822695035461, 0.524822695035461, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [425.0, 425.0, 440.0, 440.0], \"y\": [0.0, 0.6983240223463687, 0.6983240223463687, 0.524822695035461], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [402.5, 402.5, 432.5, 432.5], \"y\": [0.6097560975609756, 0.7364341085271318, 0.7364341085271318, 0.6983240223463687], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [385.0, 385.0, 417.5, 417.5], \"y\": [0.0, 0.7661290322580645, 0.7661290322580645, 0.7364341085271318], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [370.0, 370.0, 401.25, 401.25], \"y\": [0.4713114754098361, 0.8212765957446808, 0.8212765957446808, 0.7661290322580645], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [324.375, 324.375, 385.625, 385.625], \"y\": [0.8023255813953488, 0.9403973509933775, 0.9403973509933775, 0.8212765957446808], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [82.4560546875, 82.4560546875, 355.0, 355.0], \"y\": [0.9014084507042254, 0.9705882352941176, 0.9705882352941176, 0.9403973509933775], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [465.0, 465.0, 475.0, 475.0], \"y\": [0.0, 0.4230769230769231, 0.4230769230769231, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [505.0, 505.0, 515.0, 515.0], \"y\": [0.0, 0.375, 0.375, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [495.0, 495.0, 510.0, 510.0], \"y\": [0.0, 0.391304347826087, 0.391304347826087, 0.375], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [485.0, 485.0, 502.5, 502.5], \"y\": [0.0, 0.5, 0.5, 0.391304347826087], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [470.0, 470.0, 493.75, 493.75], \"y\": [0.4230769230769231, 0.7878787878787878, 0.7878787878787878, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [525.0, 525.0, 535.0, 535.0], \"y\": [0.0, 0.6981132075471698, 0.6981132075471698, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [545.0, 545.0, 555.0, 555.0], \"y\": [0.0, 0.4074074074074074, 0.4074074074074074, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [565.0, 565.0, 575.0, 575.0], \"y\": [0.0, 0.6896551724137931, 0.6896551724137931, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [550.0, 550.0, 570.0, 570.0], \"y\": [0.4074074074074074, 0.7567567567567568, 0.7567567567567568, 0.6896551724137931], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [530.0, 530.0, 560.0, 560.0], \"y\": [0.6981132075471698, 0.8604651162790697, 0.8604651162790697, 0.7567567567567568], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [481.875, 481.875, 545.0, 545.0], \"y\": [0.7878787878787878, 0.88, 0.88, 0.8604651162790697], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [595.0, 595.0, 605.0, 605.0], \"y\": [0.0, 0.36363636363636365, 0.36363636363636365, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [585.0, 585.0, 600.0, 600.0], \"y\": [0.0, 0.926829268292683, 0.926829268292683, 0.36363636363636365], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [513.4375, 513.4375, 592.5, 592.5], \"y\": [0.88, 0.9473684210526315, 0.9473684210526315, 0.926829268292683], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [455.0, 455.0, 552.96875, 552.96875], \"y\": [0.0, 0.9705882352941176, 0.9705882352941176, 0.9473684210526315], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [615.0, 615.0, 625.0, 625.0], \"y\": [0.0, 0.36231884057971014, 0.36231884057971014, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [635.0, 635.0, 645.0, 645.0], \"y\": [0.0, 0.44776119402985076, 0.44776119402985076, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [620.0, 620.0, 640.0, 640.0], \"y\": [0.36231884057971014, 0.4931506849315068, 0.4931506849315068, 0.44776119402985076], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [655.0, 655.0, 665.0, 665.0], \"y\": [0.0, 0.5, 0.5, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [630.0, 630.0, 660.0, 660.0], \"y\": [0.4931506849315068, 0.8817204301075269, 0.8817204301075269, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [675.0, 675.0, 685.0, 685.0], \"y\": [0.0, 0.4117647058823529, 0.4117647058823529, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [705.0, 705.0, 715.0, 715.0], \"y\": [0.0, 0.42857142857142855, 0.42857142857142855, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [695.0, 695.0, 710.0, 710.0], \"y\": [0.0, 0.7058823529411765, 0.7058823529411765, 0.42857142857142855], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [745.0, 745.0, 755.0, 755.0], \"y\": [0.0, 0.35714285714285715, 0.35714285714285715, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [735.0, 735.0, 750.0, 750.0], \"y\": [0.0, 0.47058823529411764, 0.47058823529411764, 0.35714285714285715], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [725.0, 725.0, 742.5, 742.5], \"y\": [0.0, 0.631578947368421, 0.631578947368421, 0.47058823529411764], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [765.0, 765.0, 775.0, 775.0], \"y\": [0.0, 0.725, 0.725, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [733.75, 733.75, 770.0, 770.0], \"y\": [0.631578947368421, 0.7407407407407407, 0.7407407407407407, 0.725], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [702.5, 702.5, 751.875, 751.875], \"y\": [0.7058823529411765, 0.85, 0.85, 0.7407407407407407], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [680.0, 680.0, 727.1875, 727.1875], \"y\": [0.4117647058823529, 0.9818181818181818, 0.9818181818181818, 0.85], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [785.0, 785.0, 795.0, 795.0], \"y\": [0.0, 0.47540983606557374, 0.47540983606557374, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [815.0, 815.0, 825.0, 825.0], \"y\": [0.0, 0.423728813559322, 0.423728813559322, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [805.0, 805.0, 820.0, 820.0], \"y\": [0.0, 0.49019607843137253, 0.49019607843137253, 0.423728813559322], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [855.0, 855.0, 865.0, 865.0], \"y\": [0.0, 0.30612244897959184, 0.30612244897959184, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [845.0, 845.0, 860.0, 860.0], \"y\": [0.0, 0.3728813559322034, 0.3728813559322034, 0.30612244897959184], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [835.0, 835.0, 852.5, 852.5], \"y\": [0.0, 0.5, 0.5, 0.3728813559322034], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [812.5, 812.5, 843.75, 843.75], \"y\": [0.49019607843137253, 0.6862745098039216, 0.6862745098039216, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [790.0, 790.0, 828.125, 828.125], \"y\": [0.47540983606557374, 0.7857142857142857, 0.7857142857142857, 0.6862745098039216], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [895.0, 895.0, 905.0, 905.0], \"y\": [0.0, 0.2876712328767123, 0.2876712328767123, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [885.0, 885.0, 900.0, 900.0], \"y\": [0.0, 0.39473684210526316, 0.39473684210526316, 0.2876712328767123], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [915.0, 915.0, 925.0, 925.0], \"y\": [0.0, 0.45569620253164556, 0.45569620253164556, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [892.5, 892.5, 920.0, 920.0], \"y\": [0.39473684210526316, 0.5119047619047619, 0.5119047619047619, 0.45569620253164556], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [935.0, 935.0, 945.0, 945.0], \"y\": [0.0, 0.35384615384615387, 0.35384615384615387, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [955.0, 955.0, 965.0, 965.0], \"y\": [0.0, 0.54, 0.54, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [940.0, 940.0, 960.0, 960.0], \"y\": [0.35384615384615387, 0.5934065934065934, 0.5934065934065934, 0.54], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [906.25, 906.25, 950.0, 950.0], \"y\": [0.5119047619047619, 0.6530612244897959, 0.6530612244897959, 0.5934065934065934], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [985.0, 985.0, 995.0, 995.0], \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [975.0, 975.0, 990.0, 990.0], \"y\": [0.0, 0.6753246753246753, 0.6753246753246753, 0.3333333333333333], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [928.125, 928.125, 982.5, 982.5], \"y\": [0.6530612244897959, 0.7093023255813954, 0.7093023255813954, 0.6753246753246753], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1005.0, 1005.0, 1015.0, 1015.0], \"y\": [0.0, 0.2777777777777778, 0.2777777777777778, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1045.0, 1045.0, 1055.0, 1055.0], \"y\": [0.0, 0.18867924528301888, 0.18867924528301888, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1035.0, 1035.0, 1050.0, 1050.0], \"y\": [0.0, 0.20754716981132076, 0.20754716981132076, 0.18867924528301888], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1025.0, 1025.0, 1042.5, 1042.5], \"y\": [0.0, 0.29508196721311475, 0.29508196721311475, 0.20754716981132076], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1065.0, 1065.0, 1075.0, 1075.0], \"y\": [0.0, 0.54, 0.54, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1033.75, 1033.75, 1070.0, 1070.0], \"y\": [0.29508196721311475, 0.5714285714285714, 0.5714285714285714, 0.54], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1010.0, 1010.0, 1051.875, 1051.875], \"y\": [0.2777777777777778, 0.75, 0.75, 0.5714285714285714], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [955.3125, 955.3125, 1030.9375, 1030.9375], \"y\": [0.7093023255813954, 0.7662337662337663, 0.7662337662337663, 0.75], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [875.0, 875.0, 993.125, 993.125], \"y\": [0.0, 0.8192771084337349, 0.8192771084337349, 0.7662337662337663], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [809.0625, 809.0625, 934.0625, 934.0625], \"y\": [0.7857142857142857, 0.8448275862068966, 0.8448275862068966, 0.8192771084337349], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1085.0, 1085.0, 1095.0, 1095.0], \"y\": [0.0, 0.8571428571428571, 0.8571428571428571, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [871.5625, 871.5625, 1090.0, 1090.0], \"y\": [0.8448275862068966, 0.9146341463414634, 0.9146341463414634, 0.8571428571428571], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"y\": [0.0, 0.8333333333333334, 0.8333333333333334, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1155.0, 1155.0, 1165.0, 1165.0], \"y\": [0.0, 0.34615384615384615, 0.34615384615384615, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1145.0, 1145.0, 1160.0, 1160.0], \"y\": [0.0, 0.6296296296296297, 0.6296296296296297, 0.34615384615384615], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1135.0, 1135.0, 1152.5, 1152.5], \"y\": [0.0, 0.8666666666666667, 0.8666666666666667, 0.6296296296296297], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1120.0, 1120.0, 1143.75, 1143.75], \"y\": [0.8333333333333334, 0.9111111111111111, 0.9111111111111111, 0.8666666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1105.0, 1105.0, 1131.875, 1131.875], \"y\": [0.0, 0.9298245614035088, 0.9298245614035088, 0.9111111111111111], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [980.78125, 980.78125, 1118.4375, 1118.4375], \"y\": [0.9146341463414634, 0.9883720930232558, 0.9883720930232558, 0.9298245614035088], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1175.0, 1175.0, 1185.0, 1185.0], \"y\": [0.0, 0.8571428571428571, 0.8571428571428571, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1215.0, 1215.0, 1225.0, 1225.0], \"y\": [0.0, 0.38461538461538464, 0.38461538461538464, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1205.0, 1205.0, 1220.0, 1220.0], \"y\": [0.0, 0.6904761904761905, 0.6904761904761905, 0.38461538461538464], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1195.0, 1195.0, 1212.5, 1212.5], \"y\": [0.0, 0.8095238095238095, 0.8095238095238095, 0.6904761904761905], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1235.0, 1235.0, 1245.0, 1245.0], \"y\": [0.0, 0.7222222222222222, 0.7222222222222222, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1265.0, 1265.0, 1275.0, 1275.0], \"y\": [0.0, 0.4, 0.4, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1255.0, 1255.0, 1270.0, 1270.0], \"y\": [0.0, 0.6521739130434783, 0.6521739130434783, 0.4], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1295.0, 1295.0, 1305.0, 1305.0], \"y\": [0.0, 0.5384615384615384, 0.5384615384615384, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1285.0, 1285.0, 1300.0, 1300.0], \"y\": [0.0, 0.8, 0.8, 0.5384615384615384], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1262.5, 1262.5, 1292.5, 1292.5], \"y\": [0.6521739130434783, 0.9629629629629629, 0.9629629629629629, 0.8], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1240.0, 1240.0, 1277.5, 1277.5], \"y\": [0.7222222222222222, 0.975609756097561, 0.975609756097561, 0.9629629629629629], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1203.75, 1203.75, 1258.75, 1258.75], \"y\": [0.8095238095238095, 0.9821428571428571, 0.9821428571428571, 0.975609756097561], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1315.0, 1315.0, 1325.0, 1325.0], \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1355.0, 1355.0, 1365.0, 1365.0], \"y\": [0.0, 0.35064935064935066, 0.35064935064935066, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1345.0, 1345.0, 1360.0, 1360.0], \"y\": [0.0, 0.43661971830985913, 0.43661971830985913, 0.35064935064935066], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1335.0, 1335.0, 1352.5, 1352.5], \"y\": [0.0, 0.6521739130434783, 0.6521739130434783, 0.43661971830985913], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1375.0, 1375.0, 1385.0, 1385.0], \"y\": [0.0, 0.32142857142857145, 0.32142857142857145, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"y\": [0.0, 0.25, 0.25, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1395.0, 1395.0, 1410.0, 1410.0], \"y\": [0.0, 0.4, 0.4, 0.25], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1380.0, 1380.0, 1402.5, 1402.5], \"y\": [0.32142857142857145, 0.42857142857142855, 0.42857142857142855, 0.4], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1435.0, 1435.0, 1445.0, 1445.0], \"y\": [0.0, 0.3888888888888889, 0.3888888888888889, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1425.0, 1425.0, 1440.0, 1440.0], \"y\": [0.0, 0.88, 0.88, 0.3888888888888889], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1391.25, 1391.25, 1432.5, 1432.5], \"y\": [0.42857142857142855, 0.918918918918919, 0.918918918918919, 0.88], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1343.75, 1343.75, 1411.875, 1411.875], \"y\": [0.6521739130434783, 0.9891304347826086, 0.9891304347826086, 0.918918918918919], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1475.0, 1475.0, 1485.0, 1485.0], \"y\": [0.0, 0.4626865671641791, 0.4626865671641791, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1465.0, 1465.0, 1480.0, 1480.0], \"y\": [0.0, 0.7444444444444445, 0.7444444444444445, 0.4626865671641791], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1495.0, 1495.0, 1505.0, 1505.0], \"y\": [0.0, 0.34285714285714286, 0.34285714285714286, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"y\": [0.0, 0.7857142857142857, 0.7857142857142857, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1515.0, 1515.0, 1530.0, 1530.0], \"y\": [0.0, 0.8181818181818182, 0.8181818181818182, 0.7857142857142857], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1500.0, 1500.0, 1522.5, 1522.5], \"y\": [0.34285714285714286, 0.8604651162790697, 0.8604651162790697, 0.8181818181818182], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1472.5, 1472.5, 1511.25, 1511.25], \"y\": [0.7444444444444445, 0.9210526315789473, 0.9210526315789473, 0.8604651162790697], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1455.0, 1455.0, 1491.875, 1491.875], \"y\": [0.0, 0.9540229885057471, 0.9540229885057471, 0.9210526315789473], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1555.0, 1555.0, 1565.0, 1565.0], \"y\": [0.0, 0.47058823529411764, 0.47058823529411764, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1575.0, 1575.0, 1585.0, 1585.0], \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1605.0, 1605.0, 1615.0, 1615.0], \"y\": [0.0, 0.25, 0.25, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1595.0, 1595.0, 1610.0, 1610.0], \"y\": [0.0, 0.4, 0.4, 0.25], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1580.0, 1580.0, 1602.5, 1602.5], \"y\": [0.2857142857142857, 0.8717948717948718, 0.8717948717948718, 0.4], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1560.0, 1560.0, 1591.25, 1591.25], \"y\": [0.47058823529411764, 0.96, 0.96, 0.8717948717948718], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1545.0, 1545.0, 1575.625, 1575.625], \"y\": [0.0, 0.9795918367346939, 0.9795918367346939, 0.96], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1635.0, 1635.0, 1645.0, 1645.0], \"y\": [0.0, 0.25, 0.25, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1625.0, 1625.0, 1640.0, 1640.0], \"y\": [0.0, 0.8787878787878788, 0.8787878787878788, 0.25], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1655.0, 1655.0, 1665.0, 1665.0], \"y\": [0.0, 0.5806451612903226, 0.5806451612903226, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1675.0, 1675.0, 1685.0, 1685.0], \"y\": [0.0, 0.6521739130434783, 0.6521739130434783, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1660.0, 1660.0, 1680.0, 1680.0], \"y\": [0.5806451612903226, 0.8125, 0.8125, 0.6521739130434783], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1695.0, 1695.0, 1705.0, 1705.0], \"y\": [0.0, 0.296875, 0.296875, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1715.0, 1715.0, 1725.0, 1725.0], \"y\": [0.0, 0.34210526315789475, 0.34210526315789475, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1700.0, 1700.0, 1720.0, 1720.0], \"y\": [0.296875, 0.5483870967741935, 0.5483870967741935, 0.34210526315789475], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1755.0, 1755.0, 1765.0, 1765.0], \"y\": [0.0, 0.6388888888888888, 0.6388888888888888, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1745.0, 1745.0, 1760.0, 1760.0], \"y\": [0.0, 0.7096774193548387, 0.7096774193548387, 0.6388888888888888], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1735.0, 1735.0, 1752.5, 1752.5], \"y\": [0.0, 0.7948717948717948, 0.7948717948717948, 0.7096774193548387], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1710.0, 1710.0, 1743.75, 1743.75], \"y\": [0.5483870967741935, 0.8571428571428571, 0.8571428571428571, 0.7948717948717948], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1670.0, 1670.0, 1726.875, 1726.875], \"y\": [0.8125, 0.9767441860465116, 0.9767441860465116, 0.8571428571428571], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"y\": [0.0, 0.34146341463414637, 0.34146341463414637, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1785.0, 1785.0, 1800.0, 1800.0], \"y\": [0.0, 0.3829787234042553, 0.3829787234042553, 0.34146341463414637], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"y\": [0.0, 0.2903225806451613, 0.2903225806451613, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1835.0, 1835.0, 1845.0, 1845.0], \"y\": [0.0, 0.3142857142857143, 0.3142857142857143, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1820.0, 1820.0, 1840.0, 1840.0], \"y\": [0.2903225806451613, 0.34375, 0.34375, 0.3142857142857143], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1865.0, 1865.0, 1875.0, 1875.0], \"y\": [0.0, 0.17647058823529413, 0.17647058823529413, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"y\": [0.0, 0.2727272727272727, 0.2727272727272727, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1870.0, 1870.0, 1890.0, 1890.0], \"y\": [0.17647058823529413, 0.35294117647058826, 0.35294117647058826, 0.2727272727272727], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1855.0, 1855.0, 1880.0, 1880.0], \"y\": [0.0, 0.3783783783783784, 0.3783783783783784, 0.35294117647058826], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1830.0, 1830.0, 1867.5, 1867.5], \"y\": [0.34375, 0.4117647058823529, 0.4117647058823529, 0.3783783783783784], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1792.5, 1792.5, 1848.75, 1848.75], \"y\": [0.3829787234042553, 0.8181818181818182, 0.8181818181818182, 0.4117647058823529], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1775.0, 1775.0, 1820.625, 1820.625], \"y\": [0.0, 0.9482758620689655, 0.9482758620689655, 0.8181818181818182], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1925.0, 1925.0, 1935.0, 1935.0], \"y\": [0.0, 0.6875, 0.6875, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1915.0, 1915.0, 1930.0, 1930.0], \"y\": [0.0, 0.8974358974358975, 0.8974358974358975, 0.6875], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"y\": [0.0, 0.9302325581395349, 0.9302325581395349, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"y\": [0.0, 0.984375, 0.984375, 0.9302325581395349], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1955.0, 1955.0, 1972.5, 1972.5], \"y\": [0.0, 1.0, 1.0, 0.984375], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1945.0, 1945.0, 1963.75, 1963.75], \"y\": [0.0, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1922.5, 1922.5, 1954.375, 1954.375], \"y\": [0.8974358974358975, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1905.0, 1905.0, 1938.4375, 1938.4375], \"y\": [0.0, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1797.8125, 1797.8125, 1921.71875, 1921.71875], \"y\": [0.9482758620689655, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1698.4375, 1698.4375, 1859.765625, 1859.765625], \"y\": [0.9767441860465116, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1632.5, 1632.5, 1779.1015625, 1779.1015625], \"y\": [0.8787878787878788, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1560.3125, 1560.3125, 1705.80078125, 1705.80078125], \"y\": [0.9795918367346939, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1473.4375, 1473.4375, 1633.056640625, 1633.056640625], \"y\": [0.9540229885057471, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1377.8125, 1377.8125, 1553.2470703125, 1553.2470703125], \"y\": [0.9891304347826086, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1320.0, 1320.0, 1465.52978515625, 1465.52978515625], \"y\": [0.4444444444444444, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1231.25, 1231.25, 1392.764892578125, 1392.764892578125], \"y\": [0.9821428571428571, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1180.0, 1180.0, 1312.0074462890625, 1312.0074462890625], \"y\": [0.8571428571428571, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1049.609375, 1049.609375, 1246.0037231445312, 1246.0037231445312], \"y\": [0.9883720930232558, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [703.59375, 703.59375, 1147.8065490722656, 1147.8065490722656], \"y\": [0.9818181818181818, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [645.0, 645.0, 925.7001495361328, 925.7001495361328], \"y\": [0.8817204301075269, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [503.984375, 503.984375, 785.3500747680664, 785.3500747680664], \"y\": [0.9705882352941176, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [218.72802734375, 218.72802734375, 644.6672248840332, 644.6672248840332], \"y\": [0.9705882352941176, 1.0, 1.0, 1.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}], {\"xaxis\": {\"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0], \"ticktext\": [\"QE_2017_001815_792.5625_866.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001814_792.56207_723.0\", \"QE_2017_001815_613.4826_734.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001815_571.47168_711.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_278.24756_683.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001814_599.40918_659.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_231.04967_404.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001816_611.16064_309.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001814_408.3681_703.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001814_364.34241_751.0\", \"QE_2017_001814_424.36325_711.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001814_421.35211_732.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17426_497.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_209.15335_478.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001816_209.15341_296.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001814_215.16406_483.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001814_129.12737_348.0\", \"QE_2017_001814_171.14908_419.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001814_332.25842_486.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001815_241.15437_67.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001815_319.13623_118.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001815_219.10146_381.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001815_291.14493_242.0\", \"QE_2017_001814_251.13872_201.0\", \"QE_2017_001815_235.14388_180.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_222.07031_314.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001816_247.12863_162.0\", \"QE_2017_001815_260.16016_140.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001815_233.14944_150.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001814_229.15451_65.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001814_194.1174_217.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001815_194.11745_132.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04474_327.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001815_182.08109_52.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001814_199.98772_303.0\", \"QE_2017_001815_199.98772_253.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_265.01532_33.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001815_237.12315_52.0\"], \"tickmode\": \"array\", \"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"sample\"}, \"yaxis\": {\"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"distance\"}, \"showlegend\": false, \"autosize\": false, \"hovermode\": \"closest\", \"width\": 900, \"height\": 500, \"title\": \"BioDendro\"}, {\"showLink\": true, \"linkText\": \"Export to plot.ly\"})});</script>"
+       "<div>\n",
+       "        \n",
+       "        \n",
+       "            <div id=\"7e7469bf-45cb-43e4-a269-000a03c27285\" class=\"plotly-graph-div\"></div>\n",
+       "            <script type=\"text/javascript\">\n",
+       "                require([\"plotly\"], function(Plotly) {\n",
+       "                    window.PLOTLYENV=window.PLOTLYENV || {};\n",
+       "                    window.PLOTLYENV.BASE_URL='https://plot.ly';\n",
+       "                    \n",
+       "                if (document.getElementById(\"7e7469bf-45cb-43e4-a269-000a03c27285\")) {\n",
+       "                    Plotly.newPlot(\n",
+       "                        '7e7469bf-45cb-43e4-a269-000a03c27285',\n",
+       "                        [{\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 1, component: QE_2017_001816_613.48218_838.0\", \"cluster: 1, component: QE_2017_001816_613.48218_838.0\", \"cluster: 1, component: QE_2017_001816_792.56232_718.0\", \"cluster: 1, component: QE_2017_001816_792.56232_718.0\"], \"type\": \"scatter\", \"uid\": \"cc305d33-4f2b-4ce5-bf16-55719365d1d8\", \"x\": [15.0, 15.0, 25.0, 25.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5662650602409639, 0.5662650602409639, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001816_613.4826_738.0\", \"cluster: 2, component: QE_2017_001816_613.4826_738.0\", null, null], \"type\": \"scatter\", \"uid\": \"90394701-f390-4601-ad00-7d5d7cbe63ec\", \"x\": [5.0, 5.0, 20.0, 20.0], \"xaxis\": \"x\", \"y\": [0.0, 0.676923076923077, 0.676923076923077, 0.5662650602409639], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 3, component: QE_2017_001814_596.30963_602.0\", \"cluster: 3, component: QE_2017_001814_596.30963_602.0\", \"cluster: 4, component: QE_2017_001815_792.5625_866.0\", \"cluster: 4, component: QE_2017_001815_792.5625_866.0\"], \"type\": \"scatter\", \"uid\": \"81ee7118-0c07-432d-a6ed-36b2fb35c1f8\", \"x\": [35.0, 35.0, 45.0, 45.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7142857142857143, 0.7142857142857143, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5e45b4fd-6a63-4dc4-aa7b-3aee790b8443\", \"x\": [12.5, 12.5, 40.0, 40.0], \"xaxis\": \"x\", \"y\": [0.676923076923077, 0.7763157894736842, 0.7763157894736842, 0.7142857142857143], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25784_608.0\", \"cluster: 5, component: QE_2017_001814_335.25784_608.0\", \"cluster: 5, component: QE_2017_001816_335.25772_723.0\", \"cluster: 5, component: QE_2017_001816_335.25772_723.0\"], \"type\": \"scatter\", \"uid\": \"7d6a06f8-46d4-4597-af82-521b3457a5a8\", \"x\": [105.0, 105.0, 115.0, 115.0], \"xaxis\": \"x\", \"y\": [0.0, 0.26, 0.26, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25772_725.0\", \"cluster: 5, component: QE_2017_001814_335.25772_725.0\", null, null], \"type\": \"scatter\", \"uid\": \"0776f6c6-5218-49d5-89f7-b3781d6ffbb2\", \"x\": [95.0, 95.0, 110.0, 110.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2830188679245283, 0.2830188679245283, 0.26], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25784_628.0\", \"cluster: 5, component: QE_2017_001814_335.25784_628.0\", \"cluster: 5, component: QE_2017_001815_335.25745_642.0\", \"cluster: 5, component: QE_2017_001815_335.25745_642.0\"], \"type\": \"scatter\", \"uid\": \"abb463b2-8f5a-449f-962d-10da48f8a961\", \"x\": [125.0, 125.0, 135.0, 135.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"19a9b309-dc7f-4a61-8839-b7ef8c97cf9e\", \"x\": [102.5, 102.5, 130.0, 130.0], \"xaxis\": \"x\", \"y\": [0.2830188679245283, 0.3389830508474576, 0.3389830508474576, 0.2857142857142857], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_261.22073_634.0\", \"cluster: 5, component: QE_2017_001814_261.22073_634.0\", \"cluster: 5, component: QE_2017_001815_335.25784_587.0\", \"cluster: 5, component: QE_2017_001815_335.25784_587.0\"], \"type\": \"scatter\", \"uid\": \"d0e06cf9-2130-48ca-91f6-716030fbabba\", \"x\": [145.0, 145.0, 155.0, 155.0], \"xaxis\": \"x\", \"y\": [0.0, 0.375, 0.375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"9979cb47-22d3-4b30-8d5a-2b136af9f695\", \"x\": [116.25, 116.25, 150.0, 150.0], \"xaxis\": \"x\", \"y\": [0.3389830508474576, 0.4117647058823529, 0.4117647058823529, 0.375], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_353.26889_609.0\", \"cluster: 5, component: QE_2017_001814_353.26889_609.0\", \"cluster: 5, component: QE_2017_001815_353.26862_642.0\", \"cluster: 5, component: QE_2017_001815_353.26862_642.0\"], \"type\": \"scatter\", \"uid\": \"6456b16f-dd4e-466f-b7d0-f85a897c7cb8\", \"x\": [165.0, 165.0, 175.0, 175.0], \"xaxis\": \"x\", \"y\": [0.0, 0.27419354838709675, 0.27419354838709675, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25772_638.0\", \"cluster: 5, component: QE_2017_001814_335.25772_638.0\", \"cluster: 5, component: QE_2017_001815_335.2579_601.0\", \"cluster: 5, component: QE_2017_001815_335.2579_601.0\"], \"type\": \"scatter\", \"uid\": \"b08da2b7-09fb-4d34-bc56-7a1db611f768\", \"x\": [195.0, 195.0, 205.0, 205.0], \"xaxis\": \"x\", \"y\": [0.0, 0.29411764705882354, 0.29411764705882354, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_261.22073_643.0\", \"cluster: 5, component: QE_2017_001815_261.22073_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"1218810c-b1dd-4c87-9f43-afac0c5b3d02\", \"x\": [185.0, 185.0, 200.0, 200.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38461538461538464, 0.38461538461538464, 0.29411764705882354], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"c4320c5f-8fbe-45ac-b746-106f935d21a0\", \"x\": [170.0, 170.0, 192.5, 192.5], \"xaxis\": \"x\", \"y\": [0.27419354838709675, 0.43333333333333335, 0.43333333333333335, 0.38461538461538464], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"22d9636b-a1b5-42f3-8c50-1cfd158d487f\", \"x\": [133.125, 133.125, 181.25, 181.25], \"xaxis\": \"x\", \"y\": [0.4117647058823529, 0.46153846153846156, 0.46153846153846156, 0.43333333333333335], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001816_571.47186_717.0\", \"cluster: 5, component: QE_2017_001816_571.47186_717.0\", null, null], \"type\": \"scatter\", \"uid\": \"92ee9b3e-827f-4fc4-9f3a-aef1a20df399\", \"x\": [85.0, 85.0, 157.1875, 157.1875], \"xaxis\": \"x\", \"y\": [0.0, 0.5538461538461539, 0.5538461538461539, 0.46153846153846156], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_507.27145_607.0\", \"cluster: 5, component: QE_2017_001815_507.27145_607.0\", null, null], \"type\": \"scatter\", \"uid\": \"8d50e727-4afa-4b10-a43a-61d573a1338e\", \"x\": [75.0, 75.0, 121.09375, 121.09375], \"xaxis\": \"x\", \"y\": [0.0, 0.5737704918032787, 0.5737704918032787, 0.5538461538461539], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 6, component: QE_2017_001814_497.31033_643.0\", \"cluster: 6, component: QE_2017_001814_497.31033_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"6e73a5e9-286b-49a6-9de8-fc482a729018\", \"x\": [65.0, 65.0, 98.046875, 98.046875], \"xaxis\": \"x\", \"y\": [0.0, 0.6986301369863014, 0.6986301369863014, 0.5737704918032787], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 7, component: QE_2017_001815_571.4292_870.0\", \"cluster: 7, component: QE_2017_001815_571.4292_870.0\", null, null], \"type\": \"scatter\", \"uid\": \"70f331d8-2b2e-436f-a226-5ef0ac38795a\", \"x\": [55.0, 55.0, 81.5234375, 81.5234375], \"xaxis\": \"x\", \"y\": [0.0, 0.7962962962962963, 0.7962962962962963, 0.6986301369863014], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001814_338.34146_850.0\", \"cluster: 8, component: QE_2017_001814_338.34146_850.0\", \"cluster: 9, component: QE_2017_001815_244.19048_762.0\", \"cluster: 9, component: QE_2017_001815_244.19048_762.0\"], \"type\": \"scatter\", \"uid\": \"c9d30922-9887-4dfb-ac5d-3cec57140d26\", \"x\": [225.0, 225.0, 235.0, 235.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6031746031746031, 0.6031746031746031, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_353.26868_633.0\", \"cluster: 10, component: QE_2017_001814_353.26868_633.0\", \"cluster: 10, component: QE_2017_001816_353.26892_600.0\", \"cluster: 10, component: QE_2017_001816_353.26892_600.0\"], \"type\": \"scatter\", \"uid\": \"d68035eb-40f4-4593-9e5d-daf86e8f5b46\", \"x\": [245.0, 245.0, 255.0, 255.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2376237623762376, 0.2376237623762376, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_279.23157_719.0\", \"cluster: 10, component: QE_2017_001814_279.23157_719.0\", \"cluster: 10, component: QE_2017_001815_278.24762_684.0\", \"cluster: 10, component: QE_2017_001815_278.24762_684.0\"], \"type\": \"scatter\", \"uid\": \"0ec0fec0-001f-441f-b3ca-f122a4a2657e\", \"x\": [265.0, 265.0, 275.0, 275.0], \"xaxis\": \"x\", \"y\": [0.0, 0.43209876543209874, 0.43209876543209874, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"53484998-64e5-44b5-a265-fdefa8faf5f7\", \"x\": [250.0, 250.0, 270.0, 270.0], \"xaxis\": \"x\", \"y\": [0.2376237623762376, 0.5229357798165137, 0.5229357798165137, 0.43209876543209874], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 11, component: QE_2017_001816_337.27338_826.0\", \"cluster: 11, component: QE_2017_001816_337.27338_826.0\", \"cluster: 11, component: QE_2017_001816_337.27341_632.0\", \"cluster: 11, component: QE_2017_001816_337.27341_632.0\"], \"type\": \"scatter\", \"uid\": \"be644c93-1927-4e26-909f-eadb45e9a65d\", \"x\": [295.0, 295.0, 305.0, 305.0], \"xaxis\": \"x\", \"y\": [0.0, 0.373134328358209, 0.373134328358209, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 11, component: QE_2017_001816_435.25037_666.0\", \"cluster: 11, component: QE_2017_001816_435.25037_666.0\", null, null], \"type\": \"scatter\", \"uid\": \"48c352a8-993b-4dca-a438-3b6bf43dd67d\", \"x\": [285.0, 285.0, 300.0, 300.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5416666666666666, 0.5416666666666666, 0.373134328358209], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ab52a142-43e4-4677-bd2a-734f9e8b6992\", \"x\": [260.0, 260.0, 292.5, 292.5], \"xaxis\": \"x\", \"y\": [0.5229357798165137, 0.6875, 0.6875, 0.5416666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"fb808ee0-d483-43b9-b451-88162ff4c3dc\", \"x\": [230.0, 230.0, 276.25, 276.25], \"xaxis\": \"x\", \"y\": [0.6031746031746031, 0.7590361445783133, 0.7590361445783133, 0.6875], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 12, component: QE_2017_001816_272.25824_582.0\", \"cluster: 12, component: QE_2017_001816_272.25824_582.0\", null, null], \"type\": \"scatter\", \"uid\": \"6731d9b8-2677-47a6-9baa-58d060e15270\", \"x\": [215.0, 215.0, 253.125, 253.125], \"xaxis\": \"x\", \"y\": [0.0, 0.8243243243243243, 0.8243243243243243, 0.7590361445783133], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8bae575d-fd45-4f47-a3a9-a55693931db0\", \"x\": [68.26171875, 68.26171875, 234.0625, 234.0625], \"xaxis\": \"x\", \"y\": [0.7962962962962963, 0.87, 0.87, 0.8243243243243243], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7365017d-d636-4455-9ebb-9ee4b95d71cb\", \"x\": [26.25, 26.25, 151.162109375, 151.162109375], \"xaxis\": \"x\", \"y\": [0.7763157894736842, 0.9130434782608695, 0.9130434782608695, 0.87], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 13, component: QE_2017_001814_601.42426_706.0\", \"cluster: 13, component: QE_2017_001814_601.42426_706.0\", \"cluster: 14, component: QE_2017_001816_599.40869_793.0\", \"cluster: 14, component: QE_2017_001816_599.40869_793.0\"], \"type\": \"scatter\", \"uid\": \"78100125-d197-4042-b267-16dfd688fd64\", \"x\": [345.0, 345.0, 355.0, 355.0], \"xaxis\": \"x\", \"y\": [0.0, 0.63, 0.63, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 15, component: QE_2017_001816_599.40948_660.0\", \"cluster: 15, component: QE_2017_001816_599.40948_660.0\", null, null], \"type\": \"scatter\", \"uid\": \"8637cad1-3cb5-4f24-8eef-a40500388394\", \"x\": [335.0, 335.0, 350.0, 350.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6710526315789473, 0.6710526315789473, 0.63], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001816_583.41382_731.0\", \"cluster: 16, component: QE_2017_001816_583.41382_731.0\", null, null], \"type\": \"scatter\", \"uid\": \"4f17b80f-85fb-4011-bf75-252cfa66c551\", \"x\": [325.0, 325.0, 342.5, 342.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7578947368421053, 0.7578947368421053, 0.6710526315789473], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 17, component: QE_2017_001814_618.42633_695.0\", \"cluster: 17, component: QE_2017_001814_618.42633_695.0\", null, null], \"type\": \"scatter\", \"uid\": \"a0b05d30-d6c2-4aee-b43e-314f3e0998a4\", \"x\": [315.0, 315.0, 333.75, 333.75], \"xaxis\": \"x\", \"y\": [0.0, 0.8, 0.8, 0.7578947368421053], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 18, component: QE_2017_001815_618.42773_646.0\", \"cluster: 18, component: QE_2017_001815_618.42773_646.0\", \"cluster: 18, component: QE_2017_001816_618.427_682.0\", \"cluster: 18, component: QE_2017_001816_618.427_682.0\"], \"type\": \"scatter\", \"uid\": \"95c5c262-df6f-49e2-a8d5-7b9075409b40\", \"x\": [365.0, 365.0, 375.0, 375.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4732510288065844, 0.4732510288065844, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 19, component: QE_2017_001814_583.41406_682.0\", \"cluster: 19, component: QE_2017_001814_583.41406_682.0\", \"cluster: 19, component: QE_2017_001815_583.41406_707.0\", \"cluster: 19, component: QE_2017_001815_583.41406_707.0\"], \"type\": \"scatter\", \"uid\": \"6523f658-c189-4008-80c9-d3f74bcf7a75\", \"x\": [405.0, 405.0, 415.0, 415.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5280898876404494, 0.5280898876404494, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 20, component: QE_2017_001814_565.4035_722.0\", \"cluster: 20, component: QE_2017_001814_565.4035_722.0\", null, null], \"type\": \"scatter\", \"uid\": \"c4a03dc7-9902-4f4c-a430-c3c7ee4ad66e\", \"x\": [395.0, 395.0, 410.0, 410.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6049382716049383, 0.6049382716049383, 0.5280898876404494], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 21, component: QE_2017_001815_583.41388_735.0\", \"cluster: 21, component: QE_2017_001815_583.41388_735.0\", \"cluster: 21, component: QE_2017_001815_583.41418_647.0\", \"cluster: 21, component: QE_2017_001815_583.41418_647.0\"], \"type\": \"scatter\", \"uid\": \"ffadba56-cd8a-468a-b382-fb18af35d2cc\", \"x\": [435.0, 435.0, 445.0, 445.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5285714285714286, 0.5285714285714286, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 22, component: QE_2017_001814_601.42334_783.0\", \"cluster: 22, component: QE_2017_001814_601.42334_783.0\", null, null], \"type\": \"scatter\", \"uid\": \"4928515b-bb89-4b6e-9424-0d18a2a641b5\", \"x\": [425.0, 425.0, 440.0, 440.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6966292134831461, 0.6966292134831461, 0.5285714285714286], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e1696001-cfba-433a-9e4a-10c674a3cb2d\", \"x\": [402.5, 402.5, 432.5, 432.5], \"xaxis\": \"x\", \"y\": [0.6049382716049383, 0.734375, 0.734375, 0.6966292134831461], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 23, component: QE_2017_001815_568.42627_841.0\", \"cluster: 23, component: QE_2017_001815_568.42627_841.0\", null, null], \"type\": \"scatter\", \"uid\": \"ffcfc1a1-ee02-46f7-9e81-3ff4d0ae2535\", \"x\": [385.0, 385.0, 417.5, 417.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7642276422764228, 0.7642276422764228, 0.734375], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"42dc08d7-eacd-45da-adea-7626e5548785\", \"x\": [370.0, 370.0, 401.25, 401.25], \"xaxis\": \"x\", \"y\": [0.4732510288065844, 0.8205128205128205, 0.8205128205128205, 0.7642276422764228], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"39238b5a-34ed-4705-85a1-3a1e56530b51\", \"x\": [324.375, 324.375, 385.625, 385.625], \"xaxis\": \"x\", \"y\": [0.8, 0.94, 0.94, 0.8205128205128205], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"74aa5c8b-af8c-47fb-8e5c-e3b862590a0e\", \"x\": [88.7060546875, 88.7060546875, 355.0, 355.0], \"xaxis\": \"x\", \"y\": [0.9130434782608695, 0.9625, 0.9625, 0.94], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 24, component: QE_2017_001814_194.04424_237.0\", \"cluster: 24, component: QE_2017_001814_194.04424_237.0\", \"cluster: 25, component: QE_2017_001815_194.11751_218.0\", \"cluster: 25, component: QE_2017_001815_194.11751_218.0\"], \"type\": \"scatter\", \"uid\": \"303ff32a-4649-4d05-9641-1c57c77953a4\", \"x\": [455.0, 455.0, 465.0, 465.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6206896551724138, 0.6206896551724138, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001815_194.04471_314.0\", \"cluster: 26, component: QE_2017_001815_194.04471_314.0\", \"cluster: 26, component: QE_2017_001815_212.05513_328.0\", \"cluster: 26, component: QE_2017_001815_212.05513_328.0\"], \"type\": \"scatter\", \"uid\": \"9eaf03fc-7a7e-489a-9956-c820fc80ed16\", \"x\": [485.0, 485.0, 495.0, 495.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35135135135135137, 0.35135135135135137, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001815_194.04469_299.0\", \"cluster: 26, component: QE_2017_001815_194.04469_299.0\", null, null], \"type\": \"scatter\", \"uid\": \"b4be4f0c-ea24-4d7d-a0fb-8ecac923d502\", \"x\": [475.0, 475.0, 490.0, 490.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5573770491803278, 0.5573770491803278, 0.35135135135135137], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 27, component: QE_2017_001814_226.07077_397.0\", \"cluster: 27, component: QE_2017_001814_226.07077_397.0\", \"cluster: 28, component: QE_2017_001815_194.04471_397.0\", \"cluster: 28, component: QE_2017_001815_194.04471_397.0\"], \"type\": \"scatter\", \"uid\": \"835d0573-9948-41d4-9590-0cf7fdf54b5f\", \"x\": [515.0, 515.0, 525.0, 525.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6285714285714286, 0.6285714285714286, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 29, component: QE_2017_001815_212.05505_267.0\", \"cluster: 29, component: QE_2017_001815_212.05505_267.0\", null, null], \"type\": \"scatter\", \"uid\": \"78a301c3-c6d9-412f-8e65-06aabb5bb337\", \"x\": [505.0, 505.0, 520.0, 520.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7, 0.7, 0.6285714285714286], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"b0432a25-a47e-4a57-9098-9f964cd25d3d\", \"x\": [482.5, 482.5, 512.5, 512.5], \"xaxis\": \"x\", \"y\": [0.5573770491803278, 0.8360655737704918, 0.8360655737704918, 0.7], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a5e5450d-de2d-4199-800d-83a9e16e5aa0\", \"x\": [460.0, 460.0, 497.5, 497.5], \"xaxis\": \"x\", \"y\": [0.6206896551724138, 0.8548387096774194, 0.8548387096774194, 0.8360655737704918], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 30, component: QE_2017_001816_533.15442_247.0\", \"cluster: 30, component: QE_2017_001816_533.15442_247.0\", \"cluster: 30, component: QE_2017_001816_533.15466_222.0\", \"cluster: 30, component: QE_2017_001816_533.15466_222.0\"], \"type\": \"scatter\", \"uid\": \"65812167-e897-4ccf-8448-7b4d7da46eb7\", \"x\": [535.0, 535.0, 545.0, 545.0], \"xaxis\": \"x\", \"y\": [0.0, 0.36764705882352944, 0.36764705882352944, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 30, component: QE_2017_001815_533.1546_207.0\", \"cluster: 30, component: QE_2017_001815_533.1546_207.0\", \"cluster: 30, component: QE_2017_001816_533.1546_271.0\", \"cluster: 30, component: QE_2017_001816_533.1546_271.0\"], \"type\": \"scatter\", \"uid\": \"b9374d29-308d-4841-9764-f94ab1a4a270\", \"x\": [555.0, 555.0, 565.0, 565.0], \"xaxis\": \"x\", \"y\": [0.0, 0.45454545454545453, 0.45454545454545453, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8066ffcb-9877-4a27-902b-6345afd36ac9\", \"x\": [540.0, 540.0, 560.0, 560.0], \"xaxis\": \"x\", \"y\": [0.36764705882352944, 0.5, 0.5, 0.45454545454545453], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 31, component: QE_2017_001814_347.09097_122.0\", \"cluster: 31, component: QE_2017_001814_347.09097_122.0\", \"cluster: 31, component: QE_2017_001815_347.09067_204.0\", \"cluster: 31, component: QE_2017_001815_347.09067_204.0\"], \"type\": \"scatter\", \"uid\": \"4080b652-9407-48ef-b990-df6ba624c03b\", \"x\": [575.0, 575.0, 585.0, 585.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5098039215686274, 0.5098039215686274, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"4099e5f6-8daa-4ccd-9246-723f6820a43a\", \"x\": [550.0, 550.0, 580.0, 580.0], \"xaxis\": \"x\", \"y\": [0.5, 0.8804347826086957, 0.8804347826086957, 0.5098039215686274], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"d4402aa2-b910-4864-a92e-bdf2bec1b080\", \"x\": [478.75, 478.75, 565.0, 565.0], \"xaxis\": \"x\", \"y\": [0.8548387096774194, 0.9857142857142858, 0.9857142857142858, 0.8804347826086957], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 32, component: QE_2017_001815_268.10373_58.0\", \"cluster: 32, component: QE_2017_001815_268.10373_58.0\", \"cluster: 32, component: QE_2017_001816_269.16055_60.0\", \"cluster: 32, component: QE_2017_001816_269.16055_60.0\"], \"type\": \"scatter\", \"uid\": \"961d7bb5-5213-4695-9ec5-99410545ed01\", \"x\": [595.0, 595.0, 605.0, 605.0], \"xaxis\": \"x\", \"y\": [0.0, 0.42424242424242425, 0.42424242424242425, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 33, component: QE_2017_001816_408.36832_704.0\", \"cluster: 33, component: QE_2017_001816_408.36832_704.0\", \"cluster: 33, component: QE_2017_001816_466.40979_731.0\", \"cluster: 33, component: QE_2017_001816_466.40979_731.0\"], \"type\": \"scatter\", \"uid\": \"eb07649e-ec34-468a-9ff1-cf0f23cb67bc\", \"x\": [625.0, 625.0, 635.0, 635.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5882352941176471, 0.5882352941176471, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 34, component: QE_2017_001815_364.34189_705.0\", \"cluster: 34, component: QE_2017_001815_364.34189_705.0\", null, null], \"type\": \"scatter\", \"uid\": \"421bdb22-7817-4dc8-a475-cb34c57f83cb\", \"x\": [615.0, 615.0, 630.0, 630.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6875, 0.6875, 0.5882352941176471], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 35, component: QE_2017_001814_364.34244_761.0\", \"cluster: 35, component: QE_2017_001814_364.34244_761.0\", \"cluster: 35, component: QE_2017_001815_364.34253_752.0\", \"cluster: 35, component: QE_2017_001815_364.34253_752.0\"], \"type\": \"scatter\", \"uid\": \"84034198-69a7-4247-b874-6a6eb311f96a\", \"x\": [665.0, 665.0, 675.0, 675.0], \"xaxis\": \"x\", \"y\": [0.0, 0.36363636363636365, 0.36363636363636365, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 36, component: QE_2017_001816_421.35226_731.0\", \"cluster: 36, component: QE_2017_001816_421.35226_731.0\", \"cluster: 36, component: QE_2017_001816_424.36325_712.0\", \"cluster: 36, component: QE_2017_001816_424.36325_712.0\"], \"type\": \"scatter\", \"uid\": \"e9efb51f-7a46-4579-add7-51e4d8584c0f\", \"x\": [685.0, 685.0, 695.0, 695.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3888888888888889, 0.3888888888888889, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f2f568a1-d52f-43f0-a909-1bce60e32db9\", \"x\": [670.0, 670.0, 690.0, 690.0], \"xaxis\": \"x\", \"y\": [0.36363636363636365, 0.6111111111111112, 0.6111111111111112, 0.3888888888888889], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 37, component: QE_2017_001815_482.40488_739.0\", \"cluster: 37, component: QE_2017_001815_482.40488_739.0\", null, null], \"type\": \"scatter\", \"uid\": \"520d9155-70bd-44a0-bc1a-2b023c8b1d62\", \"x\": [655.0, 655.0, 680.0, 680.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7037037037037037, 0.7037037037037037, 0.6111111111111112], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 38, component: QE_2017_001815_408.36853_717.0\", \"cluster: 38, component: QE_2017_001815_408.36853_717.0\", null, null], \"type\": \"scatter\", \"uid\": \"c6d67e72-c947-4cd2-b26e-07674b41b99b\", \"x\": [645.0, 645.0, 667.5, 667.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7307692307692307, 0.7307692307692307, 0.7037037037037037], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6fbbf58e-21dd-412d-941e-5dfa0f935048\", \"x\": [622.5, 622.5, 656.25, 656.25], \"xaxis\": \"x\", \"y\": [0.6875, 0.8387096774193549, 0.8387096774193549, 0.7307692307692307], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"16c576b1-2455-444b-8fb2-b9d33fb6c53a\", \"x\": [600.0, 600.0, 639.375, 639.375], \"xaxis\": \"x\", \"y\": [0.42424242424242425, 0.9814814814814815, 0.9814814814814815, 0.8387096774193549], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 39, component: QE_2017_001814_611.15997_285.0\", \"cluster: 39, component: QE_2017_001814_611.15997_285.0\", \"cluster: 39, component: QE_2017_001815_611.16046_309.0\", \"cluster: 39, component: QE_2017_001815_611.16046_309.0\"], \"type\": \"scatter\", \"uid\": \"751aa822-63b9-42c2-8e64-473153719835\", \"x\": [715.0, 715.0, 725.0, 725.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4583333333333333, 0.4583333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 40, component: QE_2017_001814_339.10742_366.0\", \"cluster: 40, component: QE_2017_001814_339.10742_366.0\", \"cluster: 40, component: QE_2017_001816_339.10733_298.0\", \"cluster: 40, component: QE_2017_001816_339.10733_298.0\"], \"type\": \"scatter\", \"uid\": \"caa91d84-682c-41a4-880c-1174b4d8a181\", \"x\": [735.0, 735.0, 745.0, 745.0], \"xaxis\": \"x\", \"y\": [0.0, 0.44, 0.44, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001814_231.04971_516.0\", \"cluster: 41, component: QE_2017_001814_231.04971_516.0\", \"cluster: 41, component: QE_2017_001815_231.04971_369.0\", \"cluster: 41, component: QE_2017_001815_231.04971_369.0\"], \"type\": \"scatter\", \"uid\": \"fadc70f3-9212-4397-b977-6c6707861759\", \"x\": [795.0, 795.0, 805.0, 805.0], \"xaxis\": \"x\", \"y\": [0.0, 0.391304347826087, 0.391304347826087, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001815_231.04968_315.0\", \"cluster: 41, component: QE_2017_001815_231.04968_315.0\", null, null], \"type\": \"scatter\", \"uid\": \"8ae0a047-13f2-48d5-9765-2e3ed5d9f186\", \"x\": [785.0, 785.0, 800.0, 800.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4090909090909091, 0.4090909090909091, 0.391304347826087], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001815_231.04973_403.0\", \"cluster: 41, component: QE_2017_001815_231.04973_403.0\", null, null], \"type\": \"scatter\", \"uid\": \"992202bc-dd23-4d08-942e-666b86571533\", \"x\": [775.0, 775.0, 792.5, 792.5], \"xaxis\": \"x\", \"y\": [0.0, 0.52, 0.52, 0.4090909090909091], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 42, component: QE_2017_001815_340.16019_314.0\", \"cluster: 42, component: QE_2017_001815_340.16019_314.0\", null, null], \"type\": \"scatter\", \"uid\": \"9878110f-a031-4b10-82ba-8dc865c57f93\", \"x\": [765.0, 765.0, 783.75, 783.75], \"xaxis\": \"x\", \"y\": [0.0, 0.6904761904761905, 0.6904761904761905, 0.52], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 43, component: QE_2017_001815_314.14453_76.0\", \"cluster: 43, component: QE_2017_001815_314.14453_76.0\", \"cluster: 43, component: QE_2017_001816_314.14462_79.0\", \"cluster: 43, component: QE_2017_001816_314.14462_79.0\"], \"type\": \"scatter\", \"uid\": \"a4aae5e4-2ba8-494c-b0e8-ff67287d189b\", \"x\": [815.0, 815.0, 825.0, 825.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4230769230769231, 0.4230769230769231, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 44, component: QE_2017_001816_310.14957_134.0\", \"cluster: 44, component: QE_2017_001816_310.14957_134.0\", \"cluster: 45, component: QE_2017_001816_342.17584_257.0\", \"cluster: 45, component: QE_2017_001816_342.17584_257.0\"], \"type\": \"scatter\", \"uid\": \"40f1e9d2-7437-472b-90e7-3c96a89ee62e\", \"x\": [835.0, 835.0, 845.0, 845.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6785714285714286, 0.6785714285714286, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"25312a11-c94f-49e6-910a-87849279acd8\", \"x\": [820.0, 820.0, 840.0, 840.0], \"xaxis\": \"x\", \"y\": [0.4230769230769231, 0.75, 0.75, 0.6785714285714286], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f444bed9-1a5d-4b58-843e-4effaa5a6a68\", \"x\": [774.375, 774.375, 830.0, 830.0], \"xaxis\": \"x\", \"y\": [0.6904761904761905, 0.8, 0.8, 0.75], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 46, component: QE_2017_001814_498.2543_475.0\", \"cluster: 46, component: QE_2017_001814_498.2543_475.0\", null, null], \"type\": \"scatter\", \"uid\": \"d6f560f4-18ae-455a-aaef-79370c4c506c\", \"x\": [755.0, 755.0, 802.1875, 802.1875], \"xaxis\": \"x\", \"y\": [0.0, 0.8571428571428571, 0.8571428571428571, 0.8], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1c575649-5007-48f1-b26f-4442686b2b7f\", \"x\": [740.0, 740.0, 778.59375, 778.59375], \"xaxis\": \"x\", \"y\": [0.44, 0.8775510204081632, 0.8775510204081632, 0.8571428571428571], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 47, component: QE_2017_001814_241.15466_73.0\", \"cluster: 47, component: QE_2017_001814_241.15466_73.0\", \"cluster: 48, component: QE_2017_001815_507.18192_178.0\", \"cluster: 48, component: QE_2017_001815_507.18192_178.0\"], \"type\": \"scatter\", \"uid\": \"2c8cd232-3839-4a30-9ab0-06d6755d6fb5\", \"x\": [855.0, 855.0, 865.0, 865.0], \"xaxis\": \"x\", \"y\": [0.0, 0.9152542372881356, 0.9152542372881356, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bd9f4bb0-395c-4ba5-a1e0-0ef23081d634\", \"x\": [759.296875, 759.296875, 860.0, 860.0], \"xaxis\": \"x\", \"y\": [0.8775510204081632, 0.9302325581395349, 0.9302325581395349, 0.9152542372881356], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"89ce7592-8c93-4e30-bbe0-90627bc80d30\", \"x\": [720.0, 720.0, 809.6484375, 809.6484375], \"xaxis\": \"x\", \"y\": [0.4583333333333333, 0.9622641509433962, 0.9622641509433962, 0.9302325581395349], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 49, component: QE_2017_001816_463.12311_410.0\", \"cluster: 49, component: QE_2017_001816_463.12311_410.0\", null, null], \"type\": \"scatter\", \"uid\": \"dc43701c-8b19-48eb-abf6-1386bab43ff1\", \"x\": [705.0, 705.0, 764.82421875, 764.82421875], \"xaxis\": \"x\", \"y\": [0.0, 0.9696969696969697, 0.9696969696969697, 0.9622641509433962], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 50, component: QE_2017_001814_320.29456_577.0\", \"cluster: 50, component: QE_2017_001814_320.29456_577.0\", \"cluster: 50, component: QE_2017_001815_320.29471_563.0\", \"cluster: 50, component: QE_2017_001815_320.29471_563.0\"], \"type\": \"scatter\", \"uid\": \"36df440e-9736-4f98-a908-3b57c1accddf\", \"x\": [895.0, 895.0, 905.0, 905.0], \"xaxis\": \"x\", \"y\": [0.0, 0.36, 0.36, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 51, component: QE_2017_001816_338.26062_643.0\", \"cluster: 51, component: QE_2017_001816_338.26062_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"1874f32c-8df0-4558-bb45-c9401f7f6f5a\", \"x\": [885.0, 885.0, 900.0, 900.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6153846153846154, 0.6153846153846154, 0.36], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 52, component: QE_2017_001814_483.27118_651.0\", \"cluster: 52, component: QE_2017_001814_483.27118_651.0\", null, null], \"type\": \"scatter\", \"uid\": \"90aab57f-de8b-4b40-b492-b018d56fbd90\", \"x\": [875.0, 875.0, 892.5, 892.5], \"xaxis\": \"x\", \"y\": [0.0, 0.8636363636363636, 0.8636363636363636, 0.6153846153846154], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 53, component: QE_2017_001815_129.12741_349.0\", \"cluster: 53, component: QE_2017_001815_129.12741_349.0\", \"cluster: 54, component: QE_2017_001815_171.14914_420.0\", \"cluster: 54, component: QE_2017_001815_171.14914_420.0\"], \"type\": \"scatter\", \"uid\": \"41f999f5-3269-4de7-a9d8-7621cdbc08e4\", \"x\": [915.0, 915.0, 925.0, 925.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8666666666666667, 0.8666666666666667, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"05a5bdf0-37b5-4fda-afe3-7df1f130a249\", \"x\": [883.75, 883.75, 920.0, 920.0], \"xaxis\": \"x\", \"y\": [0.8636363636363636, 0.9032258064516129, 0.9032258064516129, 0.8666666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 55, component: QE_2017_001815_201.16367_442.0\", \"cluster: 55, component: QE_2017_001815_201.16367_442.0\", \"cluster: 55, component: QE_2017_001816_201.16362_435.0\", \"cluster: 55, component: QE_2017_001816_201.16362_435.0\"], \"type\": \"scatter\", \"uid\": \"3d6d6eb3-fe29-4a11-bb33-f5b93b400831\", \"x\": [935.0, 935.0, 945.0, 945.0], \"xaxis\": \"x\", \"y\": [0.0, 0.48333333333333334, 0.48333333333333334, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 56, component: QE_2017_001815_209.1535_312.0\", \"cluster: 56, component: QE_2017_001815_209.1535_312.0\", \"cluster: 56, component: QE_2017_001816_209.15344_311.0\", \"cluster: 56, component: QE_2017_001816_209.15344_311.0\"], \"type\": \"scatter\", \"uid\": \"3a00025b-d762-405c-9555-4ca8262f0a92\", \"x\": [975.0, 975.0, 985.0, 985.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2916666666666667, 0.2916666666666667, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 56, component: QE_2017_001815_209.15349_295.0\", \"cluster: 56, component: QE_2017_001815_209.15349_295.0\", null, null], \"type\": \"scatter\", \"uid\": \"4a12ae9f-e60e-4bb1-8628-dbbffa004e97\", \"x\": [965.0, 965.0, 980.0, 980.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3835616438356164, 0.3835616438356164, 0.2916666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 56, component: QE_2017_001815_209.15352_479.0\", \"cluster: 56, component: QE_2017_001815_209.15352_479.0\", null, null], \"type\": \"scatter\", \"uid\": \"c594f329-59ad-4812-a988-b99881e1b53b\", \"x\": [955.0, 955.0, 972.5, 972.5], \"xaxis\": \"x\", \"y\": [0.0, 0.4473684210526316, 0.4473684210526316, 0.3835616438356164], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 57, component: QE_2017_001814_243.15892_533.0\", \"cluster: 57, component: QE_2017_001814_243.15892_533.0\", \"cluster: 57, component: QE_2017_001814_281.1745_492.0\", \"cluster: 57, component: QE_2017_001814_281.1745_492.0\"], \"type\": \"scatter\", \"uid\": \"8ff07e0f-0217-44dc-9745-c6146f35c7af\", \"x\": [995.0, 995.0, 1005.0, 1005.0], \"xaxis\": \"x\", \"y\": [0.0, 0.359375, 0.359375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 57, component: QE_2017_001815_227.16408_344.0\", \"cluster: 57, component: QE_2017_001815_227.16408_344.0\", \"cluster: 57, component: QE_2017_001815_283.19009_564.0\", \"cluster: 57, component: QE_2017_001815_283.19009_564.0\"], \"type\": \"scatter\", \"uid\": \"6280dbd6-eb59-4629-8da2-03371b634d5f\", \"x\": [1025.0, 1025.0, 1035.0, 1035.0], \"xaxis\": \"x\", \"y\": [0.0, 0.47191011235955055, 0.47191011235955055, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 57, component: QE_2017_001814_293.2106_579.0\", \"cluster: 57, component: QE_2017_001814_293.2106_579.0\", null, null], \"type\": \"scatter\", \"uid\": \"2a513c0a-e991-42bc-a1d7-ec060733c636\", \"x\": [1015.0, 1015.0, 1030.0, 1030.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5454545454545454, 0.5454545454545454, 0.47191011235955055], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1541cc0c-8fb2-40d6-b326-42c1d42331bc\", \"x\": [1000.0, 1000.0, 1022.5, 1022.5], \"xaxis\": \"x\", \"y\": [0.359375, 0.6, 0.6, 0.5454545454545454], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"665cdcf5-e0a9-4591-9585-21306d29c4ab\", \"x\": [963.75, 963.75, 1011.25, 1011.25], \"xaxis\": \"x\", \"y\": [0.4473684210526316, 0.6494845360824743, 0.6494845360824743, 0.6], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 58, component: QE_2017_001814_227.1275_293.0\", \"cluster: 58, component: QE_2017_001814_227.1275_293.0\", \"cluster: 58, component: QE_2017_001816_227.12766_295.0\", \"cluster: 58, component: QE_2017_001816_227.12766_295.0\"], \"type\": \"scatter\", \"uid\": \"5ff60a81-bb22-4e22-a4a3-615fe4c3c557\", \"x\": [1055.0, 1055.0, 1065.0, 1065.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3382352941176471, 0.3382352941176471, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 59, component: QE_2017_001815_207.13785_297.0\", \"cluster: 59, component: QE_2017_001815_207.13785_297.0\", null, null], \"type\": \"scatter\", \"uid\": \"c5cb5acb-0f0d-4b43-8ff8-3db58412589f\", \"x\": [1045.0, 1045.0, 1060.0, 1060.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6710526315789473, 0.6710526315789473, 0.3382352941176471], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f6b5a005-604c-4ffc-9829-955396fe3068\", \"x\": [987.5, 987.5, 1052.5, 1052.5], \"xaxis\": \"x\", \"y\": [0.6494845360824743, 0.7058823529411765, 0.7058823529411765, 0.6710526315789473], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 60, component: QE_2017_001815_181.1221_767.0\", \"cluster: 60, component: QE_2017_001815_181.1221_767.0\", \"cluster: 60, component: QE_2017_001816_181.12199_794.0\", \"cluster: 60, component: QE_2017_001816_181.12199_794.0\"], \"type\": \"scatter\", \"uid\": \"e858e389-cfe4-43ed-9ec7-d231b09efc34\", \"x\": [1075.0, 1075.0, 1085.0, 1085.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001814_211.16902_440.0\", \"cluster: 61, component: QE_2017_001814_211.16902_440.0\", \"cluster: 61, component: QE_2017_001815_211.16913_450.0\", \"cluster: 61, component: QE_2017_001815_211.16913_450.0\"], \"type\": \"scatter\", \"uid\": \"25f386b3-f3a1-4688-becc-9fc35dcb1488\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"xaxis\": \"x\", \"y\": [0.0, 0.19230769230769232, 0.19230769230769232, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001815_209.0807_405.0\", \"cluster: 61, component: QE_2017_001815_209.0807_405.0\", null, null], \"type\": \"scatter\", \"uid\": \"7cd42a28-3d64-4e7e-99bc-018091162266\", \"x\": [1105.0, 1105.0, 1120.0, 1120.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21153846153846154, 0.21153846153846154, 0.19230769230769232], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001816_211.16916_405.0\", \"cluster: 61, component: QE_2017_001816_211.16916_405.0\", null, null], \"type\": \"scatter\", \"uid\": \"094e41a9-2805-47da-8722-157e66beef80\", \"x\": [1095.0, 1095.0, 1112.5, 1112.5], \"xaxis\": \"x\", \"y\": [0.0, 0.3, 0.3, 0.21153846153846154], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001815_215.164_550.0\", \"cluster: 61, component: QE_2017_001815_215.164_550.0\", \"cluster: 61, component: QE_2017_001816_215.16411_482.0\", \"cluster: 61, component: QE_2017_001816_215.16411_482.0\"], \"type\": \"scatter\", \"uid\": \"110f6976-df63-4bb2-b5db-87032224e155\", \"x\": [1135.0, 1135.0, 1145.0, 1145.0], \"xaxis\": \"x\", \"y\": [0.0, 0.48717948717948717, 0.48717948717948717, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"fa6a6d8e-cda1-451f-9094-54aa93baef7f\", \"x\": [1103.75, 1103.75, 1140.0, 1140.0], \"xaxis\": \"x\", \"y\": [0.3, 0.5818181818181818, 0.5818181818181818, 0.48717948717948717], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"d0b7f65a-4e3c-48dc-8d8c-97174e9c0e50\", \"x\": [1080.0, 1080.0, 1121.875, 1121.875], \"xaxis\": \"x\", \"y\": [0.2857142857142857, 0.7446808510638298, 0.7446808510638298, 0.5818181818181818], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8222f0f0-cfa0-4157-8307-abf6697f434d\", \"x\": [1020.0, 1020.0, 1100.9375, 1100.9375], \"xaxis\": \"x\", \"y\": [0.7058823529411765, 0.7631578947368421, 0.7631578947368421, 0.7446808510638298], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 62, component: QE_2017_001814_219.17416_517.0\", \"cluster: 62, component: QE_2017_001814_219.17416_517.0\", \"cluster: 62, component: QE_2017_001815_219.17421_516.0\", \"cluster: 62, component: QE_2017_001815_219.17421_516.0\"], \"type\": \"scatter\", \"uid\": \"ebbf26f9-172e-4ddf-b15a-1382cb8667d1\", \"x\": [1165.0, 1165.0, 1175.0, 1175.0], \"xaxis\": \"x\", \"y\": [0.0, 0.25, 0.25, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 62, component: QE_2017_001814_219.17401_452.0\", \"cluster: 62, component: QE_2017_001814_219.17401_452.0\", \"cluster: 62, component: QE_2017_001814_219.17409_442.0\", \"cluster: 62, component: QE_2017_001814_219.17409_442.0\"], \"type\": \"scatter\", \"uid\": \"beb0e4c3-eca1-4391-888d-49519b17a249\", \"x\": [1195.0, 1195.0, 1205.0, 1205.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3125, 0.3125, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 62, component: QE_2017_001816_219.17438_502.0\", \"cluster: 62, component: QE_2017_001816_219.17438_502.0\", null, null], \"type\": \"scatter\", \"uid\": \"d2e098b9-a676-472f-9cb6-b0b63f049e35\", \"x\": [1185.0, 1185.0, 1200.0, 1200.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4074074074074074, 0.4074074074074074, 0.3125], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"68aa5bf2-0ab6-41db-8c5b-9ddab16380aa\", \"x\": [1170.0, 1170.0, 1192.5, 1192.5], \"xaxis\": \"x\", \"y\": [0.25, 0.4583333333333333, 0.4583333333333333, 0.4074074074074074], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 63, component: QE_2017_001815_191.14287_312.0\", \"cluster: 63, component: QE_2017_001815_191.14287_312.0\", \"cluster: 63, component: QE_2017_001816_191.14291_404.0\", \"cluster: 63, component: QE_2017_001816_191.14291_404.0\"], \"type\": \"scatter\", \"uid\": \"3e7ad572-23f3-443a-a826-c7bc4226acd3\", \"x\": [1225.0, 1225.0, 1235.0, 1235.0], \"xaxis\": \"x\", \"y\": [0.0, 0.43103448275862066, 0.43103448275862066, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 63, component: QE_2017_001814_191.14291_389.0\", \"cluster: 63, component: QE_2017_001814_191.14291_389.0\", null, null], \"type\": \"scatter\", \"uid\": \"baf83267-e8eb-4415-80fa-b1030e3945be\", \"x\": [1215.0, 1215.0, 1230.0, 1230.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5, 0.5, 0.43103448275862066], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ba8da630-76af-4c0d-adaa-47dfcf16e22a\", \"x\": [1181.25, 1181.25, 1222.5, 1222.5], \"xaxis\": \"x\", \"y\": [0.4583333333333333, 0.68, 0.68, 0.5], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 64, component: QE_2017_001816_137.09584_445.0\", \"cluster: 64, component: QE_2017_001816_137.09584_445.0\", null, null], \"type\": \"scatter\", \"uid\": \"0baf791a-4143-40d4-ba2f-47c9b8fc5b3e\", \"x\": [1155.0, 1155.0, 1201.875, 1201.875], \"xaxis\": \"x\", \"y\": [0.0, 0.782608695652174, 0.782608695652174, 0.68], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e5e89287-1279-4fcb-8c31-6d46077eefdd\", \"x\": [1060.46875, 1060.46875, 1178.4375, 1178.4375], \"xaxis\": \"x\", \"y\": [0.7631578947368421, 0.8170731707317073, 0.8170731707317073, 0.782608695652174], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f0989e32-a00c-4716-9658-823f6e4314aa\", \"x\": [940.0, 940.0, 1119.453125, 1119.453125], \"xaxis\": \"x\", \"y\": [0.48333333333333334, 0.8421052631578947, 0.8421052631578947, 0.8170731707317073], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 65, component: QE_2017_001814_209.08058_363.0\", \"cluster: 65, component: QE_2017_001814_209.08058_363.0\", \"cluster: 66, component: QE_2017_001816_207.13779_561.0\", \"cluster: 66, component: QE_2017_001816_207.13779_561.0\"], \"type\": \"scatter\", \"uid\": \"fb40fbb1-d07c-4c50-a219-2b42ff08c3c5\", \"x\": [1245.0, 1245.0, 1255.0, 1255.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8556701030927835, 0.8556701030927835, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"95f04ad4-f476-459c-acac-b7fda7b516f0\", \"x\": [1029.7265625, 1029.7265625, 1250.0, 1250.0], \"xaxis\": \"x\", \"y\": [0.8421052631578947, 0.9135802469135802, 0.9135802469135802, 0.8556701030927835], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"530f5e31-78ff-4a4b-b606-79cbce6d8dab\", \"x\": [901.875, 901.875, 1139.86328125, 1139.86328125], \"xaxis\": \"x\", \"y\": [0.9032258064516129, 0.9882352941176471, 0.9882352941176471, 0.9135802469135802], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 67, component: QE_2017_001815_333.15173_245.0\", \"cluster: 67, component: QE_2017_001815_333.15173_245.0\", \"cluster: 68, component: QE_2017_001816_333.15204_235.0\", \"cluster: 68, component: QE_2017_001816_333.15204_235.0\"], \"type\": \"scatter\", \"uid\": \"231b1738-bb36-42f9-af19-e15072155009\", \"x\": [1265.0, 1265.0, 1275.0, 1275.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8461538461538461, 0.8461538461538461, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 69, component: QE_2017_001814_194.1174_244.0\", \"cluster: 69, component: QE_2017_001814_194.1174_244.0\", \"cluster: 70, component: QE_2017_001816_194.11746_133.0\", \"cluster: 70, component: QE_2017_001816_194.11746_133.0\"], \"type\": \"scatter\", \"uid\": \"c63b9f4b-7c32-4ca7-8951-b54a6268a671\", \"x\": [1285.0, 1285.0, 1295.0, 1295.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7142857142857143, 0.7142857142857143, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 71, component: QE_2017_001814_320.29471_529.0\", \"cluster: 71, component: QE_2017_001814_320.29471_529.0\", \"cluster: 71, component: QE_2017_001815_320.29486_538.0\", \"cluster: 71, component: QE_2017_001815_320.29486_538.0\"], \"type\": \"scatter\", \"uid\": \"3ecdacfd-a0be-4e41-ac64-af8fe1c5f3d1\", \"x\": [1335.0, 1335.0, 1345.0, 1345.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 71, component: QE_2017_001814_320.29477_539.0\", \"cluster: 71, component: QE_2017_001814_320.29477_539.0\", null, null], \"type\": \"scatter\", \"uid\": \"4c6302f8-e246-4401-aa6a-4cb09ff51337\", \"x\": [1325.0, 1325.0, 1340.0, 1340.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5833333333333334, 0.5833333333333334, 0.4444444444444444], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 72, component: QE_2017_001814_320.29468_638.0\", \"cluster: 72, component: QE_2017_001814_320.29468_638.0\", null, null], \"type\": \"scatter\", \"uid\": \"fabfc28f-6315-415d-b94c-f8d53ea0ad8e\", \"x\": [1315.0, 1315.0, 1332.5, 1332.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7857142857142857, 0.7857142857142857, 0.5833333333333334], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 73, component: QE_2017_001816_320.29483_548.0\", \"cluster: 73, component: QE_2017_001816_320.29483_548.0\", null, null], \"type\": \"scatter\", \"uid\": \"817cffe1-07d1-4d7e-ba0e-af95add250a1\", \"x\": [1305.0, 1305.0, 1323.75, 1323.75], \"xaxis\": \"x\", \"y\": [0.0, 0.9393939393939394, 0.9393939393939394, 0.7857142857142857], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bd0420df-117a-4c65-b62a-167d9a837ec8\", \"x\": [1290.0, 1290.0, 1314.375, 1314.375], \"xaxis\": \"x\", \"y\": [0.7142857142857143, 0.9523809523809523, 0.9523809523809523, 0.9393939393939394], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 74, component: QE_2017_001814_241.15384_47.0\", \"cluster: 74, component: QE_2017_001814_241.15384_47.0\", \"cluster: 75, component: QE_2017_001814_241.15446_57.0\", \"cluster: 75, component: QE_2017_001814_241.15446_57.0\"], \"type\": \"scatter\", \"uid\": \"28c709f8-8a55-4ccd-b63c-7167c9fb25e2\", \"x\": [1355.0, 1355.0, 1365.0, 1365.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6363636363636364, 0.6363636363636364, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 76, component: QE_2017_001815_332.25827_508.0\", \"cluster: 76, component: QE_2017_001815_332.25827_508.0\", \"cluster: 77, component: QE_2017_001816_332.25842_487.0\", \"cluster: 77, component: QE_2017_001816_332.25842_487.0\"], \"type\": \"scatter\", \"uid\": \"f734a232-453d-4a70-99d1-6e4342960c74\", \"x\": [1385.0, 1385.0, 1395.0, 1395.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6829268292682927, 0.6829268292682927, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 78, component: QE_2017_001814_332.25827_467.0\", \"cluster: 78, component: QE_2017_001814_332.25827_467.0\", null, null], \"type\": \"scatter\", \"uid\": \"bf3ff2c3-f880-4688-b7be-6f91c795522a\", \"x\": [1375.0, 1375.0, 1390.0, 1390.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8, 0.8, 0.6829268292682927], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"b66abfa6-4a97-442b-abc1-2991c60418fc\", \"x\": [1360.0, 1360.0, 1382.5, 1382.5], \"xaxis\": \"x\", \"y\": [0.6363636363636364, 0.9666666666666667, 0.9666666666666667, 0.8], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"9b5ef1cf-5f30-4d88-9f28-836308c61b2b\", \"x\": [1302.1875, 1302.1875, 1371.25, 1371.25], \"xaxis\": \"x\", \"y\": [0.9523809523809523, 0.9772727272727273, 0.9772727272727273, 0.9666666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 79, component: QE_2017_001814_319.13638_117.0\", \"cluster: 79, component: QE_2017_001814_319.13638_117.0\", \"cluster: 80, component: QE_2017_001816_319.13614_143.0\", \"cluster: 80, component: QE_2017_001816_319.13614_143.0\"], \"type\": \"scatter\", \"uid\": \"10feeb61-5475-4fe3-8af4-eb1963c37209\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"xaxis\": \"x\", \"y\": [0.0, 0.75, 0.75, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 81, component: QE_2017_001815_219.10139_360.0\", \"cluster: 81, component: QE_2017_001815_219.10139_360.0\", \"cluster: 81, component: QE_2017_001816_219.10153_382.0\", \"cluster: 81, component: QE_2017_001816_219.10153_382.0\"], \"type\": \"scatter\", \"uid\": \"a47b62d5-ef31-42db-8806-34becca136b2\", \"x\": [1445.0, 1445.0, 1455.0, 1455.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38181818181818183, 0.38181818181818183, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 81, component: QE_2017_001815_219.10159_438.0\", \"cluster: 81, component: QE_2017_001815_219.10159_438.0\", null, null], \"type\": \"scatter\", \"uid\": \"2355d43c-2925-4d64-af2a-24d211b1b498\", \"x\": [1435.0, 1435.0, 1450.0, 1450.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4647887323943662, 0.4647887323943662, 0.38181818181818183], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 82, component: QE_2017_001814_251.09117_393.0\", \"cluster: 82, component: QE_2017_001814_251.09117_393.0\", null, null], \"type\": \"scatter\", \"uid\": \"3049eb15-ed0d-4faa-a370-142b280c52cc\", \"x\": [1425.0, 1425.0, 1442.5, 1442.5], \"xaxis\": \"x\", \"y\": [0.0, 0.6527777777777778, 0.6527777777777778, 0.4647887323943662], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 83, component: QE_2017_001814_291.1442_241.0\", \"cluster: 83, component: QE_2017_001814_291.1442_241.0\", \"cluster: 83, component: QE_2017_001816_291.14493_243.0\", \"cluster: 83, component: QE_2017_001816_291.14493_243.0\"], \"type\": \"scatter\", \"uid\": \"3c97be12-f5df-47ee-9270-cb4bd1e8f9d2\", \"x\": [1465.0, 1465.0, 1475.0, 1475.0], \"xaxis\": \"x\", \"y\": [0.0, 0.37037037037037035, 0.37037037037037035, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 83, component: QE_2017_001815_273.13425_199.0\", \"cluster: 83, component: QE_2017_001815_273.13425_199.0\", \"cluster: 83, component: QE_2017_001815_273.13434_243.0\", \"cluster: 83, component: QE_2017_001815_273.13434_243.0\"], \"type\": \"scatter\", \"uid\": \"6e2503b9-92dd-499c-8cc1-9714ff3760a5\", \"x\": [1495.0, 1495.0, 1505.0, 1505.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 83, component: QE_2017_001816_291.14499_200.0\", \"cluster: 83, component: QE_2017_001816_291.14499_200.0\", null, null], \"type\": \"scatter\", \"uid\": \"9608a52f-ba47-4a23-a30a-cab644ec51ef\", \"x\": [1485.0, 1485.0, 1500.0, 1500.0], \"xaxis\": \"x\", \"y\": [0.0, 0.41935483870967744, 0.41935483870967744, 0.3333333333333333], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7170ba61-54c4-4857-9c38-bf4504231584\", \"x\": [1470.0, 1470.0, 1492.5, 1492.5], \"xaxis\": \"x\", \"y\": [0.37037037037037035, 0.5161290322580645, 0.5161290322580645, 0.41935483870967744], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 84, component: QE_2017_001815_235.14398_226.0\", \"cluster: 84, component: QE_2017_001815_235.14398_226.0\", \"cluster: 84, component: QE_2017_001816_235.14397_183.0\", \"cluster: 84, component: QE_2017_001816_235.14397_183.0\"], \"type\": \"scatter\", \"uid\": \"552f6683-3294-43ad-a1c2-d75a6d828d96\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5263157894736842, 0.5263157894736842, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 85, component: QE_2017_001815_251.13873_202.0\", \"cluster: 85, component: QE_2017_001815_251.13873_202.0\", null, null], \"type\": \"scatter\", \"uid\": \"5abe2fb0-b1cb-417f-9d21-d099d07c3854\", \"x\": [1515.0, 1515.0, 1530.0, 1530.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8636363636363636, 0.8636363636363636, 0.5263157894736842], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"b7deb902-914f-4113-9dd8-b06dff2bbc67\", \"x\": [1481.25, 1481.25, 1522.5, 1522.5], \"xaxis\": \"x\", \"y\": [0.5161290322580645, 0.9166666666666666, 0.9166666666666666, 0.8636363636363636], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3fb249f1-d3e5-4d90-92f0-ad731c4eaabd\", \"x\": [1433.75, 1433.75, 1501.875, 1501.875], \"xaxis\": \"x\", \"y\": [0.6527777777777778, 0.9891304347826086, 0.9891304347826086, 0.9166666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 86, component: QE_2017_001814_250.10149_516.0\", \"cluster: 86, component: QE_2017_001814_250.10149_516.0\", \"cluster: 86, component: QE_2017_001815_222.07033_315.0\", \"cluster: 86, component: QE_2017_001815_222.07033_315.0\"], \"type\": \"scatter\", \"uid\": \"a81e492d-3fc6-4f81-821a-7ac2f0c79036\", \"x\": [1565.0, 1565.0, 1575.0, 1575.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5081967213114754, 0.5081967213114754, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 87, component: QE_2017_001816_268.59351_445.0\", \"cluster: 87, component: QE_2017_001816_268.59351_445.0\", null, null], \"type\": \"scatter\", \"uid\": \"24795bac-a546-4efc-bc44-bda11cce0350\", \"x\": [1555.0, 1555.0, 1570.0, 1570.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6923076923076923, 0.6923076923076923, 0.5081967213114754], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 88, component: QE_2017_001814_247.05975_245.0\", \"cluster: 88, component: QE_2017_001814_247.05975_245.0\", \"cluster: 88, component: QE_2017_001815_247.0598_242.0\", \"cluster: 88, component: QE_2017_001815_247.0598_242.0\"], \"type\": \"scatter\", \"uid\": \"2b8097ba-9dac-4fb3-b87f-019a3bd6eb40\", \"x\": [1585.0, 1585.0, 1595.0, 1595.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35294117647058826, 0.35294117647058826, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 89, component: QE_2017_001815_212.03883_181.0\", \"cluster: 89, component: QE_2017_001815_212.03883_181.0\", \"cluster: 90, component: QE_2017_001815_214.56488_409.0\", \"cluster: 90, component: QE_2017_001815_214.56488_409.0\"], \"type\": \"scatter\", \"uid\": \"d8016126-931f-4807-bb61-cffc864cadfb\", \"x\": [1615.0, 1615.0, 1625.0, 1625.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7777777777777778, 0.7777777777777778, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 91, component: QE_2017_001816_219.04672_291.0\", \"cluster: 91, component: QE_2017_001816_219.04672_291.0\", null, null], \"type\": \"scatter\", \"uid\": \"7e43b627-1e4e-4909-8acc-d042bc7328d1\", \"x\": [1605.0, 1605.0, 1620.0, 1620.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8125, 0.8125, 0.7777777777777778], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"d4a33903-f9ab-4ddc-83d0-15a14fa3725d\", \"x\": [1590.0, 1590.0, 1612.5, 1612.5], \"xaxis\": \"x\", \"y\": [0.35294117647058826, 0.8571428571428571, 0.8571428571428571, 0.8125], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5bd96641-912d-49b6-a786-5d97a55e9a5d\", \"x\": [1562.5, 1562.5, 1601.25, 1601.25], \"xaxis\": \"x\", \"y\": [0.6923076923076923, 0.9178082191780822, 0.9178082191780822, 0.8571428571428571], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 92, component: QE_2017_001815_214.51021_60.0\", \"cluster: 92, component: QE_2017_001815_214.51021_60.0\", null, null], \"type\": \"scatter\", \"uid\": \"50cfe987-9710-4085-b1cb-079f7159aa5a\", \"x\": [1545.0, 1545.0, 1581.875, 1581.875], \"xaxis\": \"x\", \"y\": [0.0, 0.9534883720930233, 0.9534883720930233, 0.9178082191780822], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 93, component: QE_2017_001815_246.14465_137.0\", \"cluster: 93, component: QE_2017_001815_246.14465_137.0\", \"cluster: 93, component: QE_2017_001815_247.12865_158.0\", \"cluster: 93, component: QE_2017_001815_247.12865_158.0\"], \"type\": \"scatter\", \"uid\": \"daebe4dd-2146-4a5c-bb9d-d0d4fb3316b9\", \"x\": [1655.0, 1655.0, 1665.0, 1665.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5, 0.5, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 94, component: QE_2017_001814_260.16037_143.0\", \"cluster: 94, component: QE_2017_001814_260.16037_143.0\", \"cluster: 94, component: QE_2017_001816_260.16022_145.0\", \"cluster: 94, component: QE_2017_001816_260.16022_145.0\"], \"type\": \"scatter\", \"uid\": \"6f57de8f-c15f-4f13-b653-ba964948831b\", \"x\": [1675.0, 1675.0, 1685.0, 1685.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 95, component: QE_2017_001814_233.14948_126.0\", \"cluster: 95, component: QE_2017_001814_233.14948_126.0\", \"cluster: 95, component: QE_2017_001816_233.14955_129.0\", \"cluster: 95, component: QE_2017_001816_233.14955_129.0\"], \"type\": \"scatter\", \"uid\": \"94af2bd6-8e1e-4847-95f4-6aab35401380\", \"x\": [1705.0, 1705.0, 1715.0, 1715.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2631578947368421, 0.2631578947368421, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 95, component: QE_2017_001814_233.14957_152.0\", \"cluster: 95, component: QE_2017_001814_233.14957_152.0\", null, null], \"type\": \"scatter\", \"uid\": \"ba9abddf-53df-4980-b448-f4e10a5dcbc8\", \"x\": [1695.0, 1695.0, 1710.0, 1710.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5416666666666666, 0.5416666666666666, 0.2631578947368421], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f27e5229-4c42-483a-84b7-01f68e4bce86\", \"x\": [1680.0, 1680.0, 1702.5, 1702.5], \"xaxis\": \"x\", \"y\": [0.2857142857142857, 0.8648648648648649, 0.8648648648648649, 0.5416666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7196db0e-8340-4913-aef3-bcc9b89f5934\", \"x\": [1660.0, 1660.0, 1691.25, 1691.25], \"xaxis\": \"x\", \"y\": [0.5, 0.9574468085106383, 0.9574468085106383, 0.8648648648648649], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 96, component: QE_2017_001816_132.04436_283.0\", \"cluster: 96, component: QE_2017_001816_132.04436_283.0\", null, null], \"type\": \"scatter\", \"uid\": \"3c66acef-c1ad-456a-bea7-d00351063361\", \"x\": [1645.0, 1645.0, 1675.625, 1675.625], \"xaxis\": \"x\", \"y\": [0.0, 0.98, 0.98, 0.9574468085106383], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 97, component: QE_2017_001815_260.16016_64.0\", \"cluster: 97, component: QE_2017_001815_260.16016_64.0\", null, null], \"type\": \"scatter\", \"uid\": \"6057e9aa-dc72-4730-abb1-3fa69ff53f75\", \"x\": [1635.0, 1635.0, 1660.3125, 1660.3125], \"xaxis\": \"x\", \"y\": [0.0, 0.9846153846153847, 0.9846153846153847, 0.98], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 98, component: QE_2017_001815_221.12837_99.0\", \"cluster: 98, component: QE_2017_001815_221.12837_99.0\", \"cluster: 99, component: QE_2017_001816_237.12325_171.0\", \"cluster: 99, component: QE_2017_001816_237.12325_171.0\"], \"type\": \"scatter\", \"uid\": \"26bd3fe7-3597-46a6-beaa-e17ac2698647\", \"x\": [1725.0, 1725.0, 1735.0, 1735.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7142857142857143, 0.7142857142857143, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 100, component: QE_2017_001814_237.12305_220.0\", \"cluster: 100, component: QE_2017_001814_237.12305_220.0\", \"cluster: 101, component: QE_2017_001816_237.12323_53.0\", \"cluster: 101, component: QE_2017_001816_237.12323_53.0\"], \"type\": \"scatter\", \"uid\": \"cccb2398-4790-4f8c-89c0-a9c736656cd7\", \"x\": [1745.0, 1745.0, 1755.0, 1755.0], \"xaxis\": \"x\", \"y\": [0.0, 0.9444444444444444, 0.9444444444444444, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e73cdf1f-3e81-4298-806e-927943d12155\", \"x\": [1730.0, 1730.0, 1750.0, 1750.0], \"xaxis\": \"x\", \"y\": [0.7142857142857143, 0.9761904761904762, 0.9761904761904762, 0.9444444444444444], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 102, component: QE_2017_001814_229.15399_46.0\", \"cluster: 102, component: QE_2017_001814_229.15399_46.0\", \"cluster: 102, component: QE_2017_001816_229.15451_66.0\", \"cluster: 102, component: QE_2017_001816_229.15451_66.0\"], \"type\": \"scatter\", \"uid\": \"70b5900a-6e4b-4b73-8760-a8dad87bcecd\", \"x\": [1775.0, 1775.0, 1785.0, 1785.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38461538461538464, 0.38461538461538464, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 103, component: QE_2017_001816_229.15469_52.0\", \"cluster: 103, component: QE_2017_001816_229.15469_52.0\", null, null], \"type\": \"scatter\", \"uid\": \"948e88ff-45f2-4a16-8341-a8a8f42d6353\", \"x\": [1765.0, 1765.0, 1780.0, 1780.0], \"xaxis\": \"x\", \"y\": [0.0, 0.875, 0.875, 0.38461538461538464], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 104, component: QE_2017_001814_182.08116_51.0\", \"cluster: 104, component: QE_2017_001814_182.08116_51.0\", \"cluster: 104, component: QE_2017_001816_182.08116_55.0\", \"cluster: 104, component: QE_2017_001816_182.08116_55.0\"], \"type\": \"scatter\", \"uid\": \"ad05809e-3e9b-4fe8-9f7e-7450e53a3254\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4375, 0.4375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 105, component: QE_2017_001815_194.04474_330.0\", \"cluster: 105, component: QE_2017_001815_194.04474_330.0\", \"cluster: 105, component: QE_2017_001816_212.05518_300.0\", \"cluster: 105, component: QE_2017_001816_212.05518_300.0\"], \"type\": \"scatter\", \"uid\": \"c8abdd3f-e9ea-45c8-855b-00a1e335ae06\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5370370370370371, 0.5370370370370371, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"567f0bee-735d-42ae-9efb-e5bec8be12d4\", \"x\": [1800.0, 1800.0, 1820.0, 1820.0], \"xaxis\": \"x\", \"y\": [0.4375, 0.921875, 0.921875, 0.5370370370370371], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 106, component: QE_2017_001814_177.05418_236.0\", \"cluster: 106, component: QE_2017_001814_177.05418_236.0\", \"cluster: 106, component: QE_2017_001815_177.05444_307.0\", \"cluster: 106, component: QE_2017_001815_177.05444_307.0\"], \"type\": \"scatter\", \"uid\": \"dfe58b8b-f102-4f0b-a0a4-8335e9b69530\", \"x\": [1845.0, 1845.0, 1855.0, 1855.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35, 0.35, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 106, component: QE_2017_001816_177.05449_217.0\", \"cluster: 106, component: QE_2017_001816_177.05449_217.0\", null, null], \"type\": \"scatter\", \"uid\": \"448fe3b8-7277-4042-821c-64c191e86be5\", \"x\": [1835.0, 1835.0, 1850.0, 1850.0], \"xaxis\": \"x\", \"y\": [0.0, 0.391304347826087, 0.391304347826087, 0.35], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001816_199.98769_294.0\", \"cluster: 107, component: QE_2017_001816_199.98769_294.0\", \"cluster: 107, component: QE_2017_001816_199.98776_304.0\", \"cluster: 107, component: QE_2017_001816_199.98776_304.0\"], \"type\": \"scatter\", \"uid\": \"a03c1eba-f4b4-4f05-87fb-93004af7c606\", \"x\": [1865.0, 1865.0, 1875.0, 1875.0], \"xaxis\": \"x\", \"y\": [0.0, 0.34146341463414637, 0.34146341463414637, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001814_199.98778_290.0\", \"cluster: 107, component: QE_2017_001814_199.98778_290.0\", \"cluster: 107, component: QE_2017_001815_199.98779_30.0\", \"cluster: 107, component: QE_2017_001815_199.98779_30.0\"], \"type\": \"scatter\", \"uid\": \"64c99d82-df3d-41ae-a771-16d7f218a923\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3, 0.3, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001815_199.98772_326.0\", \"cluster: 107, component: QE_2017_001815_199.98772_326.0\", \"cluster: 107, component: QE_2017_001816_199.98781_313.0\", \"cluster: 107, component: QE_2017_001816_199.98781_313.0\"], \"type\": \"scatter\", \"uid\": \"2e46930e-2a15-4154-a0de-2408f0d36cdd\", \"x\": [1905.0, 1905.0, 1915.0, 1915.0], \"xaxis\": \"x\", \"y\": [0.0, 0.18181818181818182, 0.18181818181818182, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001816_199.98776_254.0\", \"cluster: 107, component: QE_2017_001816_199.98776_254.0\", \"cluster: 107, component: QE_2017_001816_199.98779_335.0\", \"cluster: 107, component: QE_2017_001816_199.98779_335.0\"], \"type\": \"scatter\", \"uid\": \"f0bfb459-3927-44ff-80ed-efc6a354bb82\", \"x\": [1935.0, 1935.0, 1945.0, 1945.0], \"xaxis\": \"x\", \"y\": [0.0, 0.25, 0.25, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001816_199.98772_359.0\", \"cluster: 107, component: QE_2017_001816_199.98772_359.0\", null, null], \"type\": \"scatter\", \"uid\": \"e049032c-b76c-40a0-9e84-a19771a26b2a\", \"x\": [1925.0, 1925.0, 1940.0, 1940.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3125, 0.3125, 0.25], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1b79f9a5-072c-4f38-a0b5-dc9c16c76bc4\", \"x\": [1910.0, 1910.0, 1932.5, 1932.5], \"xaxis\": \"x\", \"y\": [0.18181818181818182, 0.36363636363636365, 0.36363636363636365, 0.3125], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"11873e5b-77d0-487a-a03c-d58ac4f982fd\", \"x\": [1890.0, 1890.0, 1921.25, 1921.25], \"xaxis\": \"x\", \"y\": [0.3, 0.42424242424242425, 0.42424242424242425, 0.36363636363636365], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ff619d44-3c5c-4412-b107-8251ee78f6df\", \"x\": [1870.0, 1870.0, 1905.625, 1905.625], \"xaxis\": \"x\", \"y\": [0.34146341463414637, 0.47368421052631576, 0.47368421052631576, 0.42424242424242425], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"86912212-6bd8-4f74-9550-a466ef738eab\", \"x\": [1842.5, 1842.5, 1887.8125, 1887.8125], \"xaxis\": \"x\", \"y\": [0.391304347826087, 0.8214285714285714, 0.8214285714285714, 0.47368421052631576], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 108, component: QE_2017_001815_463.12268_358.0\", \"cluster: 108, component: QE_2017_001815_463.12268_358.0\", \"cluster: 109, component: QE_2017_001815_625.17633_345.0\", \"cluster: 109, component: QE_2017_001815_625.17633_345.0\"], \"type\": \"scatter\", \"uid\": \"dda5fa07-016f-4e15-be9b-5dd5729bf9eb\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6774193548387096, 0.6774193548387096, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 110, component: QE_2017_001815_595.16559_315.0\", \"cluster: 110, component: QE_2017_001815_595.16559_315.0\", null, null], \"type\": \"scatter\", \"uid\": \"fdeef6c0-d170-43b4-afca-bd7a79b1a423\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8947368421052632, 0.8947368421052632, 0.6774193548387096], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 111, component: QE_2017_001815_141.0508_33.0\", \"cluster: 111, component: QE_2017_001815_141.0508_33.0\", \"cluster: 112, component: QE_2017_001815_265.01532_33.0\", \"cluster: 112, component: QE_2017_001815_265.01532_33.0\"], \"type\": \"scatter\", \"uid\": \"0ba2f81a-615d-48c2-837e-96f1ed41e02b\", \"x\": [1995.0, 1995.0, 2005.0, 2005.0], \"xaxis\": \"x\", \"y\": [0.0, 1.0, 1.0, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"997f7054-2959-430d-8922-aed32738d7bf\", \"x\": [1972.5, 1972.5, 2000.0, 2000.0], \"xaxis\": \"x\", \"y\": [0.8947368421052632, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 113, component: QE_2017_001815_797.51746_866.0\", \"cluster: 113, component: QE_2017_001815_797.51746_866.0\", null, null], \"type\": \"scatter\", \"uid\": \"0813b1a0-0379-4bb1-97c5-2ce71ff944cd\", \"x\": [1955.0, 1955.0, 1986.25, 1986.25], \"xaxis\": \"x\", \"y\": [0.0, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"04414b54-b483-423e-9dc9-5abef8285bc1\", \"x\": [1865.15625, 1865.15625, 1970.625, 1970.625], \"xaxis\": \"x\", \"y\": [0.8214285714285714, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"b675180e-f583-4aa1-8ed4-145575db1ace\", \"x\": [1810.0, 1810.0, 1917.890625, 1917.890625], \"xaxis\": \"x\", \"y\": [0.921875, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1ac659de-0a2b-4449-9816-cdfd3be4623d\", \"x\": [1772.5, 1772.5, 1863.9453125, 1863.9453125], \"xaxis\": \"x\", \"y\": [0.875, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"287d739b-d949-4274-ae46-960f4cf20be1\", \"x\": [1740.0, 1740.0, 1818.22265625, 1818.22265625], \"xaxis\": \"x\", \"y\": [0.9761904761904762, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"9ade7596-61ee-40d8-bbdf-ca6437fe7d88\", \"x\": [1647.65625, 1647.65625, 1779.111328125, 1779.111328125], \"xaxis\": \"x\", \"y\": [0.9846153846153847, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bcaca387-8773-41bd-a0ae-e1031072f6d1\", \"x\": [1563.4375, 1563.4375, 1713.3837890625, 1713.3837890625], \"xaxis\": \"x\", \"y\": [0.9534883720930233, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"aaa33d71-bd3a-4c37-a128-7d2e3e354793\", \"x\": [1467.8125, 1467.8125, 1638.41064453125, 1638.41064453125], \"xaxis\": \"x\", \"y\": [0.9891304347826086, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f2ed0bc5-6028-4bfa-8186-2730ad92a1cb\", \"x\": [1410.0, 1410.0, 1553.111572265625, 1553.111572265625], \"xaxis\": \"x\", \"y\": [0.75, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bbe407b3-517e-45bb-a52c-85b1739108aa\", \"x\": [1336.71875, 1336.71875, 1481.5557861328125, 1481.5557861328125], \"xaxis\": \"x\", \"y\": [0.9772727272727273, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"784b86ac-9ba0-43e1-aa1f-17d79f310f8a\", \"x\": [1270.0, 1270.0, 1409.1372680664062, 1409.1372680664062], \"xaxis\": \"x\", \"y\": [0.8461538461538461, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"2b97299a-bb34-470d-a2ad-76384084c5df\", \"x\": [1020.869140625, 1020.869140625, 1339.5686340332031, 1339.5686340332031], \"xaxis\": \"x\", \"y\": [0.9882352941176471, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"188dbb0c-f099-4904-8465-30a3904c6868\", \"x\": [734.912109375, 734.912109375, 1180.2188873291016, 1180.2188873291016], \"xaxis\": \"x\", \"y\": [0.9696969696969697, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a2ef48bb-de3a-4d73-804f-2fb1828026ba\", \"x\": [619.6875, 619.6875, 957.5654983520508, 957.5654983520508], \"xaxis\": \"x\", \"y\": [0.9814814814814815, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e467ad8e-9765-4a04-9f6c-a9174900f8d2\", \"x\": [521.875, 521.875, 788.6264991760254, 788.6264991760254], \"xaxis\": \"x\", \"y\": [0.9857142857142858, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"46d0cfc8-a36d-4bb6-ab2f-f59f8bedfd06\", \"x\": [221.85302734375, 221.85302734375, 655.2507495880127, 655.2507495880127], \"xaxis\": \"x\", \"y\": [0.9625, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}],\n",
+       "                        {\"autosize\": false, \"height\": 700, \"hovermode\": \"closest\", \"margin\": {\"b\": 372}, \"showlegend\": false, \"title\": {\"text\": \"Component clusters. method = jaccard, cutoff = 0.6, threshold = 0.0008\"}, \"width\": 800, \"xaxis\": {\"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showgrid\": false, \"showline\": true, \"showticklabels\": true, \"tickmode\": \"array\", \"ticks\": \"outside\", \"ticktext\": [\"QE_2017_001816_613.4826_738.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001816_792.56232_718.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001815_792.5625_866.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001816_571.47186_717.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001815_278.24762_684.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001816_599.40948_660.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001815_194.11751_218.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001816_408.36832_704.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001815_364.34253_752.0\", \"QE_2017_001816_421.35226_731.0\", \"QE_2017_001816_424.36325_712.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001815_611.16046_309.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001815_231.04973_403.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001814_241.15466_73.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001815_129.12741_349.0\", \"QE_2017_001815_171.14914_420.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001815_209.15352_479.0\", \"QE_2017_001815_209.15349_295.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001816_215.16411_482.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17421_516.0\", \"QE_2017_001816_219.17438_502.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001816_194.11746_133.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001815_320.29486_538.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001814_319.13638_117.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001816_219.10153_382.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001816_291.14493_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001815_251.13873_202.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001816_235.14397_183.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001815_222.07033_315.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001815_247.12865_158.0\", \"QE_2017_001814_260.16037_143.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001814_233.14957_152.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001816_237.12323_53.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001816_229.15451_66.0\", \"QE_2017_001814_182.08116_51.0\", \"QE_2017_001816_182.08116_55.0\", \"QE_2017_001815_194.04474_330.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001816_199.98776_304.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001816_199.98776_254.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_265.01532_33.0\"], \"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0, 1995.0, 2005.0], \"title\": {\"text\": \"Components\"}, \"type\": \"linear\", \"zeroline\": false}, \"yaxis\": {\"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showgrid\": false, \"showline\": true, \"showticklabels\": true, \"ticks\": \"outside\", \"title\": {\"text\": \"Distance\"}, \"type\": \"linear\", \"zeroline\": false}},\n",
+       "                        {\"showLink\": false, \"linkText\": \"Export to plot.ly\", \"plotlyServerURL\": \"https://plot.ly\"}\n",
+       "                    )\n",
+       "                };\n",
+       "                });\n",
+       "            </script>\n",
+       "        </div>"
       ]
      },
      "metadata": {},
@@ -6189,16 +7604,6341 @@
     }
    ],
    "source": [
-    "plotly.offline.init_notebook_mode(connected=True) # for visualising plot inline\n",
+    "# Make it a bit smaller this time\n",
+    "iplot = tree.plot(width=800, height=700)\n",
+    "\n",
+    "# for visualising plot inline\n",
+    "# You only need to set connected to True once per notebook,\n",
+    "# but doing it multiple times won't hurt.\n",
+    "plotly.offline.init_notebook_mode(connected=True)\n",
+    "\n",
     "plotly.offline.iplot(iplot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rolling over the leaf nodes with your mouse you'll be able to see which cluster each component belongs to, so you can then track it down in your results folder.\n",
+    "\n",
+    "The `plot` method is just a wrapper around the `dendrogram` function in `BioDendro.plot.dendrogram`.\n",
+    "If you want to customise your plot e.g. with custom titles, you can do that there.\n",
+    "\n",
+    "The `dendrogram` function is a modified version of plotlys [`figure_factory.create_dendrogram`](https://plot.ly/python/dendrogram/) function.\n",
+    "It is modified to reduce complexity, to handle text-rollover and to allow us to provide precomputed trees rather than having to recompute the tree each time (possibly yielding different trees and different clusters)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "linkText": "Export to plot.ly",
+        "plotlyServerURL": "https://plot.ly",
+        "showLink": false
+       },
+       "data": [
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 1, component: QE_2017_001816_613.48218_838.0",
+          "cluster: 1, component: QE_2017_001816_613.48218_838.0",
+          "cluster: 1, component: QE_2017_001816_792.56232_718.0",
+          "cluster: 1, component: QE_2017_001816_792.56232_718.0"
+         ],
+         "type": "scatter",
+         "uid": "16a34e0f-8bf0-4d86-b1f5-d9ba92aac9da",
+         "x": [
+          15,
+          15,
+          25,
+          25
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5662650602409639,
+          0.5662650602409639,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001816_613.4826_738.0",
+          "cluster: 2, component: QE_2017_001816_613.4826_738.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0ba82f9a-16a0-4d27-8d36-220c2d599bba",
+         "x": [
+          5,
+          5,
+          20,
+          20
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.676923076923077,
+          0.676923076923077,
+          0.5662650602409639
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 3, component: QE_2017_001814_596.30963_602.0",
+          "cluster: 3, component: QE_2017_001814_596.30963_602.0",
+          "cluster: 4, component: QE_2017_001815_792.5625_866.0",
+          "cluster: 4, component: QE_2017_001815_792.5625_866.0"
+         ],
+         "type": "scatter",
+         "uid": "0ad11e16-b343-4ba8-b1ce-1f07ed77392e",
+         "x": [
+          35,
+          35,
+          45,
+          45
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7142857142857143,
+          0.7142857142857143,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8dbb81a2-29f4-47c8-830f-f36868fdb008",
+         "x": [
+          12.5,
+          12.5,
+          40,
+          40
+         ],
+         "xaxis": "x",
+         "y": [
+          0.676923076923077,
+          0.7763157894736842,
+          0.7763157894736842,
+          0.7142857142857143
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25784_608.0",
+          "cluster: 5, component: QE_2017_001814_335.25784_608.0",
+          "cluster: 5, component: QE_2017_001816_335.25772_723.0",
+          "cluster: 5, component: QE_2017_001816_335.25772_723.0"
+         ],
+         "type": "scatter",
+         "uid": "3355afad-bbf5-4f26-9fc2-64e92ca0d501",
+         "x": [
+          105,
+          105,
+          115,
+          115
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.26,
+          0.26,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25772_725.0",
+          "cluster: 5, component: QE_2017_001814_335.25772_725.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8e60b35f-f1d8-41be-b306-b4434044715b",
+         "x": [
+          95,
+          95,
+          110,
+          110
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2830188679245283,
+          0.2830188679245283,
+          0.26
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25784_628.0",
+          "cluster: 5, component: QE_2017_001814_335.25784_628.0",
+          "cluster: 5, component: QE_2017_001815_335.25745_642.0",
+          "cluster: 5, component: QE_2017_001815_335.25745_642.0"
+         ],
+         "type": "scatter",
+         "uid": "2b1a450a-17a5-4d98-a0d4-9fbd46f96e72",
+         "x": [
+          125,
+          125,
+          135,
+          135
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2857142857142857,
+          0.2857142857142857,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8545612a-a409-409b-be21-1cb7829b0f17",
+         "x": [
+          102.5,
+          102.5,
+          130,
+          130
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2830188679245283,
+          0.3389830508474576,
+          0.3389830508474576,
+          0.2857142857142857
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_261.22073_634.0",
+          "cluster: 5, component: QE_2017_001814_261.22073_634.0",
+          "cluster: 5, component: QE_2017_001815_335.25784_587.0",
+          "cluster: 5, component: QE_2017_001815_335.25784_587.0"
+         ],
+         "type": "scatter",
+         "uid": "9bf05e19-4512-4515-8e50-64b9a194a877",
+         "x": [
+          145,
+          145,
+          155,
+          155
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.375,
+          0.375,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e4a2b0db-670e-4463-9a79-6cb3bb84b1c2",
+         "x": [
+          116.25,
+          116.25,
+          150,
+          150
+         ],
+         "xaxis": "x",
+         "y": [
+          0.3389830508474576,
+          0.4117647058823529,
+          0.4117647058823529,
+          0.375
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_353.26889_609.0",
+          "cluster: 5, component: QE_2017_001814_353.26889_609.0",
+          "cluster: 5, component: QE_2017_001815_353.26862_642.0",
+          "cluster: 5, component: QE_2017_001815_353.26862_642.0"
+         ],
+         "type": "scatter",
+         "uid": "3e447dd5-32b0-4e73-8c1c-47e9aafdce3b",
+         "x": [
+          165,
+          165,
+          175,
+          175
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.27419354838709675,
+          0.27419354838709675,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_335.25772_638.0",
+          "cluster: 5, component: QE_2017_001814_335.25772_638.0",
+          "cluster: 5, component: QE_2017_001815_335.2579_601.0",
+          "cluster: 5, component: QE_2017_001815_335.2579_601.0"
+         ],
+         "type": "scatter",
+         "uid": "1fcec506-6a8b-4ced-9a52-17d9b9dd536f",
+         "x": [
+          195,
+          195,
+          205,
+          205
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.29411764705882354,
+          0.29411764705882354,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001815_261.22073_643.0",
+          "cluster: 5, component: QE_2017_001815_261.22073_643.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "062ab1e2-ddd4-45d2-8952-1dda05fcd8e0",
+         "x": [
+          185,
+          185,
+          200,
+          200
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.38461538461538464,
+          0.38461538461538464,
+          0.29411764705882354
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1d1d71cf-10da-4324-861f-0c89b2225348",
+         "x": [
+          170,
+          170,
+          192.5,
+          192.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.27419354838709675,
+          0.43333333333333335,
+          0.43333333333333335,
+          0.38461538461538464
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9d519bee-e42b-49a5-a063-023322f70b92",
+         "x": [
+          133.125,
+          133.125,
+          181.25,
+          181.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4117647058823529,
+          0.46153846153846156,
+          0.46153846153846156,
+          0.43333333333333335
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001816_571.47186_717.0",
+          "cluster: 5, component: QE_2017_001816_571.47186_717.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ed91735f-403e-4bb4-a596-fef9a94af9e6",
+         "x": [
+          85,
+          85,
+          157.1875,
+          157.1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5538461538461539,
+          0.5538461538461539,
+          0.46153846153846156
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001815_507.27145_607.0",
+          "cluster: 5, component: QE_2017_001815_507.27145_607.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f7c80057-05c6-4e1d-8299-9cb44bb5465e",
+         "x": [
+          75,
+          75,
+          121.09375,
+          121.09375
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5737704918032787,
+          0.5737704918032787,
+          0.5538461538461539
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 6, component: QE_2017_001814_497.31033_643.0",
+          "cluster: 6, component: QE_2017_001814_497.31033_643.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "42585e9f-7208-4f84-ba46-52c153a4c35f",
+         "x": [
+          65,
+          65,
+          98.046875,
+          98.046875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6986301369863014,
+          0.6986301369863014,
+          0.5737704918032787
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 7, component: QE_2017_001815_571.4292_870.0",
+          "cluster: 7, component: QE_2017_001815_571.4292_870.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "61412610-ec68-4a15-87fd-e79470ec8e8f",
+         "x": [
+          55,
+          55,
+          81.5234375,
+          81.5234375
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7962962962962963,
+          0.7962962962962963,
+          0.6986301369863014
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 8, component: QE_2017_001814_338.34146_850.0",
+          "cluster: 8, component: QE_2017_001814_338.34146_850.0",
+          "cluster: 9, component: QE_2017_001815_244.19048_762.0",
+          "cluster: 9, component: QE_2017_001815_244.19048_762.0"
+         ],
+         "type": "scatter",
+         "uid": "9207f81f-0811-427a-9958-5d306777027a",
+         "x": [
+          225,
+          225,
+          235,
+          235
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6031746031746031,
+          0.6031746031746031,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 10, component: QE_2017_001814_353.26868_633.0",
+          "cluster: 10, component: QE_2017_001814_353.26868_633.0",
+          "cluster: 10, component: QE_2017_001816_353.26892_600.0",
+          "cluster: 10, component: QE_2017_001816_353.26892_600.0"
+         ],
+         "type": "scatter",
+         "uid": "1429f309-b1da-4c8f-9e16-2e50d6f32345",
+         "x": [
+          245,
+          245,
+          255,
+          255
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2376237623762376,
+          0.2376237623762376,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 10, component: QE_2017_001814_279.23157_719.0",
+          "cluster: 10, component: QE_2017_001814_279.23157_719.0",
+          "cluster: 10, component: QE_2017_001815_278.24762_684.0",
+          "cluster: 10, component: QE_2017_001815_278.24762_684.0"
+         ],
+         "type": "scatter",
+         "uid": "5f14e6e6-50d2-43a9-b7f6-a8369b546f87",
+         "x": [
+          265,
+          265,
+          275,
+          275
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.43209876543209874,
+          0.43209876543209874,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a2416765-df7d-49ef-8266-d75e985bb3a0",
+         "x": [
+          250,
+          250,
+          270,
+          270
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2376237623762376,
+          0.5229357798165137,
+          0.5229357798165137,
+          0.43209876543209874
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 11, component: QE_2017_001816_337.27338_826.0",
+          "cluster: 11, component: QE_2017_001816_337.27338_826.0",
+          "cluster: 11, component: QE_2017_001816_337.27341_632.0",
+          "cluster: 11, component: QE_2017_001816_337.27341_632.0"
+         ],
+         "type": "scatter",
+         "uid": "c0fa253d-ffcf-4dbe-859c-88048492b82c",
+         "x": [
+          295,
+          295,
+          305,
+          305
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.373134328358209,
+          0.373134328358209,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 11, component: QE_2017_001816_435.25037_666.0",
+          "cluster: 11, component: QE_2017_001816_435.25037_666.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5097db8a-a487-42fb-ae36-f57333c4aa16",
+         "x": [
+          285,
+          285,
+          300,
+          300
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5416666666666666,
+          0.5416666666666666,
+          0.373134328358209
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8b9472d6-03e5-42b2-95c0-3142f294bd85",
+         "x": [
+          260,
+          260,
+          292.5,
+          292.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5229357798165137,
+          0.6875,
+          0.6875,
+          0.5416666666666666
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9974abcb-3251-4fcb-9e20-d364aa671d71",
+         "x": [
+          230,
+          230,
+          276.25,
+          276.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6031746031746031,
+          0.7590361445783133,
+          0.7590361445783133,
+          0.6875
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 12, component: QE_2017_001816_272.25824_582.0",
+          "cluster: 12, component: QE_2017_001816_272.25824_582.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "04c2ace1-8683-4fdd-b748-6c94f24e2457",
+         "x": [
+          215,
+          215,
+          253.125,
+          253.125
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8243243243243243,
+          0.8243243243243243,
+          0.7590361445783133
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0841e9bc-90f9-4a13-bf35-abcd593a3a33",
+         "x": [
+          68.26171875,
+          68.26171875,
+          234.0625,
+          234.0625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7962962962962963,
+          0.87,
+          0.87,
+          0.8243243243243243
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a2a2d254-62d2-42b0-a465-2f7a3aa14d4b",
+         "x": [
+          26.25,
+          26.25,
+          151.162109375,
+          151.162109375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7763157894736842,
+          0.9130434782608695,
+          0.9130434782608695,
+          0.87
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 13, component: QE_2017_001814_601.42426_706.0",
+          "cluster: 13, component: QE_2017_001814_601.42426_706.0",
+          "cluster: 14, component: QE_2017_001816_599.40869_793.0",
+          "cluster: 14, component: QE_2017_001816_599.40869_793.0"
+         ],
+         "type": "scatter",
+         "uid": "0e4e76ee-1357-4f26-9a17-34e73dd3d526",
+         "x": [
+          345,
+          345,
+          355,
+          355
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.63,
+          0.63,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 15, component: QE_2017_001816_599.40948_660.0",
+          "cluster: 15, component: QE_2017_001816_599.40948_660.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3736d7fe-fdc4-4950-b7d9-3e12c79c4f6d",
+         "x": [
+          335,
+          335,
+          350,
+          350
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6710526315789473,
+          0.6710526315789473,
+          0.63
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001816_583.41382_731.0",
+          "cluster: 16, component: QE_2017_001816_583.41382_731.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "61d810d0-d6cf-47f0-8b48-2b3721e885ec",
+         "x": [
+          325,
+          325,
+          342.5,
+          342.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7578947368421053,
+          0.7578947368421053,
+          0.6710526315789473
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 17, component: QE_2017_001814_618.42633_695.0",
+          "cluster: 17, component: QE_2017_001814_618.42633_695.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "d5627fbd-08ef-4b82-a177-62fdd902d327",
+         "x": [
+          315,
+          315,
+          333.75,
+          333.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8,
+          0.8,
+          0.7578947368421053
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 18, component: QE_2017_001815_618.42773_646.0",
+          "cluster: 18, component: QE_2017_001815_618.42773_646.0",
+          "cluster: 18, component: QE_2017_001816_618.427_682.0",
+          "cluster: 18, component: QE_2017_001816_618.427_682.0"
+         ],
+         "type": "scatter",
+         "uid": "0d77ec14-8f14-45fa-b608-c9a4d7d62293",
+         "x": [
+          365,
+          365,
+          375,
+          375
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4732510288065844,
+          0.4732510288065844,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 19, component: QE_2017_001814_583.41406_682.0",
+          "cluster: 19, component: QE_2017_001814_583.41406_682.0",
+          "cluster: 19, component: QE_2017_001815_583.41406_707.0",
+          "cluster: 19, component: QE_2017_001815_583.41406_707.0"
+         ],
+         "type": "scatter",
+         "uid": "3537c558-eeba-43ed-8054-c702121674e6",
+         "x": [
+          405,
+          405,
+          415,
+          415
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5280898876404494,
+          0.5280898876404494,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 20, component: QE_2017_001814_565.4035_722.0",
+          "cluster: 20, component: QE_2017_001814_565.4035_722.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4ad2a32a-1918-40c6-bdfc-21306b381ab2",
+         "x": [
+          395,
+          395,
+          410,
+          410
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6049382716049383,
+          0.6049382716049383,
+          0.5280898876404494
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 21, component: QE_2017_001815_583.41388_735.0",
+          "cluster: 21, component: QE_2017_001815_583.41388_735.0",
+          "cluster: 21, component: QE_2017_001815_583.41418_647.0",
+          "cluster: 21, component: QE_2017_001815_583.41418_647.0"
+         ],
+         "type": "scatter",
+         "uid": "d19e4169-9405-4a46-a6c3-7812d46c214c",
+         "x": [
+          435,
+          435,
+          445,
+          445
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5285714285714286,
+          0.5285714285714286,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 22, component: QE_2017_001814_601.42334_783.0",
+          "cluster: 22, component: QE_2017_001814_601.42334_783.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "fc6899b7-a2cb-4700-82cc-0acc6dbb5603",
+         "x": [
+          425,
+          425,
+          440,
+          440
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6966292134831461,
+          0.6966292134831461,
+          0.5285714285714286
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "40ec49c3-ca5f-4cca-a713-8b730d5fa456",
+         "x": [
+          402.5,
+          402.5,
+          432.5,
+          432.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6049382716049383,
+          0.734375,
+          0.734375,
+          0.6966292134831461
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 23, component: QE_2017_001815_568.42627_841.0",
+          "cluster: 23, component: QE_2017_001815_568.42627_841.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1a5d315c-b2cf-45f7-a5f8-f0bfec367cca",
+         "x": [
+          385,
+          385,
+          417.5,
+          417.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7642276422764228,
+          0.7642276422764228,
+          0.734375
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c49e9d05-473b-4c67-8b06-76f1a7e5bcad",
+         "x": [
+          370,
+          370,
+          401.25,
+          401.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4732510288065844,
+          0.8205128205128205,
+          0.8205128205128205,
+          0.7642276422764228
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0e56f651-2019-40f6-bc54-bd29cd053fa1",
+         "x": [
+          324.375,
+          324.375,
+          385.625,
+          385.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8,
+          0.94,
+          0.94,
+          0.8205128205128205
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7fee64e3-63d3-4a66-ae10-e900fb4fcda5",
+         "x": [
+          88.7060546875,
+          88.7060546875,
+          355,
+          355
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9130434782608695,
+          0.9625,
+          0.9625,
+          0.94
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 24, component: QE_2017_001814_194.04424_237.0",
+          "cluster: 24, component: QE_2017_001814_194.04424_237.0",
+          "cluster: 25, component: QE_2017_001815_194.11751_218.0",
+          "cluster: 25, component: QE_2017_001815_194.11751_218.0"
+         ],
+         "type": "scatter",
+         "uid": "07391b72-c7e1-4a42-9b01-3407b1fc96b8",
+         "x": [
+          455,
+          455,
+          465,
+          465
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6206896551724138,
+          0.6206896551724138,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 26, component: QE_2017_001815_194.04471_314.0",
+          "cluster: 26, component: QE_2017_001815_194.04471_314.0",
+          "cluster: 26, component: QE_2017_001815_212.05513_328.0",
+          "cluster: 26, component: QE_2017_001815_212.05513_328.0"
+         ],
+         "type": "scatter",
+         "uid": "fa270db1-00b9-45de-a210-c0252a2cfd1e",
+         "x": [
+          485,
+          485,
+          495,
+          495
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.35135135135135137,
+          0.35135135135135137,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 26, component: QE_2017_001815_194.04469_299.0",
+          "cluster: 26, component: QE_2017_001815_194.04469_299.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ed411c82-266f-49ac-a9fb-ace8b2e025d7",
+         "x": [
+          475,
+          475,
+          490,
+          490
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5573770491803278,
+          0.5573770491803278,
+          0.35135135135135137
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 27, component: QE_2017_001814_226.07077_397.0",
+          "cluster: 27, component: QE_2017_001814_226.07077_397.0",
+          "cluster: 28, component: QE_2017_001815_194.04471_397.0",
+          "cluster: 28, component: QE_2017_001815_194.04471_397.0"
+         ],
+         "type": "scatter",
+         "uid": "909ca41f-2566-4a42-89aa-efb2f18e1502",
+         "x": [
+          515,
+          515,
+          525,
+          525
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6285714285714286,
+          0.6285714285714286,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 29, component: QE_2017_001815_212.05505_267.0",
+          "cluster: 29, component: QE_2017_001815_212.05505_267.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "74608047-6bdb-451d-8ce0-865d08af8061",
+         "x": [
+          505,
+          505,
+          520,
+          520
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7,
+          0.7,
+          0.6285714285714286
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3b8ba927-c8bc-4016-b978-d5df5bb6b693",
+         "x": [
+          482.5,
+          482.5,
+          512.5,
+          512.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5573770491803278,
+          0.8360655737704918,
+          0.8360655737704918,
+          0.7
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6193e6d5-2b6b-4d61-b493-99a4f8d802b1",
+         "x": [
+          460,
+          460,
+          497.5,
+          497.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6206896551724138,
+          0.8548387096774194,
+          0.8548387096774194,
+          0.8360655737704918
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 30, component: QE_2017_001816_533.15442_247.0",
+          "cluster: 30, component: QE_2017_001816_533.15442_247.0",
+          "cluster: 30, component: QE_2017_001816_533.15466_222.0",
+          "cluster: 30, component: QE_2017_001816_533.15466_222.0"
+         ],
+         "type": "scatter",
+         "uid": "32eb220d-543d-4492-bd83-2c9bda32f65a",
+         "x": [
+          535,
+          535,
+          545,
+          545
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.36764705882352944,
+          0.36764705882352944,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 30, component: QE_2017_001815_533.1546_207.0",
+          "cluster: 30, component: QE_2017_001815_533.1546_207.0",
+          "cluster: 30, component: QE_2017_001816_533.1546_271.0",
+          "cluster: 30, component: QE_2017_001816_533.1546_271.0"
+         ],
+         "type": "scatter",
+         "uid": "1f43b1a7-eb0c-4154-a57f-6b82dcdda97a",
+         "x": [
+          555,
+          555,
+          565,
+          565
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.45454545454545453,
+          0.45454545454545453,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "02354338-b660-4a3b-9f85-19851c89f92f",
+         "x": [
+          540,
+          540,
+          560,
+          560
+         ],
+         "xaxis": "x",
+         "y": [
+          0.36764705882352944,
+          0.5,
+          0.5,
+          0.45454545454545453
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 31, component: QE_2017_001814_347.09097_122.0",
+          "cluster: 31, component: QE_2017_001814_347.09097_122.0",
+          "cluster: 31, component: QE_2017_001815_347.09067_204.0",
+          "cluster: 31, component: QE_2017_001815_347.09067_204.0"
+         ],
+         "type": "scatter",
+         "uid": "4eb358b6-c972-4a05-9b80-f721966947f6",
+         "x": [
+          575,
+          575,
+          585,
+          585
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5098039215686274,
+          0.5098039215686274,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c21c3562-e183-42f9-8ce1-ee98cf07a045",
+         "x": [
+          550,
+          550,
+          580,
+          580
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5,
+          0.8804347826086957,
+          0.8804347826086957,
+          0.5098039215686274
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "59af21fa-12c1-4018-a171-647a8506249a",
+         "x": [
+          478.75,
+          478.75,
+          565,
+          565
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8548387096774194,
+          0.9857142857142858,
+          0.9857142857142858,
+          0.8804347826086957
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 32, component: QE_2017_001815_268.10373_58.0",
+          "cluster: 32, component: QE_2017_001815_268.10373_58.0",
+          "cluster: 32, component: QE_2017_001816_269.16055_60.0",
+          "cluster: 32, component: QE_2017_001816_269.16055_60.0"
+         ],
+         "type": "scatter",
+         "uid": "2d40de2b-d480-43af-970b-bf1920b8fb59",
+         "x": [
+          595,
+          595,
+          605,
+          605
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.42424242424242425,
+          0.42424242424242425,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 33, component: QE_2017_001816_408.36832_704.0",
+          "cluster: 33, component: QE_2017_001816_408.36832_704.0",
+          "cluster: 33, component: QE_2017_001816_466.40979_731.0",
+          "cluster: 33, component: QE_2017_001816_466.40979_731.0"
+         ],
+         "type": "scatter",
+         "uid": "387472a2-30f8-4683-82f2-3b4101ec524f",
+         "x": [
+          625,
+          625,
+          635,
+          635
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5882352941176471,
+          0.5882352941176471,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 34, component: QE_2017_001815_364.34189_705.0",
+          "cluster: 34, component: QE_2017_001815_364.34189_705.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "28126b6b-ef55-433a-9571-0fef7448f5a5",
+         "x": [
+          615,
+          615,
+          630,
+          630
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6875,
+          0.6875,
+          0.5882352941176471
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 35, component: QE_2017_001814_364.34244_761.0",
+          "cluster: 35, component: QE_2017_001814_364.34244_761.0",
+          "cluster: 35, component: QE_2017_001815_364.34253_752.0",
+          "cluster: 35, component: QE_2017_001815_364.34253_752.0"
+         ],
+         "type": "scatter",
+         "uid": "4d75a787-f2be-40e0-8db3-9e2221fe1e5c",
+         "x": [
+          665,
+          665,
+          675,
+          675
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.36363636363636365,
+          0.36363636363636365,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 36, component: QE_2017_001816_421.35226_731.0",
+          "cluster: 36, component: QE_2017_001816_421.35226_731.0",
+          "cluster: 36, component: QE_2017_001816_424.36325_712.0",
+          "cluster: 36, component: QE_2017_001816_424.36325_712.0"
+         ],
+         "type": "scatter",
+         "uid": "f6318128-7620-40bc-8d0f-5b1940377175",
+         "x": [
+          685,
+          685,
+          695,
+          695
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3888888888888889,
+          0.3888888888888889,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "343fdbf2-f812-4fa4-b658-1afbc12a2228",
+         "x": [
+          670,
+          670,
+          690,
+          690
+         ],
+         "xaxis": "x",
+         "y": [
+          0.36363636363636365,
+          0.6111111111111112,
+          0.6111111111111112,
+          0.3888888888888889
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 37, component: QE_2017_001815_482.40488_739.0",
+          "cluster: 37, component: QE_2017_001815_482.40488_739.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "429fa6b6-de67-4903-8266-9ba8fb231c67",
+         "x": [
+          655,
+          655,
+          680,
+          680
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7037037037037037,
+          0.7037037037037037,
+          0.6111111111111112
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 38, component: QE_2017_001815_408.36853_717.0",
+          "cluster: 38, component: QE_2017_001815_408.36853_717.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "cae5fac8-b0f0-410a-9050-2b13d7f5cb0b",
+         "x": [
+          645,
+          645,
+          667.5,
+          667.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7307692307692307,
+          0.7307692307692307,
+          0.7037037037037037
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a82419f3-d635-4915-af4e-c8974536f318",
+         "x": [
+          622.5,
+          622.5,
+          656.25,
+          656.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6875,
+          0.8387096774193549,
+          0.8387096774193549,
+          0.7307692307692307
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6449808b-92df-4e8c-809d-0a58b936cfe9",
+         "x": [
+          600,
+          600,
+          639.375,
+          639.375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.42424242424242425,
+          0.9814814814814815,
+          0.9814814814814815,
+          0.8387096774193549
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 39, component: QE_2017_001814_611.15997_285.0",
+          "cluster: 39, component: QE_2017_001814_611.15997_285.0",
+          "cluster: 39, component: QE_2017_001815_611.16046_309.0",
+          "cluster: 39, component: QE_2017_001815_611.16046_309.0"
+         ],
+         "type": "scatter",
+         "uid": "833d8299-d19b-4856-9096-d42f78c3991f",
+         "x": [
+          715,
+          715,
+          725,
+          725
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4583333333333333,
+          0.4583333333333333,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 40, component: QE_2017_001814_339.10742_366.0",
+          "cluster: 40, component: QE_2017_001814_339.10742_366.0",
+          "cluster: 40, component: QE_2017_001816_339.10733_298.0",
+          "cluster: 40, component: QE_2017_001816_339.10733_298.0"
+         ],
+         "type": "scatter",
+         "uid": "000a0f68-e082-4eda-9b2e-78723e3552a5",
+         "x": [
+          735,
+          735,
+          745,
+          745
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.44,
+          0.44,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001814_231.04971_516.0",
+          "cluster: 41, component: QE_2017_001814_231.04971_516.0",
+          "cluster: 41, component: QE_2017_001815_231.04971_369.0",
+          "cluster: 41, component: QE_2017_001815_231.04971_369.0"
+         ],
+         "type": "scatter",
+         "uid": "97311b60-c624-41d0-9e52-952ac1e0f2b9",
+         "x": [
+          795,
+          795,
+          805,
+          805
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.391304347826087,
+          0.391304347826087,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001815_231.04968_315.0",
+          "cluster: 41, component: QE_2017_001815_231.04968_315.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a96cf2e9-ab09-492d-acac-434ffad2556a",
+         "x": [
+          785,
+          785,
+          800,
+          800
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4090909090909091,
+          0.4090909090909091,
+          0.391304347826087
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001815_231.04973_403.0",
+          "cluster: 41, component: QE_2017_001815_231.04973_403.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c311156c-f42c-4425-91e4-77c723787d5b",
+         "x": [
+          775,
+          775,
+          792.5,
+          792.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.52,
+          0.52,
+          0.4090909090909091
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 42, component: QE_2017_001815_340.16019_314.0",
+          "cluster: 42, component: QE_2017_001815_340.16019_314.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ce8ce332-a2d3-4e60-892f-f3e13611fcc2",
+         "x": [
+          765,
+          765,
+          783.75,
+          783.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6904761904761905,
+          0.6904761904761905,
+          0.52
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 43, component: QE_2017_001815_314.14453_76.0",
+          "cluster: 43, component: QE_2017_001815_314.14453_76.0",
+          "cluster: 43, component: QE_2017_001816_314.14462_79.0",
+          "cluster: 43, component: QE_2017_001816_314.14462_79.0"
+         ],
+         "type": "scatter",
+         "uid": "9edc3234-6e73-403f-b9f3-31cae73581dc",
+         "x": [
+          815,
+          815,
+          825,
+          825
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4230769230769231,
+          0.4230769230769231,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 44, component: QE_2017_001816_310.14957_134.0",
+          "cluster: 44, component: QE_2017_001816_310.14957_134.0",
+          "cluster: 45, component: QE_2017_001816_342.17584_257.0",
+          "cluster: 45, component: QE_2017_001816_342.17584_257.0"
+         ],
+         "type": "scatter",
+         "uid": "789d7026-6a59-42d9-8c7e-5aa761c2a983",
+         "x": [
+          835,
+          835,
+          845,
+          845
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6785714285714286,
+          0.6785714285714286,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9c2cb6f2-3713-4e9b-bfe7-2837063a0c8a",
+         "x": [
+          820,
+          820,
+          840,
+          840
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4230769230769231,
+          0.75,
+          0.75,
+          0.6785714285714286
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "66d958de-9f3c-4fb1-b4f9-00d042e16124",
+         "x": [
+          774.375,
+          774.375,
+          830,
+          830
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6904761904761905,
+          0.8,
+          0.8,
+          0.75
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 46, component: QE_2017_001814_498.2543_475.0",
+          "cluster: 46, component: QE_2017_001814_498.2543_475.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "354eb417-88a6-4c9e-a678-fe0b7515bb9d",
+         "x": [
+          755,
+          755,
+          802.1875,
+          802.1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8571428571428571,
+          0.8571428571428571,
+          0.8
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e18f5f12-421a-441d-8354-b1df31163e80",
+         "x": [
+          740,
+          740,
+          778.59375,
+          778.59375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.44,
+          0.8775510204081632,
+          0.8775510204081632,
+          0.8571428571428571
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 47, component: QE_2017_001814_241.15466_73.0",
+          "cluster: 47, component: QE_2017_001814_241.15466_73.0",
+          "cluster: 48, component: QE_2017_001815_507.18192_178.0",
+          "cluster: 48, component: QE_2017_001815_507.18192_178.0"
+         ],
+         "type": "scatter",
+         "uid": "b84e4ee5-b99a-4433-ae30-0f51f3fce9b9",
+         "x": [
+          855,
+          855,
+          865,
+          865
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9152542372881356,
+          0.9152542372881356,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "fc52ebe2-2a1b-41dd-85a2-5f553bb888a7",
+         "x": [
+          759.296875,
+          759.296875,
+          860,
+          860
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8775510204081632,
+          0.9302325581395349,
+          0.9302325581395349,
+          0.9152542372881356
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "feeb019b-d472-4217-b2d3-8332d38dbe48",
+         "x": [
+          720,
+          720,
+          809.6484375,
+          809.6484375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4583333333333333,
+          0.9622641509433962,
+          0.9622641509433962,
+          0.9302325581395349
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 49, component: QE_2017_001816_463.12311_410.0",
+          "cluster: 49, component: QE_2017_001816_463.12311_410.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3d4c8e6b-e155-4272-b506-477dcd9a1554",
+         "x": [
+          705,
+          705,
+          764.82421875,
+          764.82421875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9696969696969697,
+          0.9696969696969697,
+          0.9622641509433962
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 50, component: QE_2017_001814_320.29456_577.0",
+          "cluster: 50, component: QE_2017_001814_320.29456_577.0",
+          "cluster: 50, component: QE_2017_001815_320.29471_563.0",
+          "cluster: 50, component: QE_2017_001815_320.29471_563.0"
+         ],
+         "type": "scatter",
+         "uid": "c3f28023-6cae-4234-b6f6-954d7c0bcc61",
+         "x": [
+          895,
+          895,
+          905,
+          905
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.36,
+          0.36,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 51, component: QE_2017_001816_338.26062_643.0",
+          "cluster: 51, component: QE_2017_001816_338.26062_643.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "04c76eb4-fe96-4dee-88a5-46d7a7f75ff3",
+         "x": [
+          885,
+          885,
+          900,
+          900
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6153846153846154,
+          0.6153846153846154,
+          0.36
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 52, component: QE_2017_001814_483.27118_651.0",
+          "cluster: 52, component: QE_2017_001814_483.27118_651.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a4e57a4d-07be-477a-89c4-d6b1388e4cf0",
+         "x": [
+          875,
+          875,
+          892.5,
+          892.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8636363636363636,
+          0.8636363636363636,
+          0.6153846153846154
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 53, component: QE_2017_001815_129.12741_349.0",
+          "cluster: 53, component: QE_2017_001815_129.12741_349.0",
+          "cluster: 54, component: QE_2017_001815_171.14914_420.0",
+          "cluster: 54, component: QE_2017_001815_171.14914_420.0"
+         ],
+         "type": "scatter",
+         "uid": "36911040-cd7d-427c-8f72-53d3b991c868",
+         "x": [
+          915,
+          915,
+          925,
+          925
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8666666666666667,
+          0.8666666666666667,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "99142d2f-3d6c-419d-963e-3e589c8dd465",
+         "x": [
+          883.75,
+          883.75,
+          920,
+          920
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8636363636363636,
+          0.9032258064516129,
+          0.9032258064516129,
+          0.8666666666666667
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 55, component: QE_2017_001815_201.16367_442.0",
+          "cluster: 55, component: QE_2017_001815_201.16367_442.0",
+          "cluster: 55, component: QE_2017_001816_201.16362_435.0",
+          "cluster: 55, component: QE_2017_001816_201.16362_435.0"
+         ],
+         "type": "scatter",
+         "uid": "92748ea9-079b-4357-bac7-db7fb4275348",
+         "x": [
+          935,
+          935,
+          945,
+          945
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.48333333333333334,
+          0.48333333333333334,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 56, component: QE_2017_001815_209.1535_312.0",
+          "cluster: 56, component: QE_2017_001815_209.1535_312.0",
+          "cluster: 56, component: QE_2017_001816_209.15344_311.0",
+          "cluster: 56, component: QE_2017_001816_209.15344_311.0"
+         ],
+         "type": "scatter",
+         "uid": "adc71ee0-69d3-48bb-8556-e91da3b4ed9c",
+         "x": [
+          975,
+          975,
+          985,
+          985
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2916666666666667,
+          0.2916666666666667,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 56, component: QE_2017_001815_209.15349_295.0",
+          "cluster: 56, component: QE_2017_001815_209.15349_295.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "aec699cf-ebe1-48c7-8076-3658ce1e99ea",
+         "x": [
+          965,
+          965,
+          980,
+          980
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3835616438356164,
+          0.3835616438356164,
+          0.2916666666666667
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 56, component: QE_2017_001815_209.15352_479.0",
+          "cluster: 56, component: QE_2017_001815_209.15352_479.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f3db22a1-36c2-46f2-b734-1ee5c60643da",
+         "x": [
+          955,
+          955,
+          972.5,
+          972.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4473684210526316,
+          0.4473684210526316,
+          0.3835616438356164
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 57, component: QE_2017_001814_243.15892_533.0",
+          "cluster: 57, component: QE_2017_001814_243.15892_533.0",
+          "cluster: 57, component: QE_2017_001814_281.1745_492.0",
+          "cluster: 57, component: QE_2017_001814_281.1745_492.0"
+         ],
+         "type": "scatter",
+         "uid": "9762e35b-857b-4571-a0b8-d56a6f390f87",
+         "x": [
+          995,
+          995,
+          1005,
+          1005
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.359375,
+          0.359375,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 57, component: QE_2017_001815_227.16408_344.0",
+          "cluster: 57, component: QE_2017_001815_227.16408_344.0",
+          "cluster: 57, component: QE_2017_001815_283.19009_564.0",
+          "cluster: 57, component: QE_2017_001815_283.19009_564.0"
+         ],
+         "type": "scatter",
+         "uid": "aa444ac3-3deb-440c-a64e-eb80f4d9563d",
+         "x": [
+          1025,
+          1025,
+          1035,
+          1035
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.47191011235955055,
+          0.47191011235955055,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 57, component: QE_2017_001814_293.2106_579.0",
+          "cluster: 57, component: QE_2017_001814_293.2106_579.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "061d72d2-d616-4b67-ac45-c6d67a5c83e0",
+         "x": [
+          1015,
+          1015,
+          1030,
+          1030
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5454545454545454,
+          0.5454545454545454,
+          0.47191011235955055
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6ca4dbe8-d11e-4ddb-b84c-2e9b35ff1595",
+         "x": [
+          1000,
+          1000,
+          1022.5,
+          1022.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.359375,
+          0.6,
+          0.6,
+          0.5454545454545454
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7426a81d-7bb8-4fa4-96ab-d67b4dd47603",
+         "x": [
+          963.75,
+          963.75,
+          1011.25,
+          1011.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4473684210526316,
+          0.6494845360824743,
+          0.6494845360824743,
+          0.6
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 58, component: QE_2017_001814_227.1275_293.0",
+          "cluster: 58, component: QE_2017_001814_227.1275_293.0",
+          "cluster: 58, component: QE_2017_001816_227.12766_295.0",
+          "cluster: 58, component: QE_2017_001816_227.12766_295.0"
+         ],
+         "type": "scatter",
+         "uid": "946de5af-5dd1-4e27-a690-6cd2c9b7d16b",
+         "x": [
+          1055,
+          1055,
+          1065,
+          1065
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3382352941176471,
+          0.3382352941176471,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 59, component: QE_2017_001815_207.13785_297.0",
+          "cluster: 59, component: QE_2017_001815_207.13785_297.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0ca706ec-18d7-4c05-a9d3-42e94abae61c",
+         "x": [
+          1045,
+          1045,
+          1060,
+          1060
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6710526315789473,
+          0.6710526315789473,
+          0.3382352941176471
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "496cc73e-da0d-45b1-af70-80faa40c23c1",
+         "x": [
+          987.5,
+          987.5,
+          1052.5,
+          1052.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6494845360824743,
+          0.7058823529411765,
+          0.7058823529411765,
+          0.6710526315789473
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 60, component: QE_2017_001815_181.1221_767.0",
+          "cluster: 60, component: QE_2017_001815_181.1221_767.0",
+          "cluster: 60, component: QE_2017_001816_181.12199_794.0",
+          "cluster: 60, component: QE_2017_001816_181.12199_794.0"
+         ],
+         "type": "scatter",
+         "uid": "466f52a4-009e-45eb-91c8-3d14291b41b5",
+         "x": [
+          1075,
+          1075,
+          1085,
+          1085
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2857142857142857,
+          0.2857142857142857,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 61, component: QE_2017_001814_211.16902_440.0",
+          "cluster: 61, component: QE_2017_001814_211.16902_440.0",
+          "cluster: 61, component: QE_2017_001815_211.16913_450.0",
+          "cluster: 61, component: QE_2017_001815_211.16913_450.0"
+         ],
+         "type": "scatter",
+         "uid": "a8622ba5-8027-44f7-aa34-625e25c46271",
+         "x": [
+          1115,
+          1115,
+          1125,
+          1125
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.19230769230769232,
+          0.19230769230769232,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 61, component: QE_2017_001815_209.0807_405.0",
+          "cluster: 61, component: QE_2017_001815_209.0807_405.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "959129d8-ff8b-461d-84d2-52e1160378b0",
+         "x": [
+          1105,
+          1105,
+          1120,
+          1120
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.21153846153846154,
+          0.21153846153846154,
+          0.19230769230769232
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 61, component: QE_2017_001816_211.16916_405.0",
+          "cluster: 61, component: QE_2017_001816_211.16916_405.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7cc04ad3-9159-4c87-a907-6036d1d22925",
+         "x": [
+          1095,
+          1095,
+          1112.5,
+          1112.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3,
+          0.3,
+          0.21153846153846154
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 61, component: QE_2017_001815_215.164_550.0",
+          "cluster: 61, component: QE_2017_001815_215.164_550.0",
+          "cluster: 61, component: QE_2017_001816_215.16411_482.0",
+          "cluster: 61, component: QE_2017_001816_215.16411_482.0"
+         ],
+         "type": "scatter",
+         "uid": "7a6864e0-36a7-4e8f-9dc9-53d68f707269",
+         "x": [
+          1135,
+          1135,
+          1145,
+          1145
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.48717948717948717,
+          0.48717948717948717,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "705cecd3-6dad-4d4c-bb5a-1419a7324d6d",
+         "x": [
+          1103.75,
+          1103.75,
+          1140,
+          1140
+         ],
+         "xaxis": "x",
+         "y": [
+          0.3,
+          0.5818181818181818,
+          0.5818181818181818,
+          0.48717948717948717
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "24958fd1-a081-4f23-b850-25a33ba6a1bf",
+         "x": [
+          1080,
+          1080,
+          1121.875,
+          1121.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2857142857142857,
+          0.7446808510638298,
+          0.7446808510638298,
+          0.5818181818181818
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c8f43b2f-0f27-4a64-bf76-dbc04c47dde4",
+         "x": [
+          1020,
+          1020,
+          1100.9375,
+          1100.9375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7058823529411765,
+          0.7631578947368421,
+          0.7631578947368421,
+          0.7446808510638298
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 62, component: QE_2017_001814_219.17416_517.0",
+          "cluster: 62, component: QE_2017_001814_219.17416_517.0",
+          "cluster: 62, component: QE_2017_001815_219.17421_516.0",
+          "cluster: 62, component: QE_2017_001815_219.17421_516.0"
+         ],
+         "type": "scatter",
+         "uid": "4c126ce0-9fab-4812-af1c-beb520d608cd",
+         "x": [
+          1165,
+          1165,
+          1175,
+          1175
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.25,
+          0.25,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 62, component: QE_2017_001814_219.17401_452.0",
+          "cluster: 62, component: QE_2017_001814_219.17401_452.0",
+          "cluster: 62, component: QE_2017_001814_219.17409_442.0",
+          "cluster: 62, component: QE_2017_001814_219.17409_442.0"
+         ],
+         "type": "scatter",
+         "uid": "b5269da2-e3a0-4ec1-89c7-f542c30d9fb3",
+         "x": [
+          1195,
+          1195,
+          1205,
+          1205
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3125,
+          0.3125,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 62, component: QE_2017_001816_219.17438_502.0",
+          "cluster: 62, component: QE_2017_001816_219.17438_502.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f92a69cf-a0f7-4424-95c0-df9c9d203fb2",
+         "x": [
+          1185,
+          1185,
+          1200,
+          1200
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4074074074074074,
+          0.4074074074074074,
+          0.3125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "44abb1ef-f3c8-4e99-b6bc-ee15bf077abc",
+         "x": [
+          1170,
+          1170,
+          1192.5,
+          1192.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.25,
+          0.4583333333333333,
+          0.4583333333333333,
+          0.4074074074074074
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 63, component: QE_2017_001815_191.14287_312.0",
+          "cluster: 63, component: QE_2017_001815_191.14287_312.0",
+          "cluster: 63, component: QE_2017_001816_191.14291_404.0",
+          "cluster: 63, component: QE_2017_001816_191.14291_404.0"
+         ],
+         "type": "scatter",
+         "uid": "a6460c90-2d46-444e-b719-a7adfbe52dd5",
+         "x": [
+          1225,
+          1225,
+          1235,
+          1235
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.43103448275862066,
+          0.43103448275862066,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 63, component: QE_2017_001814_191.14291_389.0",
+          "cluster: 63, component: QE_2017_001814_191.14291_389.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f9744588-9eeb-432f-8fc0-54e1b1ee8c6b",
+         "x": [
+          1215,
+          1215,
+          1230,
+          1230
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5,
+          0.5,
+          0.43103448275862066
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "58f6cfb9-8743-4174-a4f9-b60f39df13ea",
+         "x": [
+          1181.25,
+          1181.25,
+          1222.5,
+          1222.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4583333333333333,
+          0.68,
+          0.68,
+          0.5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 64, component: QE_2017_001816_137.09584_445.0",
+          "cluster: 64, component: QE_2017_001816_137.09584_445.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0534ed07-39aa-4455-bd44-7924515d09ac",
+         "x": [
+          1155,
+          1155,
+          1201.875,
+          1201.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.782608695652174,
+          0.782608695652174,
+          0.68
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ad92aa42-a605-409d-b6a4-2d734ee00e6c",
+         "x": [
+          1060.46875,
+          1060.46875,
+          1178.4375,
+          1178.4375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7631578947368421,
+          0.8170731707317073,
+          0.8170731707317073,
+          0.782608695652174
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7074b37b-01f3-4df5-9e56-1deef092d694",
+         "x": [
+          940,
+          940,
+          1119.453125,
+          1119.453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.48333333333333334,
+          0.8421052631578947,
+          0.8421052631578947,
+          0.8170731707317073
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 65, component: QE_2017_001814_209.08058_363.0",
+          "cluster: 65, component: QE_2017_001814_209.08058_363.0",
+          "cluster: 66, component: QE_2017_001816_207.13779_561.0",
+          "cluster: 66, component: QE_2017_001816_207.13779_561.0"
+         ],
+         "type": "scatter",
+         "uid": "b13c37c2-5845-4c97-8395-6f9978fb86fb",
+         "x": [
+          1245,
+          1245,
+          1255,
+          1255
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8556701030927835,
+          0.8556701030927835,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "72a257f4-87f1-4429-ae9d-ee64746e763c",
+         "x": [
+          1029.7265625,
+          1029.7265625,
+          1250,
+          1250
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8421052631578947,
+          0.9135802469135802,
+          0.9135802469135802,
+          0.8556701030927835
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e44459e1-9723-48b3-80ca-10f212f30621",
+         "x": [
+          901.875,
+          901.875,
+          1139.86328125,
+          1139.86328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9032258064516129,
+          0.9882352941176471,
+          0.9882352941176471,
+          0.9135802469135802
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 67, component: QE_2017_001815_333.15173_245.0",
+          "cluster: 67, component: QE_2017_001815_333.15173_245.0",
+          "cluster: 68, component: QE_2017_001816_333.15204_235.0",
+          "cluster: 68, component: QE_2017_001816_333.15204_235.0"
+         ],
+         "type": "scatter",
+         "uid": "d86d41d7-6789-4023-81d2-8b79f5d8170d",
+         "x": [
+          1265,
+          1265,
+          1275,
+          1275
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8461538461538461,
+          0.8461538461538461,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 69, component: QE_2017_001814_194.1174_244.0",
+          "cluster: 69, component: QE_2017_001814_194.1174_244.0",
+          "cluster: 70, component: QE_2017_001816_194.11746_133.0",
+          "cluster: 70, component: QE_2017_001816_194.11746_133.0"
+         ],
+         "type": "scatter",
+         "uid": "5f12aa9b-b9f7-4a2b-af69-b54896dce02f",
+         "x": [
+          1285,
+          1285,
+          1295,
+          1295
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7142857142857143,
+          0.7142857142857143,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 71, component: QE_2017_001814_320.29471_529.0",
+          "cluster: 71, component: QE_2017_001814_320.29471_529.0",
+          "cluster: 71, component: QE_2017_001815_320.29486_538.0",
+          "cluster: 71, component: QE_2017_001815_320.29486_538.0"
+         ],
+         "type": "scatter",
+         "uid": "f953adec-12a2-42ce-99bd-c50776a628b8",
+         "x": [
+          1335,
+          1335,
+          1345,
+          1345
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4444444444444444,
+          0.4444444444444444,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 71, component: QE_2017_001814_320.29477_539.0",
+          "cluster: 71, component: QE_2017_001814_320.29477_539.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "eebe332b-0573-4e2f-b490-ebc5c5d4265d",
+         "x": [
+          1325,
+          1325,
+          1340,
+          1340
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5833333333333334,
+          0.5833333333333334,
+          0.4444444444444444
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 72, component: QE_2017_001814_320.29468_638.0",
+          "cluster: 72, component: QE_2017_001814_320.29468_638.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b13086af-a6b3-495b-8c26-646bb2ffab45",
+         "x": [
+          1315,
+          1315,
+          1332.5,
+          1332.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7857142857142857,
+          0.7857142857142857,
+          0.5833333333333334
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 73, component: QE_2017_001816_320.29483_548.0",
+          "cluster: 73, component: QE_2017_001816_320.29483_548.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "26cd133c-e419-4bdd-b967-cec624c6e047",
+         "x": [
+          1305,
+          1305,
+          1323.75,
+          1323.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9393939393939394,
+          0.9393939393939394,
+          0.7857142857142857
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "13828924-f473-4096-b246-4693b606d6bd",
+         "x": [
+          1290,
+          1290,
+          1314.375,
+          1314.375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7142857142857143,
+          0.9523809523809523,
+          0.9523809523809523,
+          0.9393939393939394
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 74, component: QE_2017_001814_241.15384_47.0",
+          "cluster: 74, component: QE_2017_001814_241.15384_47.0",
+          "cluster: 75, component: QE_2017_001814_241.15446_57.0",
+          "cluster: 75, component: QE_2017_001814_241.15446_57.0"
+         ],
+         "type": "scatter",
+         "uid": "f74380d0-4fa4-4ea8-805c-2f7b03f17028",
+         "x": [
+          1355,
+          1355,
+          1365,
+          1365
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6363636363636364,
+          0.6363636363636364,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 76, component: QE_2017_001815_332.25827_508.0",
+          "cluster: 76, component: QE_2017_001815_332.25827_508.0",
+          "cluster: 77, component: QE_2017_001816_332.25842_487.0",
+          "cluster: 77, component: QE_2017_001816_332.25842_487.0"
+         ],
+         "type": "scatter",
+         "uid": "c8270e37-200d-4af7-b073-1c7b24cfa14d",
+         "x": [
+          1385,
+          1385,
+          1395,
+          1395
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6829268292682927,
+          0.6829268292682927,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 78, component: QE_2017_001814_332.25827_467.0",
+          "cluster: 78, component: QE_2017_001814_332.25827_467.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1d97d01f-c4ac-4d5d-b502-84d297ab248c",
+         "x": [
+          1375,
+          1375,
+          1390,
+          1390
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8,
+          0.8,
+          0.6829268292682927
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "55da1c4e-28ba-4373-8a5b-dc31d039edad",
+         "x": [
+          1360,
+          1360,
+          1382.5,
+          1382.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6363636363636364,
+          0.9666666666666667,
+          0.9666666666666667,
+          0.8
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e6db35a7-9d95-4633-82cd-2621aa80d7a3",
+         "x": [
+          1302.1875,
+          1302.1875,
+          1371.25,
+          1371.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9523809523809523,
+          0.9772727272727273,
+          0.9772727272727273,
+          0.9666666666666667
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 79, component: QE_2017_001814_319.13638_117.0",
+          "cluster: 79, component: QE_2017_001814_319.13638_117.0",
+          "cluster: 80, component: QE_2017_001816_319.13614_143.0",
+          "cluster: 80, component: QE_2017_001816_319.13614_143.0"
+         ],
+         "type": "scatter",
+         "uid": "e36fc99e-5d61-41c3-8be9-ca2e28e84a82",
+         "x": [
+          1405,
+          1405,
+          1415,
+          1415
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.75,
+          0.75,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 81, component: QE_2017_001815_219.10139_360.0",
+          "cluster: 81, component: QE_2017_001815_219.10139_360.0",
+          "cluster: 81, component: QE_2017_001816_219.10153_382.0",
+          "cluster: 81, component: QE_2017_001816_219.10153_382.0"
+         ],
+         "type": "scatter",
+         "uid": "b83b3a63-a178-48b3-b8bb-73c5a97266e1",
+         "x": [
+          1445,
+          1445,
+          1455,
+          1455
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.38181818181818183,
+          0.38181818181818183,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 81, component: QE_2017_001815_219.10159_438.0",
+          "cluster: 81, component: QE_2017_001815_219.10159_438.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "d0599819-8988-41e6-8467-e2a072c9d125",
+         "x": [
+          1435,
+          1435,
+          1450,
+          1450
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4647887323943662,
+          0.4647887323943662,
+          0.38181818181818183
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 82, component: QE_2017_001814_251.09117_393.0",
+          "cluster: 82, component: QE_2017_001814_251.09117_393.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "771fcc68-9d52-401e-8fc9-6be226666608",
+         "x": [
+          1425,
+          1425,
+          1442.5,
+          1442.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6527777777777778,
+          0.6527777777777778,
+          0.4647887323943662
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 83, component: QE_2017_001814_291.1442_241.0",
+          "cluster: 83, component: QE_2017_001814_291.1442_241.0",
+          "cluster: 83, component: QE_2017_001816_291.14493_243.0",
+          "cluster: 83, component: QE_2017_001816_291.14493_243.0"
+         ],
+         "type": "scatter",
+         "uid": "c08ef52e-3c22-4af4-b340-5daf236c22be",
+         "x": [
+          1465,
+          1465,
+          1475,
+          1475
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.37037037037037035,
+          0.37037037037037035,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 83, component: QE_2017_001815_273.13425_199.0",
+          "cluster: 83, component: QE_2017_001815_273.13425_199.0",
+          "cluster: 83, component: QE_2017_001815_273.13434_243.0",
+          "cluster: 83, component: QE_2017_001815_273.13434_243.0"
+         ],
+         "type": "scatter",
+         "uid": "b48647e0-3689-4865-82ab-acf645c29feb",
+         "x": [
+          1495,
+          1495,
+          1505,
+          1505
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3333333333333333,
+          0.3333333333333333,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 83, component: QE_2017_001816_291.14499_200.0",
+          "cluster: 83, component: QE_2017_001816_291.14499_200.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4e6fda57-aec4-493b-ad76-8318088b0285",
+         "x": [
+          1485,
+          1485,
+          1500,
+          1500
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.41935483870967744,
+          0.41935483870967744,
+          0.3333333333333333
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "422bca9b-8f40-41e1-a246-b9e7b4a88bed",
+         "x": [
+          1470,
+          1470,
+          1492.5,
+          1492.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.37037037037037035,
+          0.5161290322580645,
+          0.5161290322580645,
+          0.41935483870967744
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 84, component: QE_2017_001815_235.14398_226.0",
+          "cluster: 84, component: QE_2017_001815_235.14398_226.0",
+          "cluster: 84, component: QE_2017_001816_235.14397_183.0",
+          "cluster: 84, component: QE_2017_001816_235.14397_183.0"
+         ],
+         "type": "scatter",
+         "uid": "8cfbff62-db4a-4176-95dc-a05c32197be2",
+         "x": [
+          1525,
+          1525,
+          1535,
+          1535
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5263157894736842,
+          0.5263157894736842,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 85, component: QE_2017_001815_251.13873_202.0",
+          "cluster: 85, component: QE_2017_001815_251.13873_202.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "46af34da-9ea4-4d24-b615-d936534e102c",
+         "x": [
+          1515,
+          1515,
+          1530,
+          1530
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8636363636363636,
+          0.8636363636363636,
+          0.5263157894736842
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a57cdd0f-0416-4446-b40f-08611fad94be",
+         "x": [
+          1481.25,
+          1481.25,
+          1522.5,
+          1522.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5161290322580645,
+          0.9166666666666666,
+          0.9166666666666666,
+          0.8636363636363636
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f03c9a34-f1f0-49a2-9878-f2173ab858bc",
+         "x": [
+          1433.75,
+          1433.75,
+          1501.875,
+          1501.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6527777777777778,
+          0.9891304347826086,
+          0.9891304347826086,
+          0.9166666666666666
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 86, component: QE_2017_001814_250.10149_516.0",
+          "cluster: 86, component: QE_2017_001814_250.10149_516.0",
+          "cluster: 86, component: QE_2017_001815_222.07033_315.0",
+          "cluster: 86, component: QE_2017_001815_222.07033_315.0"
+         ],
+         "type": "scatter",
+         "uid": "37b123ca-4405-4051-a8a8-595ff8f27965",
+         "x": [
+          1565,
+          1565,
+          1575,
+          1575
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5081967213114754,
+          0.5081967213114754,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 87, component: QE_2017_001816_268.59351_445.0",
+          "cluster: 87, component: QE_2017_001816_268.59351_445.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "16e1767a-c439-4300-bf25-096ddb10cf1b",
+         "x": [
+          1555,
+          1555,
+          1570,
+          1570
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6923076923076923,
+          0.6923076923076923,
+          0.5081967213114754
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 88, component: QE_2017_001814_247.05975_245.0",
+          "cluster: 88, component: QE_2017_001814_247.05975_245.0",
+          "cluster: 88, component: QE_2017_001815_247.0598_242.0",
+          "cluster: 88, component: QE_2017_001815_247.0598_242.0"
+         ],
+         "type": "scatter",
+         "uid": "95da162b-3d9a-4a48-b5ac-1148ff9270f5",
+         "x": [
+          1585,
+          1585,
+          1595,
+          1595
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.35294117647058826,
+          0.35294117647058826,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 89, component: QE_2017_001815_212.03883_181.0",
+          "cluster: 89, component: QE_2017_001815_212.03883_181.0",
+          "cluster: 90, component: QE_2017_001815_214.56488_409.0",
+          "cluster: 90, component: QE_2017_001815_214.56488_409.0"
+         ],
+         "type": "scatter",
+         "uid": "da33cefa-40ca-4cb8-bf88-7824877edd60",
+         "x": [
+          1615,
+          1615,
+          1625,
+          1625
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7777777777777778,
+          0.7777777777777778,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 91, component: QE_2017_001816_219.04672_291.0",
+          "cluster: 91, component: QE_2017_001816_219.04672_291.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4511df91-e903-43e8-9089-9924ed42fdbe",
+         "x": [
+          1605,
+          1605,
+          1620,
+          1620
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8125,
+          0.8125,
+          0.7777777777777778
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "bb0eefd4-d9ea-4ccb-a08e-4053b1be82b2",
+         "x": [
+          1590,
+          1590,
+          1612.5,
+          1612.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.35294117647058826,
+          0.8571428571428571,
+          0.8571428571428571,
+          0.8125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ad25f491-f89a-43bf-a2a3-763b66e1d5bc",
+         "x": [
+          1562.5,
+          1562.5,
+          1601.25,
+          1601.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6923076923076923,
+          0.9178082191780822,
+          0.9178082191780822,
+          0.8571428571428571
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 92, component: QE_2017_001815_214.51021_60.0",
+          "cluster: 92, component: QE_2017_001815_214.51021_60.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7f78a712-127b-40fe-819d-67f02a231c3c",
+         "x": [
+          1545,
+          1545,
+          1581.875,
+          1581.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9534883720930233,
+          0.9534883720930233,
+          0.9178082191780822
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 93, component: QE_2017_001815_246.14465_137.0",
+          "cluster: 93, component: QE_2017_001815_246.14465_137.0",
+          "cluster: 93, component: QE_2017_001815_247.12865_158.0",
+          "cluster: 93, component: QE_2017_001815_247.12865_158.0"
+         ],
+         "type": "scatter",
+         "uid": "2214ab0a-ee55-4f29-8e3d-869c1f04068c",
+         "x": [
+          1655,
+          1655,
+          1665,
+          1665
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5,
+          0.5,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 94, component: QE_2017_001814_260.16037_143.0",
+          "cluster: 94, component: QE_2017_001814_260.16037_143.0",
+          "cluster: 94, component: QE_2017_001816_260.16022_145.0",
+          "cluster: 94, component: QE_2017_001816_260.16022_145.0"
+         ],
+         "type": "scatter",
+         "uid": "e52637f2-eda9-42cb-9576-3eb74cc0371e",
+         "x": [
+          1675,
+          1675,
+          1685,
+          1685
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2857142857142857,
+          0.2857142857142857,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 95, component: QE_2017_001814_233.14948_126.0",
+          "cluster: 95, component: QE_2017_001814_233.14948_126.0",
+          "cluster: 95, component: QE_2017_001816_233.14955_129.0",
+          "cluster: 95, component: QE_2017_001816_233.14955_129.0"
+         ],
+         "type": "scatter",
+         "uid": "73d068d3-676d-4f33-9dd2-410409a371b2",
+         "x": [
+          1705,
+          1705,
+          1715,
+          1715
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2631578947368421,
+          0.2631578947368421,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 95, component: QE_2017_001814_233.14957_152.0",
+          "cluster: 95, component: QE_2017_001814_233.14957_152.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "350387dd-27c1-4f2f-b3af-240b430f687f",
+         "x": [
+          1695,
+          1695,
+          1710,
+          1710
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5416666666666666,
+          0.5416666666666666,
+          0.2631578947368421
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "763b75bf-5f7f-4012-b2c0-cf23dd9d5bdf",
+         "x": [
+          1680,
+          1680,
+          1702.5,
+          1702.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2857142857142857,
+          0.8648648648648649,
+          0.8648648648648649,
+          0.5416666666666666
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "2d2f2750-264c-4b7d-b91d-f7817319c3a4",
+         "x": [
+          1660,
+          1660,
+          1691.25,
+          1691.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5,
+          0.9574468085106383,
+          0.9574468085106383,
+          0.8648648648648649
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 96, component: QE_2017_001816_132.04436_283.0",
+          "cluster: 96, component: QE_2017_001816_132.04436_283.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "838017ad-ca40-4df0-ae52-40da928c8bdf",
+         "x": [
+          1645,
+          1645,
+          1675.625,
+          1675.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.98,
+          0.98,
+          0.9574468085106383
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 97, component: QE_2017_001815_260.16016_64.0",
+          "cluster: 97, component: QE_2017_001815_260.16016_64.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3624fde4-7be2-4d3f-8e35-7966f1954805",
+         "x": [
+          1635,
+          1635,
+          1660.3125,
+          1660.3125
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9846153846153847,
+          0.9846153846153847,
+          0.98
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 98, component: QE_2017_001815_221.12837_99.0",
+          "cluster: 98, component: QE_2017_001815_221.12837_99.0",
+          "cluster: 99, component: QE_2017_001816_237.12325_171.0",
+          "cluster: 99, component: QE_2017_001816_237.12325_171.0"
+         ],
+         "type": "scatter",
+         "uid": "1f839e5a-4bfb-4841-ad56-3e9f23b0cccc",
+         "x": [
+          1725,
+          1725,
+          1735,
+          1735
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7142857142857143,
+          0.7142857142857143,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 100, component: QE_2017_001814_237.12305_220.0",
+          "cluster: 100, component: QE_2017_001814_237.12305_220.0",
+          "cluster: 101, component: QE_2017_001816_237.12323_53.0",
+          "cluster: 101, component: QE_2017_001816_237.12323_53.0"
+         ],
+         "type": "scatter",
+         "uid": "01c0ec73-ac25-41ef-a01c-3e4aeb3bd10b",
+         "x": [
+          1745,
+          1745,
+          1755,
+          1755
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9444444444444444,
+          0.9444444444444444,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "172eb381-c2e7-43d2-98df-b7d47873e7c5",
+         "x": [
+          1730,
+          1730,
+          1750,
+          1750
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7142857142857143,
+          0.9761904761904762,
+          0.9761904761904762,
+          0.9444444444444444
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 102, component: QE_2017_001814_229.15399_46.0",
+          "cluster: 102, component: QE_2017_001814_229.15399_46.0",
+          "cluster: 102, component: QE_2017_001816_229.15451_66.0",
+          "cluster: 102, component: QE_2017_001816_229.15451_66.0"
+         ],
+         "type": "scatter",
+         "uid": "dfe8792b-dd1d-48fb-8fe9-2e245d1b5f7f",
+         "x": [
+          1775,
+          1775,
+          1785,
+          1785
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.38461538461538464,
+          0.38461538461538464,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 103, component: QE_2017_001816_229.15469_52.0",
+          "cluster: 103, component: QE_2017_001816_229.15469_52.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "2c05e77b-de1f-4112-a7f2-4bf7eb37d544",
+         "x": [
+          1765,
+          1765,
+          1780,
+          1780
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.875,
+          0.875,
+          0.38461538461538464
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 104, component: QE_2017_001814_182.08116_51.0",
+          "cluster: 104, component: QE_2017_001814_182.08116_51.0",
+          "cluster: 104, component: QE_2017_001816_182.08116_55.0",
+          "cluster: 104, component: QE_2017_001816_182.08116_55.0"
+         ],
+         "type": "scatter",
+         "uid": "f74adfc4-4244-4da0-bae8-6f195a461799",
+         "x": [
+          1795,
+          1795,
+          1805,
+          1805
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4375,
+          0.4375,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 105, component: QE_2017_001815_194.04474_330.0",
+          "cluster: 105, component: QE_2017_001815_194.04474_330.0",
+          "cluster: 105, component: QE_2017_001816_212.05518_300.0",
+          "cluster: 105, component: QE_2017_001816_212.05518_300.0"
+         ],
+         "type": "scatter",
+         "uid": "4f78b7f9-9847-4c79-ae88-7f2db0cd6151",
+         "x": [
+          1815,
+          1815,
+          1825,
+          1825
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5370370370370371,
+          0.5370370370370371,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6bc65494-b496-427d-9bb2-51602642e486",
+         "x": [
+          1800,
+          1800,
+          1820,
+          1820
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4375,
+          0.921875,
+          0.921875,
+          0.5370370370370371
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 106, component: QE_2017_001814_177.05418_236.0",
+          "cluster: 106, component: QE_2017_001814_177.05418_236.0",
+          "cluster: 106, component: QE_2017_001815_177.05444_307.0",
+          "cluster: 106, component: QE_2017_001815_177.05444_307.0"
+         ],
+         "type": "scatter",
+         "uid": "0e210bb3-761f-4150-9eeb-a0605ee6378e",
+         "x": [
+          1845,
+          1845,
+          1855,
+          1855
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.35,
+          0.35,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 106, component: QE_2017_001816_177.05449_217.0",
+          "cluster: 106, component: QE_2017_001816_177.05449_217.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "eebac0f0-6722-4862-a45c-d32067b2893a",
+         "x": [
+          1835,
+          1835,
+          1850,
+          1850
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.391304347826087,
+          0.391304347826087,
+          0.35
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 107, component: QE_2017_001816_199.98769_294.0",
+          "cluster: 107, component: QE_2017_001816_199.98769_294.0",
+          "cluster: 107, component: QE_2017_001816_199.98776_304.0",
+          "cluster: 107, component: QE_2017_001816_199.98776_304.0"
+         ],
+         "type": "scatter",
+         "uid": "11f06a3d-49c1-4c1d-b5da-0c9815af3470",
+         "x": [
+          1865,
+          1865,
+          1875,
+          1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.34146341463414637,
+          0.34146341463414637,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 107, component: QE_2017_001814_199.98778_290.0",
+          "cluster: 107, component: QE_2017_001814_199.98778_290.0",
+          "cluster: 107, component: QE_2017_001815_199.98779_30.0",
+          "cluster: 107, component: QE_2017_001815_199.98779_30.0"
+         ],
+         "type": "scatter",
+         "uid": "d8e1ffcd-3adf-446c-9d5f-7d010b0c8cf3",
+         "x": [
+          1885,
+          1885,
+          1895,
+          1895
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3,
+          0.3,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 107, component: QE_2017_001815_199.98772_326.0",
+          "cluster: 107, component: QE_2017_001815_199.98772_326.0",
+          "cluster: 107, component: QE_2017_001816_199.98781_313.0",
+          "cluster: 107, component: QE_2017_001816_199.98781_313.0"
+         ],
+         "type": "scatter",
+         "uid": "24d80132-68fc-4ac3-a1a8-bd609f4a4933",
+         "x": [
+          1905,
+          1905,
+          1915,
+          1915
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.18181818181818182,
+          0.18181818181818182,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 107, component: QE_2017_001816_199.98776_254.0",
+          "cluster: 107, component: QE_2017_001816_199.98776_254.0",
+          "cluster: 107, component: QE_2017_001816_199.98779_335.0",
+          "cluster: 107, component: QE_2017_001816_199.98779_335.0"
+         ],
+         "type": "scatter",
+         "uid": "261a8e0e-e417-46a3-af85-04cc0430a761",
+         "x": [
+          1935,
+          1935,
+          1945,
+          1945
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.25,
+          0.25,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 107, component: QE_2017_001816_199.98772_359.0",
+          "cluster: 107, component: QE_2017_001816_199.98772_359.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3bd02766-270a-4b63-804c-ef02ba12bee0",
+         "x": [
+          1925,
+          1925,
+          1940,
+          1940
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3125,
+          0.3125,
+          0.25
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1e7dfe4d-747e-4f65-8442-2137230af60d",
+         "x": [
+          1910,
+          1910,
+          1932.5,
+          1932.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.18181818181818182,
+          0.36363636363636365,
+          0.36363636363636365,
+          0.3125
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "2d2b80ea-cb62-47c3-8c82-c5ae12f2c1b1",
+         "x": [
+          1890,
+          1890,
+          1921.25,
+          1921.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.3,
+          0.42424242424242425,
+          0.42424242424242425,
+          0.36363636363636365
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e998a0cd-d71e-4979-807b-af98fa42a2f9",
+         "x": [
+          1870,
+          1870,
+          1905.625,
+          1905.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.34146341463414637,
+          0.47368421052631576,
+          0.47368421052631576,
+          0.42424242424242425
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "29978e69-1bab-4254-abcf-293e018727e4",
+         "x": [
+          1842.5,
+          1842.5,
+          1887.8125,
+          1887.8125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.391304347826087,
+          0.8214285714285714,
+          0.8214285714285714,
+          0.47368421052631576
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 108, component: QE_2017_001815_463.12268_358.0",
+          "cluster: 108, component: QE_2017_001815_463.12268_358.0",
+          "cluster: 109, component: QE_2017_001815_625.17633_345.0",
+          "cluster: 109, component: QE_2017_001815_625.17633_345.0"
+         ],
+         "type": "scatter",
+         "uid": "b46ed09e-1d90-4de0-aaa9-30bee1e47a78",
+         "x": [
+          1975,
+          1975,
+          1985,
+          1985
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6774193548387096,
+          0.6774193548387096,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 110, component: QE_2017_001815_595.16559_315.0",
+          "cluster: 110, component: QE_2017_001815_595.16559_315.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "02fa6b8b-7ee2-4dda-a56e-3830f687cd82",
+         "x": [
+          1965,
+          1965,
+          1980,
+          1980
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.8947368421052632,
+          0.8947368421052632,
+          0.6774193548387096
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 111, component: QE_2017_001815_141.0508_33.0",
+          "cluster: 111, component: QE_2017_001815_141.0508_33.0",
+          "cluster: 112, component: QE_2017_001815_265.01532_33.0",
+          "cluster: 112, component: QE_2017_001815_265.01532_33.0"
+         ],
+         "type": "scatter",
+         "uid": "f071ca91-9117-43bb-9d79-62e408daff2e",
+         "x": [
+          1995,
+          1995,
+          2005,
+          2005
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          1,
+          1,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "10bf23e5-da8a-4f97-bbbf-e6f5d32044e4",
+         "x": [
+          1972.5,
+          1972.5,
+          2000,
+          2000
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8947368421052632,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 113, component: QE_2017_001815_797.51746_866.0",
+          "cluster: 113, component: QE_2017_001815_797.51746_866.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c8af79ff-cbe9-4e42-917e-72623d262605",
+         "x": [
+          1955,
+          1955,
+          1986.25,
+          1986.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "25d0d588-a88f-425c-ae15-d435aeff41e2",
+         "x": [
+          1865.15625,
+          1865.15625,
+          1970.625,
+          1970.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8214285714285714,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9b750d62-a060-407e-ad5e-f390ee1114b4",
+         "x": [
+          1810,
+          1810,
+          1917.890625,
+          1917.890625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.921875,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5036fdc9-67ae-4790-8d99-e0b274289897",
+         "x": [
+          1772.5,
+          1772.5,
+          1863.9453125,
+          1863.9453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.875,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b90cf2ba-485a-4055-ba65-1f6cb4f060a4",
+         "x": [
+          1740,
+          1740,
+          1818.22265625,
+          1818.22265625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9761904761904762,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "1e9d619a-54d6-4e84-9feb-377e151444c4",
+         "x": [
+          1647.65625,
+          1647.65625,
+          1779.111328125,
+          1779.111328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9846153846153847,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "bd4b47aa-4445-4ad2-aecd-773ded1ed361",
+         "x": [
+          1563.4375,
+          1563.4375,
+          1713.3837890625,
+          1713.3837890625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9534883720930233,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4248d801-41e9-4aff-b6d6-8977d036acbc",
+         "x": [
+          1467.8125,
+          1467.8125,
+          1638.41064453125,
+          1638.41064453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9891304347826086,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a08f0c19-0463-48ce-86d7-ff666d92b57d",
+         "x": [
+          1410,
+          1410,
+          1553.111572265625,
+          1553.111572265625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.75,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6ce55441-6447-4587-a0d0-1a9677b05196",
+         "x": [
+          1336.71875,
+          1336.71875,
+          1481.5557861328125,
+          1481.5557861328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9772727272727273,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b4f31e9e-6db2-4386-a1cd-9ad1182b925f",
+         "x": [
+          1270,
+          1270,
+          1409.1372680664062,
+          1409.1372680664062
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8461538461538461,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e56cded3-30bd-414b-9400-5de6bdfd602f",
+         "x": [
+          1020.869140625,
+          1020.869140625,
+          1339.5686340332031,
+          1339.5686340332031
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9882352941176471,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9e7b641a-ecf9-4941-9035-5d6f13fd780e",
+         "x": [
+          734.912109375,
+          734.912109375,
+          1180.2188873291016,
+          1180.2188873291016
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9696969696969697,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9f1d30be-b94f-47c9-805a-acd86dabcdba",
+         "x": [
+          619.6875,
+          619.6875,
+          957.5654983520508,
+          957.5654983520508
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9814814814814815,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "881d0566-f95e-4413-a089-500154ce2757",
+         "x": [
+          521.875,
+          521.875,
+          788.6264991760254,
+          788.6264991760254
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9857142857142858,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b502da3d-6c32-40b9-8e88-d441a340f431",
+         "x": [
+          221.85302734375,
+          221.85302734375,
+          655.2507495880127,
+          655.2507495880127
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9625,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "height": 700,
+        "hovermode": "closest",
+        "margin": {
+         "b": 372
+        },
+        "showlegend": false,
+        "title": {
+         "text": "TreesRCool"
+        },
+        "width": 800,
+        "xaxis": {
+         "mirror": "allticks",
+         "rangemode": "tozero",
+         "showgrid": false,
+         "showline": true,
+         "showticklabels": true,
+         "tickmode": "array",
+         "ticks": "outside",
+         "ticktext": [
+          "QE_2017_001816_613.4826_738.0",
+          "QE_2017_001816_613.48218_838.0",
+          "QE_2017_001816_792.56232_718.0",
+          "QE_2017_001814_596.30963_602.0",
+          "QE_2017_001815_792.5625_866.0",
+          "QE_2017_001815_571.4292_870.0",
+          "QE_2017_001814_497.31033_643.0",
+          "QE_2017_001815_507.27145_607.0",
+          "QE_2017_001816_571.47186_717.0",
+          "QE_2017_001814_335.25772_725.0",
+          "QE_2017_001814_335.25784_608.0",
+          "QE_2017_001816_335.25772_723.0",
+          "QE_2017_001814_335.25784_628.0",
+          "QE_2017_001815_335.25745_642.0",
+          "QE_2017_001814_261.22073_634.0",
+          "QE_2017_001815_335.25784_587.0",
+          "QE_2017_001814_353.26889_609.0",
+          "QE_2017_001815_353.26862_642.0",
+          "QE_2017_001815_261.22073_643.0",
+          "QE_2017_001814_335.25772_638.0",
+          "QE_2017_001815_335.2579_601.0",
+          "QE_2017_001816_272.25824_582.0",
+          "QE_2017_001814_338.34146_850.0",
+          "QE_2017_001815_244.19048_762.0",
+          "QE_2017_001814_353.26868_633.0",
+          "QE_2017_001816_353.26892_600.0",
+          "QE_2017_001814_279.23157_719.0",
+          "QE_2017_001815_278.24762_684.0",
+          "QE_2017_001816_435.25037_666.0",
+          "QE_2017_001816_337.27338_826.0",
+          "QE_2017_001816_337.27341_632.0",
+          "QE_2017_001814_618.42633_695.0",
+          "QE_2017_001816_583.41382_731.0",
+          "QE_2017_001816_599.40948_660.0",
+          "QE_2017_001814_601.42426_706.0",
+          "QE_2017_001816_599.40869_793.0",
+          "QE_2017_001815_618.42773_646.0",
+          "QE_2017_001816_618.427_682.0",
+          "QE_2017_001815_568.42627_841.0",
+          "QE_2017_001814_565.4035_722.0",
+          "QE_2017_001814_583.41406_682.0",
+          "QE_2017_001815_583.41406_707.0",
+          "QE_2017_001814_601.42334_783.0",
+          "QE_2017_001815_583.41388_735.0",
+          "QE_2017_001815_583.41418_647.0",
+          "QE_2017_001814_194.04424_237.0",
+          "QE_2017_001815_194.11751_218.0",
+          "QE_2017_001815_194.04469_299.0",
+          "QE_2017_001815_194.04471_314.0",
+          "QE_2017_001815_212.05513_328.0",
+          "QE_2017_001815_212.05505_267.0",
+          "QE_2017_001814_226.07077_397.0",
+          "QE_2017_001815_194.04471_397.0",
+          "QE_2017_001816_533.15442_247.0",
+          "QE_2017_001816_533.15466_222.0",
+          "QE_2017_001815_533.1546_207.0",
+          "QE_2017_001816_533.1546_271.0",
+          "QE_2017_001814_347.09097_122.0",
+          "QE_2017_001815_347.09067_204.0",
+          "QE_2017_001815_268.10373_58.0",
+          "QE_2017_001816_269.16055_60.0",
+          "QE_2017_001815_364.34189_705.0",
+          "QE_2017_001816_408.36832_704.0",
+          "QE_2017_001816_466.40979_731.0",
+          "QE_2017_001815_408.36853_717.0",
+          "QE_2017_001815_482.40488_739.0",
+          "QE_2017_001814_364.34244_761.0",
+          "QE_2017_001815_364.34253_752.0",
+          "QE_2017_001816_421.35226_731.0",
+          "QE_2017_001816_424.36325_712.0",
+          "QE_2017_001816_463.12311_410.0",
+          "QE_2017_001814_611.15997_285.0",
+          "QE_2017_001815_611.16046_309.0",
+          "QE_2017_001814_339.10742_366.0",
+          "QE_2017_001816_339.10733_298.0",
+          "QE_2017_001814_498.2543_475.0",
+          "QE_2017_001815_340.16019_314.0",
+          "QE_2017_001815_231.04973_403.0",
+          "QE_2017_001815_231.04968_315.0",
+          "QE_2017_001814_231.04971_516.0",
+          "QE_2017_001815_231.04971_369.0",
+          "QE_2017_001815_314.14453_76.0",
+          "QE_2017_001816_314.14462_79.0",
+          "QE_2017_001816_310.14957_134.0",
+          "QE_2017_001816_342.17584_257.0",
+          "QE_2017_001814_241.15466_73.0",
+          "QE_2017_001815_507.18192_178.0",
+          "QE_2017_001814_483.27118_651.0",
+          "QE_2017_001816_338.26062_643.0",
+          "QE_2017_001814_320.29456_577.0",
+          "QE_2017_001815_320.29471_563.0",
+          "QE_2017_001815_129.12741_349.0",
+          "QE_2017_001815_171.14914_420.0",
+          "QE_2017_001815_201.16367_442.0",
+          "QE_2017_001816_201.16362_435.0",
+          "QE_2017_001815_209.15352_479.0",
+          "QE_2017_001815_209.15349_295.0",
+          "QE_2017_001815_209.1535_312.0",
+          "QE_2017_001816_209.15344_311.0",
+          "QE_2017_001814_243.15892_533.0",
+          "QE_2017_001814_281.1745_492.0",
+          "QE_2017_001814_293.2106_579.0",
+          "QE_2017_001815_227.16408_344.0",
+          "QE_2017_001815_283.19009_564.0",
+          "QE_2017_001815_207.13785_297.0",
+          "QE_2017_001814_227.1275_293.0",
+          "QE_2017_001816_227.12766_295.0",
+          "QE_2017_001815_181.1221_767.0",
+          "QE_2017_001816_181.12199_794.0",
+          "QE_2017_001816_211.16916_405.0",
+          "QE_2017_001815_209.0807_405.0",
+          "QE_2017_001814_211.16902_440.0",
+          "QE_2017_001815_211.16913_450.0",
+          "QE_2017_001815_215.164_550.0",
+          "QE_2017_001816_215.16411_482.0",
+          "QE_2017_001816_137.09584_445.0",
+          "QE_2017_001814_219.17416_517.0",
+          "QE_2017_001815_219.17421_516.0",
+          "QE_2017_001816_219.17438_502.0",
+          "QE_2017_001814_219.17401_452.0",
+          "QE_2017_001814_219.17409_442.0",
+          "QE_2017_001814_191.14291_389.0",
+          "QE_2017_001815_191.14287_312.0",
+          "QE_2017_001816_191.14291_404.0",
+          "QE_2017_001814_209.08058_363.0",
+          "QE_2017_001816_207.13779_561.0",
+          "QE_2017_001815_333.15173_245.0",
+          "QE_2017_001816_333.15204_235.0",
+          "QE_2017_001814_194.1174_244.0",
+          "QE_2017_001816_194.11746_133.0",
+          "QE_2017_001816_320.29483_548.0",
+          "QE_2017_001814_320.29468_638.0",
+          "QE_2017_001814_320.29477_539.0",
+          "QE_2017_001814_320.29471_529.0",
+          "QE_2017_001815_320.29486_538.0",
+          "QE_2017_001814_241.15384_47.0",
+          "QE_2017_001814_241.15446_57.0",
+          "QE_2017_001814_332.25827_467.0",
+          "QE_2017_001815_332.25827_508.0",
+          "QE_2017_001816_332.25842_487.0",
+          "QE_2017_001814_319.13638_117.0",
+          "QE_2017_001816_319.13614_143.0",
+          "QE_2017_001814_251.09117_393.0",
+          "QE_2017_001815_219.10159_438.0",
+          "QE_2017_001815_219.10139_360.0",
+          "QE_2017_001816_219.10153_382.0",
+          "QE_2017_001814_291.1442_241.0",
+          "QE_2017_001816_291.14493_243.0",
+          "QE_2017_001816_291.14499_200.0",
+          "QE_2017_001815_273.13425_199.0",
+          "QE_2017_001815_273.13434_243.0",
+          "QE_2017_001815_251.13873_202.0",
+          "QE_2017_001815_235.14398_226.0",
+          "QE_2017_001816_235.14397_183.0",
+          "QE_2017_001815_214.51021_60.0",
+          "QE_2017_001816_268.59351_445.0",
+          "QE_2017_001814_250.10149_516.0",
+          "QE_2017_001815_222.07033_315.0",
+          "QE_2017_001814_247.05975_245.0",
+          "QE_2017_001815_247.0598_242.0",
+          "QE_2017_001816_219.04672_291.0",
+          "QE_2017_001815_212.03883_181.0",
+          "QE_2017_001815_214.56488_409.0",
+          "QE_2017_001815_260.16016_64.0",
+          "QE_2017_001816_132.04436_283.0",
+          "QE_2017_001815_246.14465_137.0",
+          "QE_2017_001815_247.12865_158.0",
+          "QE_2017_001814_260.16037_143.0",
+          "QE_2017_001816_260.16022_145.0",
+          "QE_2017_001814_233.14957_152.0",
+          "QE_2017_001814_233.14948_126.0",
+          "QE_2017_001816_233.14955_129.0",
+          "QE_2017_001815_221.12837_99.0",
+          "QE_2017_001816_237.12325_171.0",
+          "QE_2017_001814_237.12305_220.0",
+          "QE_2017_001816_237.12323_53.0",
+          "QE_2017_001816_229.15469_52.0",
+          "QE_2017_001814_229.15399_46.0",
+          "QE_2017_001816_229.15451_66.0",
+          "QE_2017_001814_182.08116_51.0",
+          "QE_2017_001816_182.08116_55.0",
+          "QE_2017_001815_194.04474_330.0",
+          "QE_2017_001816_212.05518_300.0",
+          "QE_2017_001816_177.05449_217.0",
+          "QE_2017_001814_177.05418_236.0",
+          "QE_2017_001815_177.05444_307.0",
+          "QE_2017_001816_199.98769_294.0",
+          "QE_2017_001816_199.98776_304.0",
+          "QE_2017_001814_199.98778_290.0",
+          "QE_2017_001815_199.98779_30.0",
+          "QE_2017_001815_199.98772_326.0",
+          "QE_2017_001816_199.98781_313.0",
+          "QE_2017_001816_199.98772_359.0",
+          "QE_2017_001816_199.98776_254.0",
+          "QE_2017_001816_199.98779_335.0",
+          "QE_2017_001815_797.51746_866.0",
+          "QE_2017_001815_595.16559_315.0",
+          "QE_2017_001815_463.12268_358.0",
+          "QE_2017_001815_625.17633_345.0",
+          "QE_2017_001815_141.0508_33.0",
+          "QE_2017_001815_265.01532_33.0"
+         ],
+         "tickvals": [
+          5,
+          15,
+          25,
+          35,
+          45,
+          55,
+          65,
+          75,
+          85,
+          95,
+          105,
+          115,
+          125,
+          135,
+          145,
+          155,
+          165,
+          175,
+          185,
+          195,
+          205,
+          215,
+          225,
+          235,
+          245,
+          255,
+          265,
+          275,
+          285,
+          295,
+          305,
+          315,
+          325,
+          335,
+          345,
+          355,
+          365,
+          375,
+          385,
+          395,
+          405,
+          415,
+          425,
+          435,
+          445,
+          455,
+          465,
+          475,
+          485,
+          495,
+          505,
+          515,
+          525,
+          535,
+          545,
+          555,
+          565,
+          575,
+          585,
+          595,
+          605,
+          615,
+          625,
+          635,
+          645,
+          655,
+          665,
+          675,
+          685,
+          695,
+          705,
+          715,
+          725,
+          735,
+          745,
+          755,
+          765,
+          775,
+          785,
+          795,
+          805,
+          815,
+          825,
+          835,
+          845,
+          855,
+          865,
+          875,
+          885,
+          895,
+          905,
+          915,
+          925,
+          935,
+          945,
+          955,
+          965,
+          975,
+          985,
+          995,
+          1005,
+          1015,
+          1025,
+          1035,
+          1045,
+          1055,
+          1065,
+          1075,
+          1085,
+          1095,
+          1105,
+          1115,
+          1125,
+          1135,
+          1145,
+          1155,
+          1165,
+          1175,
+          1185,
+          1195,
+          1205,
+          1215,
+          1225,
+          1235,
+          1245,
+          1255,
+          1265,
+          1275,
+          1285,
+          1295,
+          1305,
+          1315,
+          1325,
+          1335,
+          1345,
+          1355,
+          1365,
+          1375,
+          1385,
+          1395,
+          1405,
+          1415,
+          1425,
+          1435,
+          1445,
+          1455,
+          1465,
+          1475,
+          1485,
+          1495,
+          1505,
+          1515,
+          1525,
+          1535,
+          1545,
+          1555,
+          1565,
+          1575,
+          1585,
+          1595,
+          1605,
+          1615,
+          1625,
+          1635,
+          1645,
+          1655,
+          1665,
+          1675,
+          1685,
+          1695,
+          1705,
+          1715,
+          1725,
+          1735,
+          1745,
+          1755,
+          1765,
+          1775,
+          1785,
+          1795,
+          1805,
+          1815,
+          1825,
+          1835,
+          1845,
+          1855,
+          1865,
+          1875,
+          1885,
+          1895,
+          1905,
+          1915,
+          1925,
+          1935,
+          1945,
+          1955,
+          1965,
+          1975,
+          1985,
+          1995,
+          2005
+         ],
+         "title": {
+          "text": "Samples"
+         },
+         "type": "linear",
+         "zeroline": false
+        },
+        "yaxis": {
+         "mirror": "allticks",
+         "rangemode": "tozero",
+         "showgrid": false,
+         "showline": true,
+         "showticklabels": true,
+         "ticks": "outside",
+         "title": {
+          "text": "Distance"
+         },
+         "type": "linear",
+         "zeroline": false
+        }
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "        \n",
+       "        \n",
+       "            <div id=\"19a4434f-99bb-4417-9804-24c6b82f7e4a\" class=\"plotly-graph-div\"></div>\n",
+       "            <script type=\"text/javascript\">\n",
+       "                require([\"plotly\"], function(Plotly) {\n",
+       "                    window.PLOTLYENV=window.PLOTLYENV || {};\n",
+       "                    window.PLOTLYENV.BASE_URL='https://plot.ly';\n",
+       "                    \n",
+       "                if (document.getElementById(\"19a4434f-99bb-4417-9804-24c6b82f7e4a\")) {\n",
+       "                    Plotly.newPlot(\n",
+       "                        '19a4434f-99bb-4417-9804-24c6b82f7e4a',\n",
+       "                        [{\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 1, component: QE_2017_001816_613.48218_838.0\", \"cluster: 1, component: QE_2017_001816_613.48218_838.0\", \"cluster: 1, component: QE_2017_001816_792.56232_718.0\", \"cluster: 1, component: QE_2017_001816_792.56232_718.0\"], \"type\": \"scatter\", \"uid\": \"2b5f0b64-c45e-4826-bed8-3182aea5bc38\", \"x\": [15.0, 15.0, 25.0, 25.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5662650602409639, 0.5662650602409639, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001816_613.4826_738.0\", \"cluster: 2, component: QE_2017_001816_613.4826_738.0\", null, null], \"type\": \"scatter\", \"uid\": \"8f7f3eec-ffc0-4319-aee6-adddc8a77938\", \"x\": [5.0, 5.0, 20.0, 20.0], \"xaxis\": \"x\", \"y\": [0.0, 0.676923076923077, 0.676923076923077, 0.5662650602409639], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 3, component: QE_2017_001814_596.30963_602.0\", \"cluster: 3, component: QE_2017_001814_596.30963_602.0\", \"cluster: 4, component: QE_2017_001815_792.5625_866.0\", \"cluster: 4, component: QE_2017_001815_792.5625_866.0\"], \"type\": \"scatter\", \"uid\": \"626e4c41-02e6-47b0-a06a-dce556fff30c\", \"x\": [35.0, 35.0, 45.0, 45.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7142857142857143, 0.7142857142857143, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5d3672ef-43ee-4b80-9ed5-1f82e98fdb56\", \"x\": [12.5, 12.5, 40.0, 40.0], \"xaxis\": \"x\", \"y\": [0.676923076923077, 0.7763157894736842, 0.7763157894736842, 0.7142857142857143], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25784_608.0\", \"cluster: 5, component: QE_2017_001814_335.25784_608.0\", \"cluster: 5, component: QE_2017_001816_335.25772_723.0\", \"cluster: 5, component: QE_2017_001816_335.25772_723.0\"], \"type\": \"scatter\", \"uid\": \"bf22e3b4-77cb-4ec2-b908-45af4878e204\", \"x\": [105.0, 105.0, 115.0, 115.0], \"xaxis\": \"x\", \"y\": [0.0, 0.26, 0.26, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25772_725.0\", \"cluster: 5, component: QE_2017_001814_335.25772_725.0\", null, null], \"type\": \"scatter\", \"uid\": \"d98cf8cd-5225-4a0a-bfa5-22d259f94823\", \"x\": [95.0, 95.0, 110.0, 110.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2830188679245283, 0.2830188679245283, 0.26], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25784_628.0\", \"cluster: 5, component: QE_2017_001814_335.25784_628.0\", \"cluster: 5, component: QE_2017_001815_335.25745_642.0\", \"cluster: 5, component: QE_2017_001815_335.25745_642.0\"], \"type\": \"scatter\", \"uid\": \"bb6cd70c-765a-4f5a-bd4b-f570019f9826\", \"x\": [125.0, 125.0, 135.0, 135.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"95589e61-205e-4b10-8fab-32d12841de2e\", \"x\": [102.5, 102.5, 130.0, 130.0], \"xaxis\": \"x\", \"y\": [0.2830188679245283, 0.3389830508474576, 0.3389830508474576, 0.2857142857142857], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_261.22073_634.0\", \"cluster: 5, component: QE_2017_001814_261.22073_634.0\", \"cluster: 5, component: QE_2017_001815_335.25784_587.0\", \"cluster: 5, component: QE_2017_001815_335.25784_587.0\"], \"type\": \"scatter\", \"uid\": \"2c6b65ed-e9ba-4931-86d6-25bba9fccde3\", \"x\": [145.0, 145.0, 155.0, 155.0], \"xaxis\": \"x\", \"y\": [0.0, 0.375, 0.375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a282e2d4-d990-4d8c-a3a5-a111e2c9b195\", \"x\": [116.25, 116.25, 150.0, 150.0], \"xaxis\": \"x\", \"y\": [0.3389830508474576, 0.4117647058823529, 0.4117647058823529, 0.375], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_353.26889_609.0\", \"cluster: 5, component: QE_2017_001814_353.26889_609.0\", \"cluster: 5, component: QE_2017_001815_353.26862_642.0\", \"cluster: 5, component: QE_2017_001815_353.26862_642.0\"], \"type\": \"scatter\", \"uid\": \"04261183-868f-4e79-ab0b-e85a9dea84fc\", \"x\": [165.0, 165.0, 175.0, 175.0], \"xaxis\": \"x\", \"y\": [0.0, 0.27419354838709675, 0.27419354838709675, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_335.25772_638.0\", \"cluster: 5, component: QE_2017_001814_335.25772_638.0\", \"cluster: 5, component: QE_2017_001815_335.2579_601.0\", \"cluster: 5, component: QE_2017_001815_335.2579_601.0\"], \"type\": \"scatter\", \"uid\": \"48829a38-aafa-4026-accd-726aeef1c634\", \"x\": [195.0, 195.0, 205.0, 205.0], \"xaxis\": \"x\", \"y\": [0.0, 0.29411764705882354, 0.29411764705882354, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_261.22073_643.0\", \"cluster: 5, component: QE_2017_001815_261.22073_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"0f98bf85-3b32-4c39-a47a-627e96af5537\", \"x\": [185.0, 185.0, 200.0, 200.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38461538461538464, 0.38461538461538464, 0.29411764705882354], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6adb42cd-156f-415b-9fad-50451ad68c4a\", \"x\": [170.0, 170.0, 192.5, 192.5], \"xaxis\": \"x\", \"y\": [0.27419354838709675, 0.43333333333333335, 0.43333333333333335, 0.38461538461538464], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"4c444e4f-e166-47f2-98dd-0518eecc7b8d\", \"x\": [133.125, 133.125, 181.25, 181.25], \"xaxis\": \"x\", \"y\": [0.4117647058823529, 0.46153846153846156, 0.46153846153846156, 0.43333333333333335], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001816_571.47186_717.0\", \"cluster: 5, component: QE_2017_001816_571.47186_717.0\", null, null], \"type\": \"scatter\", \"uid\": \"22bf302d-f372-4b4a-8f09-0ec3eefcae5f\", \"x\": [85.0, 85.0, 157.1875, 157.1875], \"xaxis\": \"x\", \"y\": [0.0, 0.5538461538461539, 0.5538461538461539, 0.46153846153846156], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_507.27145_607.0\", \"cluster: 5, component: QE_2017_001815_507.27145_607.0\", null, null], \"type\": \"scatter\", \"uid\": \"21f08f61-ca21-475e-8a9c-c77484fb892a\", \"x\": [75.0, 75.0, 121.09375, 121.09375], \"xaxis\": \"x\", \"y\": [0.0, 0.5737704918032787, 0.5737704918032787, 0.5538461538461539], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 6, component: QE_2017_001814_497.31033_643.0\", \"cluster: 6, component: QE_2017_001814_497.31033_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"cad71f1f-b46e-4ab7-bc37-c69b917c8f60\", \"x\": [65.0, 65.0, 98.046875, 98.046875], \"xaxis\": \"x\", \"y\": [0.0, 0.6986301369863014, 0.6986301369863014, 0.5737704918032787], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 7, component: QE_2017_001815_571.4292_870.0\", \"cluster: 7, component: QE_2017_001815_571.4292_870.0\", null, null], \"type\": \"scatter\", \"uid\": \"fe091c20-2e51-493c-bda6-33e00553fbde\", \"x\": [55.0, 55.0, 81.5234375, 81.5234375], \"xaxis\": \"x\", \"y\": [0.0, 0.7962962962962963, 0.7962962962962963, 0.6986301369863014], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001814_338.34146_850.0\", \"cluster: 8, component: QE_2017_001814_338.34146_850.0\", \"cluster: 9, component: QE_2017_001815_244.19048_762.0\", \"cluster: 9, component: QE_2017_001815_244.19048_762.0\"], \"type\": \"scatter\", \"uid\": \"cfd6033b-3da0-407e-8323-b5c737fef6f8\", \"x\": [225.0, 225.0, 235.0, 235.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6031746031746031, 0.6031746031746031, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_353.26868_633.0\", \"cluster: 10, component: QE_2017_001814_353.26868_633.0\", \"cluster: 10, component: QE_2017_001816_353.26892_600.0\", \"cluster: 10, component: QE_2017_001816_353.26892_600.0\"], \"type\": \"scatter\", \"uid\": \"d5cb587e-a2a0-47de-9d56-734e27ca2309\", \"x\": [245.0, 245.0, 255.0, 255.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2376237623762376, 0.2376237623762376, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_279.23157_719.0\", \"cluster: 10, component: QE_2017_001814_279.23157_719.0\", \"cluster: 10, component: QE_2017_001815_278.24762_684.0\", \"cluster: 10, component: QE_2017_001815_278.24762_684.0\"], \"type\": \"scatter\", \"uid\": \"070a9ce0-846f-4681-88fd-076d12a7d9ea\", \"x\": [265.0, 265.0, 275.0, 275.0], \"xaxis\": \"x\", \"y\": [0.0, 0.43209876543209874, 0.43209876543209874, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"53fc27de-fd96-4df1-b1d1-5534a2aad9a7\", \"x\": [250.0, 250.0, 270.0, 270.0], \"xaxis\": \"x\", \"y\": [0.2376237623762376, 0.5229357798165137, 0.5229357798165137, 0.43209876543209874], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 11, component: QE_2017_001816_337.27338_826.0\", \"cluster: 11, component: QE_2017_001816_337.27338_826.0\", \"cluster: 11, component: QE_2017_001816_337.27341_632.0\", \"cluster: 11, component: QE_2017_001816_337.27341_632.0\"], \"type\": \"scatter\", \"uid\": \"96826eb6-ec2c-4ec7-a8e5-33962c9fd7a5\", \"x\": [295.0, 295.0, 305.0, 305.0], \"xaxis\": \"x\", \"y\": [0.0, 0.373134328358209, 0.373134328358209, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 11, component: QE_2017_001816_435.25037_666.0\", \"cluster: 11, component: QE_2017_001816_435.25037_666.0\", null, null], \"type\": \"scatter\", \"uid\": \"e8b6b59d-6993-4ac5-b495-ec1662927b0a\", \"x\": [285.0, 285.0, 300.0, 300.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5416666666666666, 0.5416666666666666, 0.373134328358209], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8cd8ab0b-ba2a-4875-8315-6efaf04b1927\", \"x\": [260.0, 260.0, 292.5, 292.5], \"xaxis\": \"x\", \"y\": [0.5229357798165137, 0.6875, 0.6875, 0.5416666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7d1a2eab-b331-4950-b165-1c6b1ffa4c14\", \"x\": [230.0, 230.0, 276.25, 276.25], \"xaxis\": \"x\", \"y\": [0.6031746031746031, 0.7590361445783133, 0.7590361445783133, 0.6875], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 12, component: QE_2017_001816_272.25824_582.0\", \"cluster: 12, component: QE_2017_001816_272.25824_582.0\", null, null], \"type\": \"scatter\", \"uid\": \"c4b0f58b-3cc6-46d9-82e4-8159661e83d8\", \"x\": [215.0, 215.0, 253.125, 253.125], \"xaxis\": \"x\", \"y\": [0.0, 0.8243243243243243, 0.8243243243243243, 0.7590361445783133], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"0a2fd2f0-4a75-4696-a7a9-2d83eecfe92a\", \"x\": [68.26171875, 68.26171875, 234.0625, 234.0625], \"xaxis\": \"x\", \"y\": [0.7962962962962963, 0.87, 0.87, 0.8243243243243243], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ad950ac6-592b-42d5-99fc-c6281657cb30\", \"x\": [26.25, 26.25, 151.162109375, 151.162109375], \"xaxis\": \"x\", \"y\": [0.7763157894736842, 0.9130434782608695, 0.9130434782608695, 0.87], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 13, component: QE_2017_001814_601.42426_706.0\", \"cluster: 13, component: QE_2017_001814_601.42426_706.0\", \"cluster: 14, component: QE_2017_001816_599.40869_793.0\", \"cluster: 14, component: QE_2017_001816_599.40869_793.0\"], \"type\": \"scatter\", \"uid\": \"d6ebf44d-48fe-4daa-99cb-9f27943bbc13\", \"x\": [345.0, 345.0, 355.0, 355.0], \"xaxis\": \"x\", \"y\": [0.0, 0.63, 0.63, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 15, component: QE_2017_001816_599.40948_660.0\", \"cluster: 15, component: QE_2017_001816_599.40948_660.0\", null, null], \"type\": \"scatter\", \"uid\": \"e28a1fdb-c76f-4705-adf3-a9c59bdf2378\", \"x\": [335.0, 335.0, 350.0, 350.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6710526315789473, 0.6710526315789473, 0.63], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001816_583.41382_731.0\", \"cluster: 16, component: QE_2017_001816_583.41382_731.0\", null, null], \"type\": \"scatter\", \"uid\": \"c89de9a0-5ce4-48b5-a737-8ed39f881e87\", \"x\": [325.0, 325.0, 342.5, 342.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7578947368421053, 0.7578947368421053, 0.6710526315789473], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 17, component: QE_2017_001814_618.42633_695.0\", \"cluster: 17, component: QE_2017_001814_618.42633_695.0\", null, null], \"type\": \"scatter\", \"uid\": \"3001fcab-649c-42a4-a674-a6b55234e8d9\", \"x\": [315.0, 315.0, 333.75, 333.75], \"xaxis\": \"x\", \"y\": [0.0, 0.8, 0.8, 0.7578947368421053], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 18, component: QE_2017_001815_618.42773_646.0\", \"cluster: 18, component: QE_2017_001815_618.42773_646.0\", \"cluster: 18, component: QE_2017_001816_618.427_682.0\", \"cluster: 18, component: QE_2017_001816_618.427_682.0\"], \"type\": \"scatter\", \"uid\": \"8dfff2ac-77e8-4c18-9861-13cc3b1034fa\", \"x\": [365.0, 365.0, 375.0, 375.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4732510288065844, 0.4732510288065844, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 19, component: QE_2017_001814_583.41406_682.0\", \"cluster: 19, component: QE_2017_001814_583.41406_682.0\", \"cluster: 19, component: QE_2017_001815_583.41406_707.0\", \"cluster: 19, component: QE_2017_001815_583.41406_707.0\"], \"type\": \"scatter\", \"uid\": \"67aa2695-7a1d-40f6-abaf-09698886f3f1\", \"x\": [405.0, 405.0, 415.0, 415.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5280898876404494, 0.5280898876404494, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 20, component: QE_2017_001814_565.4035_722.0\", \"cluster: 20, component: QE_2017_001814_565.4035_722.0\", null, null], \"type\": \"scatter\", \"uid\": \"845fa2e3-aa8a-4cea-920c-8c183575bd6c\", \"x\": [395.0, 395.0, 410.0, 410.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6049382716049383, 0.6049382716049383, 0.5280898876404494], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 21, component: QE_2017_001815_583.41388_735.0\", \"cluster: 21, component: QE_2017_001815_583.41388_735.0\", \"cluster: 21, component: QE_2017_001815_583.41418_647.0\", \"cluster: 21, component: QE_2017_001815_583.41418_647.0\"], \"type\": \"scatter\", \"uid\": \"4ceaaf57-31ba-4231-be4e-366ad0a851ad\", \"x\": [435.0, 435.0, 445.0, 445.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5285714285714286, 0.5285714285714286, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 22, component: QE_2017_001814_601.42334_783.0\", \"cluster: 22, component: QE_2017_001814_601.42334_783.0\", null, null], \"type\": \"scatter\", \"uid\": \"ef58a0bf-c461-4141-8143-c58bb9219789\", \"x\": [425.0, 425.0, 440.0, 440.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6966292134831461, 0.6966292134831461, 0.5285714285714286], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"4f6c6ed6-2b36-4cbf-9dda-2b7a9efd9961\", \"x\": [402.5, 402.5, 432.5, 432.5], \"xaxis\": \"x\", \"y\": [0.6049382716049383, 0.734375, 0.734375, 0.6966292134831461], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 23, component: QE_2017_001815_568.42627_841.0\", \"cluster: 23, component: QE_2017_001815_568.42627_841.0\", null, null], \"type\": \"scatter\", \"uid\": \"5c4cf680-1e79-403d-9fea-80578df2a450\", \"x\": [385.0, 385.0, 417.5, 417.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7642276422764228, 0.7642276422764228, 0.734375], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"d46a72ff-a2b5-41fa-b022-fe541b2c31da\", \"x\": [370.0, 370.0, 401.25, 401.25], \"xaxis\": \"x\", \"y\": [0.4732510288065844, 0.8205128205128205, 0.8205128205128205, 0.7642276422764228], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"9e675c91-de44-4ef0-a24f-833673851053\", \"x\": [324.375, 324.375, 385.625, 385.625], \"xaxis\": \"x\", \"y\": [0.8, 0.94, 0.94, 0.8205128205128205], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"4d172796-9bf5-45a2-a0e7-88a8ae70f4a5\", \"x\": [88.7060546875, 88.7060546875, 355.0, 355.0], \"xaxis\": \"x\", \"y\": [0.9130434782608695, 0.9625, 0.9625, 0.94], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 24, component: QE_2017_001814_194.04424_237.0\", \"cluster: 24, component: QE_2017_001814_194.04424_237.0\", \"cluster: 25, component: QE_2017_001815_194.11751_218.0\", \"cluster: 25, component: QE_2017_001815_194.11751_218.0\"], \"type\": \"scatter\", \"uid\": \"be00210e-a73e-4d0c-b8d3-6a8e55c6f0f1\", \"x\": [455.0, 455.0, 465.0, 465.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6206896551724138, 0.6206896551724138, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001815_194.04471_314.0\", \"cluster: 26, component: QE_2017_001815_194.04471_314.0\", \"cluster: 26, component: QE_2017_001815_212.05513_328.0\", \"cluster: 26, component: QE_2017_001815_212.05513_328.0\"], \"type\": \"scatter\", \"uid\": \"582776ca-74c8-420a-93f8-469752de6679\", \"x\": [485.0, 485.0, 495.0, 495.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35135135135135137, 0.35135135135135137, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001815_194.04469_299.0\", \"cluster: 26, component: QE_2017_001815_194.04469_299.0\", null, null], \"type\": \"scatter\", \"uid\": \"bdb56b39-351f-475f-95f5-53fbbcbae058\", \"x\": [475.0, 475.0, 490.0, 490.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5573770491803278, 0.5573770491803278, 0.35135135135135137], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 27, component: QE_2017_001814_226.07077_397.0\", \"cluster: 27, component: QE_2017_001814_226.07077_397.0\", \"cluster: 28, component: QE_2017_001815_194.04471_397.0\", \"cluster: 28, component: QE_2017_001815_194.04471_397.0\"], \"type\": \"scatter\", \"uid\": \"f5cf0160-5600-48ea-b532-d7fcc47fb1a8\", \"x\": [515.0, 515.0, 525.0, 525.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6285714285714286, 0.6285714285714286, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 29, component: QE_2017_001815_212.05505_267.0\", \"cluster: 29, component: QE_2017_001815_212.05505_267.0\", null, null], \"type\": \"scatter\", \"uid\": \"34ebf0b9-e3b0-4857-a99f-8f4728f2182b\", \"x\": [505.0, 505.0, 520.0, 520.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7, 0.7, 0.6285714285714286], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5dfb2140-849a-45ce-8926-147c492ed653\", \"x\": [482.5, 482.5, 512.5, 512.5], \"xaxis\": \"x\", \"y\": [0.5573770491803278, 0.8360655737704918, 0.8360655737704918, 0.7], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6d43311a-986b-48f4-82d9-0e54925bf7f1\", \"x\": [460.0, 460.0, 497.5, 497.5], \"xaxis\": \"x\", \"y\": [0.6206896551724138, 0.8548387096774194, 0.8548387096774194, 0.8360655737704918], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 30, component: QE_2017_001816_533.15442_247.0\", \"cluster: 30, component: QE_2017_001816_533.15442_247.0\", \"cluster: 30, component: QE_2017_001816_533.15466_222.0\", \"cluster: 30, component: QE_2017_001816_533.15466_222.0\"], \"type\": \"scatter\", \"uid\": \"6bc2b2fd-9c59-4a32-bee2-eb9eebae5d8f\", \"x\": [535.0, 535.0, 545.0, 545.0], \"xaxis\": \"x\", \"y\": [0.0, 0.36764705882352944, 0.36764705882352944, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 30, component: QE_2017_001815_533.1546_207.0\", \"cluster: 30, component: QE_2017_001815_533.1546_207.0\", \"cluster: 30, component: QE_2017_001816_533.1546_271.0\", \"cluster: 30, component: QE_2017_001816_533.1546_271.0\"], \"type\": \"scatter\", \"uid\": \"52aa83ac-7f87-4c30-a60c-e33675e84e33\", \"x\": [555.0, 555.0, 565.0, 565.0], \"xaxis\": \"x\", \"y\": [0.0, 0.45454545454545453, 0.45454545454545453, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"db4c1e24-e96c-454b-ae49-d7f6c84c4f36\", \"x\": [540.0, 540.0, 560.0, 560.0], \"xaxis\": \"x\", \"y\": [0.36764705882352944, 0.5, 0.5, 0.45454545454545453], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 31, component: QE_2017_001814_347.09097_122.0\", \"cluster: 31, component: QE_2017_001814_347.09097_122.0\", \"cluster: 31, component: QE_2017_001815_347.09067_204.0\", \"cluster: 31, component: QE_2017_001815_347.09067_204.0\"], \"type\": \"scatter\", \"uid\": \"86a7a3bb-89c4-441d-9e93-c52567cf5829\", \"x\": [575.0, 575.0, 585.0, 585.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5098039215686274, 0.5098039215686274, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6d36ee43-d471-4b8a-8a78-1708a35baf98\", \"x\": [550.0, 550.0, 580.0, 580.0], \"xaxis\": \"x\", \"y\": [0.5, 0.8804347826086957, 0.8804347826086957, 0.5098039215686274], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"94ca2006-9f66-4543-8b61-8c867e7ede70\", \"x\": [478.75, 478.75, 565.0, 565.0], \"xaxis\": \"x\", \"y\": [0.8548387096774194, 0.9857142857142858, 0.9857142857142858, 0.8804347826086957], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 32, component: QE_2017_001815_268.10373_58.0\", \"cluster: 32, component: QE_2017_001815_268.10373_58.0\", \"cluster: 32, component: QE_2017_001816_269.16055_60.0\", \"cluster: 32, component: QE_2017_001816_269.16055_60.0\"], \"type\": \"scatter\", \"uid\": \"021c5c26-e31d-4bce-8c68-efe58a109250\", \"x\": [595.0, 595.0, 605.0, 605.0], \"xaxis\": \"x\", \"y\": [0.0, 0.42424242424242425, 0.42424242424242425, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 33, component: QE_2017_001816_408.36832_704.0\", \"cluster: 33, component: QE_2017_001816_408.36832_704.0\", \"cluster: 33, component: QE_2017_001816_466.40979_731.0\", \"cluster: 33, component: QE_2017_001816_466.40979_731.0\"], \"type\": \"scatter\", \"uid\": \"75593aff-c94b-473e-b371-f66226281011\", \"x\": [625.0, 625.0, 635.0, 635.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5882352941176471, 0.5882352941176471, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 34, component: QE_2017_001815_364.34189_705.0\", \"cluster: 34, component: QE_2017_001815_364.34189_705.0\", null, null], \"type\": \"scatter\", \"uid\": \"b985799d-1323-4d23-a1cb-9530dad06b7c\", \"x\": [615.0, 615.0, 630.0, 630.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6875, 0.6875, 0.5882352941176471], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 35, component: QE_2017_001814_364.34244_761.0\", \"cluster: 35, component: QE_2017_001814_364.34244_761.0\", \"cluster: 35, component: QE_2017_001815_364.34253_752.0\", \"cluster: 35, component: QE_2017_001815_364.34253_752.0\"], \"type\": \"scatter\", \"uid\": \"ae58a457-ec0c-42b1-9364-58c0fc647c6f\", \"x\": [665.0, 665.0, 675.0, 675.0], \"xaxis\": \"x\", \"y\": [0.0, 0.36363636363636365, 0.36363636363636365, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 36, component: QE_2017_001816_421.35226_731.0\", \"cluster: 36, component: QE_2017_001816_421.35226_731.0\", \"cluster: 36, component: QE_2017_001816_424.36325_712.0\", \"cluster: 36, component: QE_2017_001816_424.36325_712.0\"], \"type\": \"scatter\", \"uid\": \"fb132a62-ad37-42f8-b9c3-8e64397f0c25\", \"x\": [685.0, 685.0, 695.0, 695.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3888888888888889, 0.3888888888888889, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f374c455-cf22-4b01-b731-c1aed317cad7\", \"x\": [670.0, 670.0, 690.0, 690.0], \"xaxis\": \"x\", \"y\": [0.36363636363636365, 0.6111111111111112, 0.6111111111111112, 0.3888888888888889], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 37, component: QE_2017_001815_482.40488_739.0\", \"cluster: 37, component: QE_2017_001815_482.40488_739.0\", null, null], \"type\": \"scatter\", \"uid\": \"e9c7dc0e-6db5-4978-aa56-caa098f31270\", \"x\": [655.0, 655.0, 680.0, 680.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7037037037037037, 0.7037037037037037, 0.6111111111111112], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 38, component: QE_2017_001815_408.36853_717.0\", \"cluster: 38, component: QE_2017_001815_408.36853_717.0\", null, null], \"type\": \"scatter\", \"uid\": \"31fe61de-dc72-479c-b5d6-92ba40d78048\", \"x\": [645.0, 645.0, 667.5, 667.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7307692307692307, 0.7307692307692307, 0.7037037037037037], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"fbcaea57-9f6d-4773-acea-57d4bcee138e\", \"x\": [622.5, 622.5, 656.25, 656.25], \"xaxis\": \"x\", \"y\": [0.6875, 0.8387096774193549, 0.8387096774193549, 0.7307692307692307], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1c6f4d49-05e0-468a-8b09-ffd723f3509d\", \"x\": [600.0, 600.0, 639.375, 639.375], \"xaxis\": \"x\", \"y\": [0.42424242424242425, 0.9814814814814815, 0.9814814814814815, 0.8387096774193549], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 39, component: QE_2017_001814_611.15997_285.0\", \"cluster: 39, component: QE_2017_001814_611.15997_285.0\", \"cluster: 39, component: QE_2017_001815_611.16046_309.0\", \"cluster: 39, component: QE_2017_001815_611.16046_309.0\"], \"type\": \"scatter\", \"uid\": \"7d6a8523-fffe-45af-84e0-c82d409749eb\", \"x\": [715.0, 715.0, 725.0, 725.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4583333333333333, 0.4583333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 40, component: QE_2017_001814_339.10742_366.0\", \"cluster: 40, component: QE_2017_001814_339.10742_366.0\", \"cluster: 40, component: QE_2017_001816_339.10733_298.0\", \"cluster: 40, component: QE_2017_001816_339.10733_298.0\"], \"type\": \"scatter\", \"uid\": \"04afac7d-967c-41cc-9b2c-410a50138280\", \"x\": [735.0, 735.0, 745.0, 745.0], \"xaxis\": \"x\", \"y\": [0.0, 0.44, 0.44, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001814_231.04971_516.0\", \"cluster: 41, component: QE_2017_001814_231.04971_516.0\", \"cluster: 41, component: QE_2017_001815_231.04971_369.0\", \"cluster: 41, component: QE_2017_001815_231.04971_369.0\"], \"type\": \"scatter\", \"uid\": \"2cfbf753-604b-4749-9066-a0dc2a68c0e1\", \"x\": [795.0, 795.0, 805.0, 805.0], \"xaxis\": \"x\", \"y\": [0.0, 0.391304347826087, 0.391304347826087, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001815_231.04968_315.0\", \"cluster: 41, component: QE_2017_001815_231.04968_315.0\", null, null], \"type\": \"scatter\", \"uid\": \"ad3e38a0-e6a4-4ccf-b20c-fe0c620a662c\", \"x\": [785.0, 785.0, 800.0, 800.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4090909090909091, 0.4090909090909091, 0.391304347826087], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001815_231.04973_403.0\", \"cluster: 41, component: QE_2017_001815_231.04973_403.0\", null, null], \"type\": \"scatter\", \"uid\": \"1ab41b3c-020f-4e48-87dd-0913e95583f6\", \"x\": [775.0, 775.0, 792.5, 792.5], \"xaxis\": \"x\", \"y\": [0.0, 0.52, 0.52, 0.4090909090909091], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 42, component: QE_2017_001815_340.16019_314.0\", \"cluster: 42, component: QE_2017_001815_340.16019_314.0\", null, null], \"type\": \"scatter\", \"uid\": \"4f978ba7-28a3-4653-a47e-d0133137819c\", \"x\": [765.0, 765.0, 783.75, 783.75], \"xaxis\": \"x\", \"y\": [0.0, 0.6904761904761905, 0.6904761904761905, 0.52], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 43, component: QE_2017_001815_314.14453_76.0\", \"cluster: 43, component: QE_2017_001815_314.14453_76.0\", \"cluster: 43, component: QE_2017_001816_314.14462_79.0\", \"cluster: 43, component: QE_2017_001816_314.14462_79.0\"], \"type\": \"scatter\", \"uid\": \"55346262-dbe4-4c5a-8abb-670bbf541144\", \"x\": [815.0, 815.0, 825.0, 825.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4230769230769231, 0.4230769230769231, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 44, component: QE_2017_001816_310.14957_134.0\", \"cluster: 44, component: QE_2017_001816_310.14957_134.0\", \"cluster: 45, component: QE_2017_001816_342.17584_257.0\", \"cluster: 45, component: QE_2017_001816_342.17584_257.0\"], \"type\": \"scatter\", \"uid\": \"df5a923e-263e-42fb-b41e-7d7b8916cf8f\", \"x\": [835.0, 835.0, 845.0, 845.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6785714285714286, 0.6785714285714286, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"cec5e962-9b69-4f31-b358-adf24ee23996\", \"x\": [820.0, 820.0, 840.0, 840.0], \"xaxis\": \"x\", \"y\": [0.4230769230769231, 0.75, 0.75, 0.6785714285714286], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1c40baff-76ae-41ab-998b-6a80dd3d74de\", \"x\": [774.375, 774.375, 830.0, 830.0], \"xaxis\": \"x\", \"y\": [0.6904761904761905, 0.8, 0.8, 0.75], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 46, component: QE_2017_001814_498.2543_475.0\", \"cluster: 46, component: QE_2017_001814_498.2543_475.0\", null, null], \"type\": \"scatter\", \"uid\": \"5267c712-f544-4dea-826e-544ec1da1711\", \"x\": [755.0, 755.0, 802.1875, 802.1875], \"xaxis\": \"x\", \"y\": [0.0, 0.8571428571428571, 0.8571428571428571, 0.8], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e97e6990-f5c0-4662-9df0-2076ae28de50\", \"x\": [740.0, 740.0, 778.59375, 778.59375], \"xaxis\": \"x\", \"y\": [0.44, 0.8775510204081632, 0.8775510204081632, 0.8571428571428571], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 47, component: QE_2017_001814_241.15466_73.0\", \"cluster: 47, component: QE_2017_001814_241.15466_73.0\", \"cluster: 48, component: QE_2017_001815_507.18192_178.0\", \"cluster: 48, component: QE_2017_001815_507.18192_178.0\"], \"type\": \"scatter\", \"uid\": \"7eb90103-ac73-42c0-b498-efd65faeefb8\", \"x\": [855.0, 855.0, 865.0, 865.0], \"xaxis\": \"x\", \"y\": [0.0, 0.9152542372881356, 0.9152542372881356, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"fc470126-c7b9-440f-ae81-988b17686be5\", \"x\": [759.296875, 759.296875, 860.0, 860.0], \"xaxis\": \"x\", \"y\": [0.8775510204081632, 0.9302325581395349, 0.9302325581395349, 0.9152542372881356], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"0e36ce77-3595-442e-9119-05f2fbeb5965\", \"x\": [720.0, 720.0, 809.6484375, 809.6484375], \"xaxis\": \"x\", \"y\": [0.4583333333333333, 0.9622641509433962, 0.9622641509433962, 0.9302325581395349], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 49, component: QE_2017_001816_463.12311_410.0\", \"cluster: 49, component: QE_2017_001816_463.12311_410.0\", null, null], \"type\": \"scatter\", \"uid\": \"ad90c3fe-3abb-42ab-887c-637de620360b\", \"x\": [705.0, 705.0, 764.82421875, 764.82421875], \"xaxis\": \"x\", \"y\": [0.0, 0.9696969696969697, 0.9696969696969697, 0.9622641509433962], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 50, component: QE_2017_001814_320.29456_577.0\", \"cluster: 50, component: QE_2017_001814_320.29456_577.0\", \"cluster: 50, component: QE_2017_001815_320.29471_563.0\", \"cluster: 50, component: QE_2017_001815_320.29471_563.0\"], \"type\": \"scatter\", \"uid\": \"7c27fe1a-67f3-49fd-929b-7ffb02136fa4\", \"x\": [895.0, 895.0, 905.0, 905.0], \"xaxis\": \"x\", \"y\": [0.0, 0.36, 0.36, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 51, component: QE_2017_001816_338.26062_643.0\", \"cluster: 51, component: QE_2017_001816_338.26062_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"824cde00-c25d-4e57-981a-5e3b77bc9737\", \"x\": [885.0, 885.0, 900.0, 900.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6153846153846154, 0.6153846153846154, 0.36], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 52, component: QE_2017_001814_483.27118_651.0\", \"cluster: 52, component: QE_2017_001814_483.27118_651.0\", null, null], \"type\": \"scatter\", \"uid\": \"7b7f49c0-eb95-4cc9-81f8-fbd477992c64\", \"x\": [875.0, 875.0, 892.5, 892.5], \"xaxis\": \"x\", \"y\": [0.0, 0.8636363636363636, 0.8636363636363636, 0.6153846153846154], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 53, component: QE_2017_001815_129.12741_349.0\", \"cluster: 53, component: QE_2017_001815_129.12741_349.0\", \"cluster: 54, component: QE_2017_001815_171.14914_420.0\", \"cluster: 54, component: QE_2017_001815_171.14914_420.0\"], \"type\": \"scatter\", \"uid\": \"b6d5eb7c-1862-444c-996d-ebffe51e1ab6\", \"x\": [915.0, 915.0, 925.0, 925.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8666666666666667, 0.8666666666666667, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5a4251e6-4288-4d9e-9e34-5f0fb0513ae3\", \"x\": [883.75, 883.75, 920.0, 920.0], \"xaxis\": \"x\", \"y\": [0.8636363636363636, 0.9032258064516129, 0.9032258064516129, 0.8666666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 55, component: QE_2017_001815_201.16367_442.0\", \"cluster: 55, component: QE_2017_001815_201.16367_442.0\", \"cluster: 55, component: QE_2017_001816_201.16362_435.0\", \"cluster: 55, component: QE_2017_001816_201.16362_435.0\"], \"type\": \"scatter\", \"uid\": \"d1f0d570-b546-4a28-8cb8-3753c12a2ae6\", \"x\": [935.0, 935.0, 945.0, 945.0], \"xaxis\": \"x\", \"y\": [0.0, 0.48333333333333334, 0.48333333333333334, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 56, component: QE_2017_001815_209.1535_312.0\", \"cluster: 56, component: QE_2017_001815_209.1535_312.0\", \"cluster: 56, component: QE_2017_001816_209.15344_311.0\", \"cluster: 56, component: QE_2017_001816_209.15344_311.0\"], \"type\": \"scatter\", \"uid\": \"8e846a58-89eb-4ead-bfd9-24c738aad9cb\", \"x\": [975.0, 975.0, 985.0, 985.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2916666666666667, 0.2916666666666667, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 56, component: QE_2017_001815_209.15349_295.0\", \"cluster: 56, component: QE_2017_001815_209.15349_295.0\", null, null], \"type\": \"scatter\", \"uid\": \"f614c836-cd9d-4cd3-97f0-a58ecae03642\", \"x\": [965.0, 965.0, 980.0, 980.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3835616438356164, 0.3835616438356164, 0.2916666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 56, component: QE_2017_001815_209.15352_479.0\", \"cluster: 56, component: QE_2017_001815_209.15352_479.0\", null, null], \"type\": \"scatter\", \"uid\": \"34052197-20e5-4801-a972-5c1bb5d50578\", \"x\": [955.0, 955.0, 972.5, 972.5], \"xaxis\": \"x\", \"y\": [0.0, 0.4473684210526316, 0.4473684210526316, 0.3835616438356164], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 57, component: QE_2017_001814_243.15892_533.0\", \"cluster: 57, component: QE_2017_001814_243.15892_533.0\", \"cluster: 57, component: QE_2017_001814_281.1745_492.0\", \"cluster: 57, component: QE_2017_001814_281.1745_492.0\"], \"type\": \"scatter\", \"uid\": \"5431fce4-fcee-4341-b9a3-99dfc12ca4f8\", \"x\": [995.0, 995.0, 1005.0, 1005.0], \"xaxis\": \"x\", \"y\": [0.0, 0.359375, 0.359375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 57, component: QE_2017_001815_227.16408_344.0\", \"cluster: 57, component: QE_2017_001815_227.16408_344.0\", \"cluster: 57, component: QE_2017_001815_283.19009_564.0\", \"cluster: 57, component: QE_2017_001815_283.19009_564.0\"], \"type\": \"scatter\", \"uid\": \"d1f465bd-ac7a-4c15-9bfb-15a470cab274\", \"x\": [1025.0, 1025.0, 1035.0, 1035.0], \"xaxis\": \"x\", \"y\": [0.0, 0.47191011235955055, 0.47191011235955055, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 57, component: QE_2017_001814_293.2106_579.0\", \"cluster: 57, component: QE_2017_001814_293.2106_579.0\", null, null], \"type\": \"scatter\", \"uid\": \"878ae246-2b53-471a-ba69-71b478d1c2aa\", \"x\": [1015.0, 1015.0, 1030.0, 1030.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5454545454545454, 0.5454545454545454, 0.47191011235955055], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bd7a22e6-fa2f-4b67-99b8-17c9f79db5a2\", \"x\": [1000.0, 1000.0, 1022.5, 1022.5], \"xaxis\": \"x\", \"y\": [0.359375, 0.6, 0.6, 0.5454545454545454], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"58c276e8-cb6d-4ed4-8491-84700a7ed527\", \"x\": [963.75, 963.75, 1011.25, 1011.25], \"xaxis\": \"x\", \"y\": [0.4473684210526316, 0.6494845360824743, 0.6494845360824743, 0.6], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 58, component: QE_2017_001814_227.1275_293.0\", \"cluster: 58, component: QE_2017_001814_227.1275_293.0\", \"cluster: 58, component: QE_2017_001816_227.12766_295.0\", \"cluster: 58, component: QE_2017_001816_227.12766_295.0\"], \"type\": \"scatter\", \"uid\": \"a19c14f7-99c1-4b36-ba55-bdb9f3e18f03\", \"x\": [1055.0, 1055.0, 1065.0, 1065.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3382352941176471, 0.3382352941176471, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 59, component: QE_2017_001815_207.13785_297.0\", \"cluster: 59, component: QE_2017_001815_207.13785_297.0\", null, null], \"type\": \"scatter\", \"uid\": \"e98cd654-d886-4f9c-badc-f0e8e4da7156\", \"x\": [1045.0, 1045.0, 1060.0, 1060.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6710526315789473, 0.6710526315789473, 0.3382352941176471], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6afd2da4-7b78-48c5-bf7f-39f561494d4d\", \"x\": [987.5, 987.5, 1052.5, 1052.5], \"xaxis\": \"x\", \"y\": [0.6494845360824743, 0.7058823529411765, 0.7058823529411765, 0.6710526315789473], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 60, component: QE_2017_001815_181.1221_767.0\", \"cluster: 60, component: QE_2017_001815_181.1221_767.0\", \"cluster: 60, component: QE_2017_001816_181.12199_794.0\", \"cluster: 60, component: QE_2017_001816_181.12199_794.0\"], \"type\": \"scatter\", \"uid\": \"e4a62c0c-149e-4f72-9cc7-066a0685e444\", \"x\": [1075.0, 1075.0, 1085.0, 1085.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001814_211.16902_440.0\", \"cluster: 61, component: QE_2017_001814_211.16902_440.0\", \"cluster: 61, component: QE_2017_001815_211.16913_450.0\", \"cluster: 61, component: QE_2017_001815_211.16913_450.0\"], \"type\": \"scatter\", \"uid\": \"35be1401-b404-456a-8431-6181be1f765b\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"xaxis\": \"x\", \"y\": [0.0, 0.19230769230769232, 0.19230769230769232, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001815_209.0807_405.0\", \"cluster: 61, component: QE_2017_001815_209.0807_405.0\", null, null], \"type\": \"scatter\", \"uid\": \"7327559f-53da-40f8-9b0a-9c77941969d1\", \"x\": [1105.0, 1105.0, 1120.0, 1120.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21153846153846154, 0.21153846153846154, 0.19230769230769232], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001816_211.16916_405.0\", \"cluster: 61, component: QE_2017_001816_211.16916_405.0\", null, null], \"type\": \"scatter\", \"uid\": \"2ae5b9f0-4202-4e3e-a9a0-56c92f76504e\", \"x\": [1095.0, 1095.0, 1112.5, 1112.5], \"xaxis\": \"x\", \"y\": [0.0, 0.3, 0.3, 0.21153846153846154], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 61, component: QE_2017_001815_215.164_550.0\", \"cluster: 61, component: QE_2017_001815_215.164_550.0\", \"cluster: 61, component: QE_2017_001816_215.16411_482.0\", \"cluster: 61, component: QE_2017_001816_215.16411_482.0\"], \"type\": \"scatter\", \"uid\": \"2f6198ff-1332-473a-b3a5-0b0a07263c99\", \"x\": [1135.0, 1135.0, 1145.0, 1145.0], \"xaxis\": \"x\", \"y\": [0.0, 0.48717948717948717, 0.48717948717948717, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bb4cf674-0c32-4801-a5f6-69cff28c615e\", \"x\": [1103.75, 1103.75, 1140.0, 1140.0], \"xaxis\": \"x\", \"y\": [0.3, 0.5818181818181818, 0.5818181818181818, 0.48717948717948717], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3381350b-1d83-41e3-8df0-97fc25ddf114\", \"x\": [1080.0, 1080.0, 1121.875, 1121.875], \"xaxis\": \"x\", \"y\": [0.2857142857142857, 0.7446808510638298, 0.7446808510638298, 0.5818181818181818], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a97992cb-f283-460b-9c89-46c6cd10f887\", \"x\": [1020.0, 1020.0, 1100.9375, 1100.9375], \"xaxis\": \"x\", \"y\": [0.7058823529411765, 0.7631578947368421, 0.7631578947368421, 0.7446808510638298], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 62, component: QE_2017_001814_219.17416_517.0\", \"cluster: 62, component: QE_2017_001814_219.17416_517.0\", \"cluster: 62, component: QE_2017_001815_219.17421_516.0\", \"cluster: 62, component: QE_2017_001815_219.17421_516.0\"], \"type\": \"scatter\", \"uid\": \"609a342c-34a8-4b10-9e87-8596ed33f865\", \"x\": [1165.0, 1165.0, 1175.0, 1175.0], \"xaxis\": \"x\", \"y\": [0.0, 0.25, 0.25, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 62, component: QE_2017_001814_219.17401_452.0\", \"cluster: 62, component: QE_2017_001814_219.17401_452.0\", \"cluster: 62, component: QE_2017_001814_219.17409_442.0\", \"cluster: 62, component: QE_2017_001814_219.17409_442.0\"], \"type\": \"scatter\", \"uid\": \"25ee3e40-b29d-4e9d-9b3f-2196fa61afb5\", \"x\": [1195.0, 1195.0, 1205.0, 1205.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3125, 0.3125, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 62, component: QE_2017_001816_219.17438_502.0\", \"cluster: 62, component: QE_2017_001816_219.17438_502.0\", null, null], \"type\": \"scatter\", \"uid\": \"b3d110e2-7676-4d3f-aeea-7d25ea0d345e\", \"x\": [1185.0, 1185.0, 1200.0, 1200.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4074074074074074, 0.4074074074074074, 0.3125], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"217f1dd9-77ec-4f22-aa98-7027f2a4a201\", \"x\": [1170.0, 1170.0, 1192.5, 1192.5], \"xaxis\": \"x\", \"y\": [0.25, 0.4583333333333333, 0.4583333333333333, 0.4074074074074074], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 63, component: QE_2017_001815_191.14287_312.0\", \"cluster: 63, component: QE_2017_001815_191.14287_312.0\", \"cluster: 63, component: QE_2017_001816_191.14291_404.0\", \"cluster: 63, component: QE_2017_001816_191.14291_404.0\"], \"type\": \"scatter\", \"uid\": \"24ba046d-c33a-4319-8897-acdce29cdc49\", \"x\": [1225.0, 1225.0, 1235.0, 1235.0], \"xaxis\": \"x\", \"y\": [0.0, 0.43103448275862066, 0.43103448275862066, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 63, component: QE_2017_001814_191.14291_389.0\", \"cluster: 63, component: QE_2017_001814_191.14291_389.0\", null, null], \"type\": \"scatter\", \"uid\": \"b65a2850-c8cd-4084-8d18-011f45255c78\", \"x\": [1215.0, 1215.0, 1230.0, 1230.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5, 0.5, 0.43103448275862066], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3e717111-c041-4927-9093-cc528c8f2ea9\", \"x\": [1181.25, 1181.25, 1222.5, 1222.5], \"xaxis\": \"x\", \"y\": [0.4583333333333333, 0.68, 0.68, 0.5], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 64, component: QE_2017_001816_137.09584_445.0\", \"cluster: 64, component: QE_2017_001816_137.09584_445.0\", null, null], \"type\": \"scatter\", \"uid\": \"33ea5464-090d-439f-ae1b-798a05d2aa04\", \"x\": [1155.0, 1155.0, 1201.875, 1201.875], \"xaxis\": \"x\", \"y\": [0.0, 0.782608695652174, 0.782608695652174, 0.68], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ec16378c-31ab-4dfa-861b-5db985869d7e\", \"x\": [1060.46875, 1060.46875, 1178.4375, 1178.4375], \"xaxis\": \"x\", \"y\": [0.7631578947368421, 0.8170731707317073, 0.8170731707317073, 0.782608695652174], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"dbd8d6d7-36f5-4016-b709-37754c19a239\", \"x\": [940.0, 940.0, 1119.453125, 1119.453125], \"xaxis\": \"x\", \"y\": [0.48333333333333334, 0.8421052631578947, 0.8421052631578947, 0.8170731707317073], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 65, component: QE_2017_001814_209.08058_363.0\", \"cluster: 65, component: QE_2017_001814_209.08058_363.0\", \"cluster: 66, component: QE_2017_001816_207.13779_561.0\", \"cluster: 66, component: QE_2017_001816_207.13779_561.0\"], \"type\": \"scatter\", \"uid\": \"0cc87e2b-362f-44ea-b45c-0f2e8e5f079a\", \"x\": [1245.0, 1245.0, 1255.0, 1255.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8556701030927835, 0.8556701030927835, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"66173ff5-024a-481d-b4e2-bbde4f92f000\", \"x\": [1029.7265625, 1029.7265625, 1250.0, 1250.0], \"xaxis\": \"x\", \"y\": [0.8421052631578947, 0.9135802469135802, 0.9135802469135802, 0.8556701030927835], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"eb5d3e41-52a7-4010-9723-1ecb978918a6\", \"x\": [901.875, 901.875, 1139.86328125, 1139.86328125], \"xaxis\": \"x\", \"y\": [0.9032258064516129, 0.9882352941176471, 0.9882352941176471, 0.9135802469135802], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 67, component: QE_2017_001815_333.15173_245.0\", \"cluster: 67, component: QE_2017_001815_333.15173_245.0\", \"cluster: 68, component: QE_2017_001816_333.15204_235.0\", \"cluster: 68, component: QE_2017_001816_333.15204_235.0\"], \"type\": \"scatter\", \"uid\": \"dd6b33bb-caef-4436-823f-c248c45f5c21\", \"x\": [1265.0, 1265.0, 1275.0, 1275.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8461538461538461, 0.8461538461538461, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 69, component: QE_2017_001814_194.1174_244.0\", \"cluster: 69, component: QE_2017_001814_194.1174_244.0\", \"cluster: 70, component: QE_2017_001816_194.11746_133.0\", \"cluster: 70, component: QE_2017_001816_194.11746_133.0\"], \"type\": \"scatter\", \"uid\": \"d9902ab9-5145-4d7b-9108-4cda0f6ef562\", \"x\": [1285.0, 1285.0, 1295.0, 1295.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7142857142857143, 0.7142857142857143, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 71, component: QE_2017_001814_320.29471_529.0\", \"cluster: 71, component: QE_2017_001814_320.29471_529.0\", \"cluster: 71, component: QE_2017_001815_320.29486_538.0\", \"cluster: 71, component: QE_2017_001815_320.29486_538.0\"], \"type\": \"scatter\", \"uid\": \"3f3953a2-9cb9-4f6a-bc72-8cd74f2ff3f9\", \"x\": [1335.0, 1335.0, 1345.0, 1345.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 71, component: QE_2017_001814_320.29477_539.0\", \"cluster: 71, component: QE_2017_001814_320.29477_539.0\", null, null], \"type\": \"scatter\", \"uid\": \"6f483613-452c-4f74-bd97-d3e2fd275be2\", \"x\": [1325.0, 1325.0, 1340.0, 1340.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5833333333333334, 0.5833333333333334, 0.4444444444444444], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 72, component: QE_2017_001814_320.29468_638.0\", \"cluster: 72, component: QE_2017_001814_320.29468_638.0\", null, null], \"type\": \"scatter\", \"uid\": \"f7d32d52-9fb4-4d78-a94f-c1f1bf290237\", \"x\": [1315.0, 1315.0, 1332.5, 1332.5], \"xaxis\": \"x\", \"y\": [0.0, 0.7857142857142857, 0.7857142857142857, 0.5833333333333334], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 73, component: QE_2017_001816_320.29483_548.0\", \"cluster: 73, component: QE_2017_001816_320.29483_548.0\", null, null], \"type\": \"scatter\", \"uid\": \"ee39676e-dc7b-412a-8468-ef7ef6efad5d\", \"x\": [1305.0, 1305.0, 1323.75, 1323.75], \"xaxis\": \"x\", \"y\": [0.0, 0.9393939393939394, 0.9393939393939394, 0.7857142857142857], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3b1c6306-265d-46e1-abd6-c5f46c3f525f\", \"x\": [1290.0, 1290.0, 1314.375, 1314.375], \"xaxis\": \"x\", \"y\": [0.7142857142857143, 0.9523809523809523, 0.9523809523809523, 0.9393939393939394], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 74, component: QE_2017_001814_241.15384_47.0\", \"cluster: 74, component: QE_2017_001814_241.15384_47.0\", \"cluster: 75, component: QE_2017_001814_241.15446_57.0\", \"cluster: 75, component: QE_2017_001814_241.15446_57.0\"], \"type\": \"scatter\", \"uid\": \"68fed69e-07b4-4920-bfea-e8e61b8dec20\", \"x\": [1355.0, 1355.0, 1365.0, 1365.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6363636363636364, 0.6363636363636364, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 76, component: QE_2017_001815_332.25827_508.0\", \"cluster: 76, component: QE_2017_001815_332.25827_508.0\", \"cluster: 77, component: QE_2017_001816_332.25842_487.0\", \"cluster: 77, component: QE_2017_001816_332.25842_487.0\"], \"type\": \"scatter\", \"uid\": \"514a2588-bad0-4624-bd60-692161c0262f\", \"x\": [1385.0, 1385.0, 1395.0, 1395.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6829268292682927, 0.6829268292682927, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 78, component: QE_2017_001814_332.25827_467.0\", \"cluster: 78, component: QE_2017_001814_332.25827_467.0\", null, null], \"type\": \"scatter\", \"uid\": \"e052946e-b5c8-47b7-8112-5604fc42eb93\", \"x\": [1375.0, 1375.0, 1390.0, 1390.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8, 0.8, 0.6829268292682927], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"557b0aae-1126-4595-b824-e4fd9d390404\", \"x\": [1360.0, 1360.0, 1382.5, 1382.5], \"xaxis\": \"x\", \"y\": [0.6363636363636364, 0.9666666666666667, 0.9666666666666667, 0.8], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"cd7b67fa-0996-40bd-a66e-56bbd9704db3\", \"x\": [1302.1875, 1302.1875, 1371.25, 1371.25], \"xaxis\": \"x\", \"y\": [0.9523809523809523, 0.9772727272727273, 0.9772727272727273, 0.9666666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 79, component: QE_2017_001814_319.13638_117.0\", \"cluster: 79, component: QE_2017_001814_319.13638_117.0\", \"cluster: 80, component: QE_2017_001816_319.13614_143.0\", \"cluster: 80, component: QE_2017_001816_319.13614_143.0\"], \"type\": \"scatter\", \"uid\": \"861f2e84-528a-41a4-8983-8cbb7063eaf9\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"xaxis\": \"x\", \"y\": [0.0, 0.75, 0.75, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 81, component: QE_2017_001815_219.10139_360.0\", \"cluster: 81, component: QE_2017_001815_219.10139_360.0\", \"cluster: 81, component: QE_2017_001816_219.10153_382.0\", \"cluster: 81, component: QE_2017_001816_219.10153_382.0\"], \"type\": \"scatter\", \"uid\": \"d4e059f8-069f-4406-bfdb-97a2932c5fef\", \"x\": [1445.0, 1445.0, 1455.0, 1455.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38181818181818183, 0.38181818181818183, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 81, component: QE_2017_001815_219.10159_438.0\", \"cluster: 81, component: QE_2017_001815_219.10159_438.0\", null, null], \"type\": \"scatter\", \"uid\": \"da0e6de2-1a20-466a-a13d-8b9c1b54c5dc\", \"x\": [1435.0, 1435.0, 1450.0, 1450.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4647887323943662, 0.4647887323943662, 0.38181818181818183], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 82, component: QE_2017_001814_251.09117_393.0\", \"cluster: 82, component: QE_2017_001814_251.09117_393.0\", null, null], \"type\": \"scatter\", \"uid\": \"5d1e9621-79c3-4e3b-a89b-ea716d64c329\", \"x\": [1425.0, 1425.0, 1442.5, 1442.5], \"xaxis\": \"x\", \"y\": [0.0, 0.6527777777777778, 0.6527777777777778, 0.4647887323943662], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 83, component: QE_2017_001814_291.1442_241.0\", \"cluster: 83, component: QE_2017_001814_291.1442_241.0\", \"cluster: 83, component: QE_2017_001816_291.14493_243.0\", \"cluster: 83, component: QE_2017_001816_291.14493_243.0\"], \"type\": \"scatter\", \"uid\": \"84bdb54a-8754-488b-9663-75530413907b\", \"x\": [1465.0, 1465.0, 1475.0, 1475.0], \"xaxis\": \"x\", \"y\": [0.0, 0.37037037037037035, 0.37037037037037035, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 83, component: QE_2017_001815_273.13425_199.0\", \"cluster: 83, component: QE_2017_001815_273.13425_199.0\", \"cluster: 83, component: QE_2017_001815_273.13434_243.0\", \"cluster: 83, component: QE_2017_001815_273.13434_243.0\"], \"type\": \"scatter\", \"uid\": \"22ed8d14-4af1-4880-9f72-3624b590de9b\", \"x\": [1495.0, 1495.0, 1505.0, 1505.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 83, component: QE_2017_001816_291.14499_200.0\", \"cluster: 83, component: QE_2017_001816_291.14499_200.0\", null, null], \"type\": \"scatter\", \"uid\": \"0060bb16-2eae-4c52-9422-ed6688cf85ac\", \"x\": [1485.0, 1485.0, 1500.0, 1500.0], \"xaxis\": \"x\", \"y\": [0.0, 0.41935483870967744, 0.41935483870967744, 0.3333333333333333], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"62267e1b-604c-4534-8ca6-f7a56d2ce831\", \"x\": [1470.0, 1470.0, 1492.5, 1492.5], \"xaxis\": \"x\", \"y\": [0.37037037037037035, 0.5161290322580645, 0.5161290322580645, 0.41935483870967744], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 84, component: QE_2017_001815_235.14398_226.0\", \"cluster: 84, component: QE_2017_001815_235.14398_226.0\", \"cluster: 84, component: QE_2017_001816_235.14397_183.0\", \"cluster: 84, component: QE_2017_001816_235.14397_183.0\"], \"type\": \"scatter\", \"uid\": \"9bf5a41f-5619-45ae-9f35-bf7be540fcd4\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5263157894736842, 0.5263157894736842, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 85, component: QE_2017_001815_251.13873_202.0\", \"cluster: 85, component: QE_2017_001815_251.13873_202.0\", null, null], \"type\": \"scatter\", \"uid\": \"1fe4aaf1-22b4-417a-bf9d-3dacad8a8bb4\", \"x\": [1515.0, 1515.0, 1530.0, 1530.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8636363636363636, 0.8636363636363636, 0.5263157894736842], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"c8da6524-c139-48b9-b512-b59a064799d3\", \"x\": [1481.25, 1481.25, 1522.5, 1522.5], \"xaxis\": \"x\", \"y\": [0.5161290322580645, 0.9166666666666666, 0.9166666666666666, 0.8636363636363636], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e878869b-b80a-48f6-b513-1677f878bddc\", \"x\": [1433.75, 1433.75, 1501.875, 1501.875], \"xaxis\": \"x\", \"y\": [0.6527777777777778, 0.9891304347826086, 0.9891304347826086, 0.9166666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 86, component: QE_2017_001814_250.10149_516.0\", \"cluster: 86, component: QE_2017_001814_250.10149_516.0\", \"cluster: 86, component: QE_2017_001815_222.07033_315.0\", \"cluster: 86, component: QE_2017_001815_222.07033_315.0\"], \"type\": \"scatter\", \"uid\": \"65343cb5-ff89-4762-8af1-00b49e840192\", \"x\": [1565.0, 1565.0, 1575.0, 1575.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5081967213114754, 0.5081967213114754, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 87, component: QE_2017_001816_268.59351_445.0\", \"cluster: 87, component: QE_2017_001816_268.59351_445.0\", null, null], \"type\": \"scatter\", \"uid\": \"953fcbfa-096d-40dc-842d-b8febaa2ea7d\", \"x\": [1555.0, 1555.0, 1570.0, 1570.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6923076923076923, 0.6923076923076923, 0.5081967213114754], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 88, component: QE_2017_001814_247.05975_245.0\", \"cluster: 88, component: QE_2017_001814_247.05975_245.0\", \"cluster: 88, component: QE_2017_001815_247.0598_242.0\", \"cluster: 88, component: QE_2017_001815_247.0598_242.0\"], \"type\": \"scatter\", \"uid\": \"25d86642-72e8-4c54-ae2d-f4a0f35ef4df\", \"x\": [1585.0, 1585.0, 1595.0, 1595.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35294117647058826, 0.35294117647058826, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 89, component: QE_2017_001815_212.03883_181.0\", \"cluster: 89, component: QE_2017_001815_212.03883_181.0\", \"cluster: 90, component: QE_2017_001815_214.56488_409.0\", \"cluster: 90, component: QE_2017_001815_214.56488_409.0\"], \"type\": \"scatter\", \"uid\": \"8d1c293b-e6fc-451e-844d-9b0f9a846b63\", \"x\": [1615.0, 1615.0, 1625.0, 1625.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7777777777777778, 0.7777777777777778, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 91, component: QE_2017_001816_219.04672_291.0\", \"cluster: 91, component: QE_2017_001816_219.04672_291.0\", null, null], \"type\": \"scatter\", \"uid\": \"0566fcd5-2117-494a-b70e-db0e906219d2\", \"x\": [1605.0, 1605.0, 1620.0, 1620.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8125, 0.8125, 0.7777777777777778], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"eac2b73c-48d8-4cf9-a4fd-270f19e601b3\", \"x\": [1590.0, 1590.0, 1612.5, 1612.5], \"xaxis\": \"x\", \"y\": [0.35294117647058826, 0.8571428571428571, 0.8571428571428571, 0.8125], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"efd21fb0-79b2-40c2-8c4f-ed710f2036cf\", \"x\": [1562.5, 1562.5, 1601.25, 1601.25], \"xaxis\": \"x\", \"y\": [0.6923076923076923, 0.9178082191780822, 0.9178082191780822, 0.8571428571428571], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 92, component: QE_2017_001815_214.51021_60.0\", \"cluster: 92, component: QE_2017_001815_214.51021_60.0\", null, null], \"type\": \"scatter\", \"uid\": \"a261f120-4f0f-4b29-a842-7e3e12513413\", \"x\": [1545.0, 1545.0, 1581.875, 1581.875], \"xaxis\": \"x\", \"y\": [0.0, 0.9534883720930233, 0.9534883720930233, 0.9178082191780822], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 93, component: QE_2017_001815_246.14465_137.0\", \"cluster: 93, component: QE_2017_001815_246.14465_137.0\", \"cluster: 93, component: QE_2017_001815_247.12865_158.0\", \"cluster: 93, component: QE_2017_001815_247.12865_158.0\"], \"type\": \"scatter\", \"uid\": \"32716247-3a56-4173-aeb3-f149c8530d28\", \"x\": [1655.0, 1655.0, 1665.0, 1665.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5, 0.5, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 94, component: QE_2017_001814_260.16037_143.0\", \"cluster: 94, component: QE_2017_001814_260.16037_143.0\", \"cluster: 94, component: QE_2017_001816_260.16022_145.0\", \"cluster: 94, component: QE_2017_001816_260.16022_145.0\"], \"type\": \"scatter\", \"uid\": \"308a8807-0fa5-444d-af45-ab89763ce488\", \"x\": [1675.0, 1675.0, 1685.0, 1685.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 95, component: QE_2017_001814_233.14948_126.0\", \"cluster: 95, component: QE_2017_001814_233.14948_126.0\", \"cluster: 95, component: QE_2017_001816_233.14955_129.0\", \"cluster: 95, component: QE_2017_001816_233.14955_129.0\"], \"type\": \"scatter\", \"uid\": \"de7359e7-1b56-4045-86ff-1df4c911e1ae\", \"x\": [1705.0, 1705.0, 1715.0, 1715.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2631578947368421, 0.2631578947368421, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 95, component: QE_2017_001814_233.14957_152.0\", \"cluster: 95, component: QE_2017_001814_233.14957_152.0\", null, null], \"type\": \"scatter\", \"uid\": \"7d5fc9c8-90ac-42f3-9c73-9ae770f37a33\", \"x\": [1695.0, 1695.0, 1710.0, 1710.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5416666666666666, 0.5416666666666666, 0.2631578947368421], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bcb037ae-9902-4e08-95cd-079b70811812\", \"x\": [1680.0, 1680.0, 1702.5, 1702.5], \"xaxis\": \"x\", \"y\": [0.2857142857142857, 0.8648648648648649, 0.8648648648648649, 0.5416666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ac4a802e-c169-4268-9f9a-5bcf55741eac\", \"x\": [1660.0, 1660.0, 1691.25, 1691.25], \"xaxis\": \"x\", \"y\": [0.5, 0.9574468085106383, 0.9574468085106383, 0.8648648648648649], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 96, component: QE_2017_001816_132.04436_283.0\", \"cluster: 96, component: QE_2017_001816_132.04436_283.0\", null, null], \"type\": \"scatter\", \"uid\": \"e8dd301c-66b0-4444-8a11-db49a6657e2a\", \"x\": [1645.0, 1645.0, 1675.625, 1675.625], \"xaxis\": \"x\", \"y\": [0.0, 0.98, 0.98, 0.9574468085106383], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 97, component: QE_2017_001815_260.16016_64.0\", \"cluster: 97, component: QE_2017_001815_260.16016_64.0\", null, null], \"type\": \"scatter\", \"uid\": \"a153d0ea-4dab-4df1-8b51-7537074343b9\", \"x\": [1635.0, 1635.0, 1660.3125, 1660.3125], \"xaxis\": \"x\", \"y\": [0.0, 0.9846153846153847, 0.9846153846153847, 0.98], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 98, component: QE_2017_001815_221.12837_99.0\", \"cluster: 98, component: QE_2017_001815_221.12837_99.0\", \"cluster: 99, component: QE_2017_001816_237.12325_171.0\", \"cluster: 99, component: QE_2017_001816_237.12325_171.0\"], \"type\": \"scatter\", \"uid\": \"8e631433-328e-49b6-a56a-3397e5b394c3\", \"x\": [1725.0, 1725.0, 1735.0, 1735.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7142857142857143, 0.7142857142857143, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 100, component: QE_2017_001814_237.12305_220.0\", \"cluster: 100, component: QE_2017_001814_237.12305_220.0\", \"cluster: 101, component: QE_2017_001816_237.12323_53.0\", \"cluster: 101, component: QE_2017_001816_237.12323_53.0\"], \"type\": \"scatter\", \"uid\": \"b1babd4c-8efd-4de2-978c-71661330039a\", \"x\": [1745.0, 1745.0, 1755.0, 1755.0], \"xaxis\": \"x\", \"y\": [0.0, 0.9444444444444444, 0.9444444444444444, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"4023f435-60fd-4ab7-897e-06e37f0f9034\", \"x\": [1730.0, 1730.0, 1750.0, 1750.0], \"xaxis\": \"x\", \"y\": [0.7142857142857143, 0.9761904761904762, 0.9761904761904762, 0.9444444444444444], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 102, component: QE_2017_001814_229.15399_46.0\", \"cluster: 102, component: QE_2017_001814_229.15399_46.0\", \"cluster: 102, component: QE_2017_001816_229.15451_66.0\", \"cluster: 102, component: QE_2017_001816_229.15451_66.0\"], \"type\": \"scatter\", \"uid\": \"94722fca-8dd7-4ddc-83e1-7b795d633956\", \"x\": [1775.0, 1775.0, 1785.0, 1785.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38461538461538464, 0.38461538461538464, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 103, component: QE_2017_001816_229.15469_52.0\", \"cluster: 103, component: QE_2017_001816_229.15469_52.0\", null, null], \"type\": \"scatter\", \"uid\": \"4e2176d5-3037-47e3-8275-680d388c1827\", \"x\": [1765.0, 1765.0, 1780.0, 1780.0], \"xaxis\": \"x\", \"y\": [0.0, 0.875, 0.875, 0.38461538461538464], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 104, component: QE_2017_001814_182.08116_51.0\", \"cluster: 104, component: QE_2017_001814_182.08116_51.0\", \"cluster: 104, component: QE_2017_001816_182.08116_55.0\", \"cluster: 104, component: QE_2017_001816_182.08116_55.0\"], \"type\": \"scatter\", \"uid\": \"3a8b9eb8-a93a-455b-b6cf-4a52fc138cf5\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4375, 0.4375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 105, component: QE_2017_001815_194.04474_330.0\", \"cluster: 105, component: QE_2017_001815_194.04474_330.0\", \"cluster: 105, component: QE_2017_001816_212.05518_300.0\", \"cluster: 105, component: QE_2017_001816_212.05518_300.0\"], \"type\": \"scatter\", \"uid\": \"4cf99bb2-57f2-4b04-8970-60805c717463\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5370370370370371, 0.5370370370370371, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1ab8fe4c-ef4d-407d-b269-344cd397da03\", \"x\": [1800.0, 1800.0, 1820.0, 1820.0], \"xaxis\": \"x\", \"y\": [0.4375, 0.921875, 0.921875, 0.5370370370370371], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 106, component: QE_2017_001814_177.05418_236.0\", \"cluster: 106, component: QE_2017_001814_177.05418_236.0\", \"cluster: 106, component: QE_2017_001815_177.05444_307.0\", \"cluster: 106, component: QE_2017_001815_177.05444_307.0\"], \"type\": \"scatter\", \"uid\": \"54e0572f-82cf-43de-be05-e9129b0e26d6\", \"x\": [1845.0, 1845.0, 1855.0, 1855.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35, 0.35, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 106, component: QE_2017_001816_177.05449_217.0\", \"cluster: 106, component: QE_2017_001816_177.05449_217.0\", null, null], \"type\": \"scatter\", \"uid\": \"aec7e5a0-3f6e-4acd-bb09-8504b824b7f3\", \"x\": [1835.0, 1835.0, 1850.0, 1850.0], \"xaxis\": \"x\", \"y\": [0.0, 0.391304347826087, 0.391304347826087, 0.35], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001816_199.98769_294.0\", \"cluster: 107, component: QE_2017_001816_199.98769_294.0\", \"cluster: 107, component: QE_2017_001816_199.98776_304.0\", \"cluster: 107, component: QE_2017_001816_199.98776_304.0\"], \"type\": \"scatter\", \"uid\": \"57c0e125-97b5-4ef2-9d4c-fe9f0336c1c7\", \"x\": [1865.0, 1865.0, 1875.0, 1875.0], \"xaxis\": \"x\", \"y\": [0.0, 0.34146341463414637, 0.34146341463414637, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001814_199.98778_290.0\", \"cluster: 107, component: QE_2017_001814_199.98778_290.0\", \"cluster: 107, component: QE_2017_001815_199.98779_30.0\", \"cluster: 107, component: QE_2017_001815_199.98779_30.0\"], \"type\": \"scatter\", \"uid\": \"292b6ebd-64c2-4f3a-9973-0fe08dae43c5\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3, 0.3, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001815_199.98772_326.0\", \"cluster: 107, component: QE_2017_001815_199.98772_326.0\", \"cluster: 107, component: QE_2017_001816_199.98781_313.0\", \"cluster: 107, component: QE_2017_001816_199.98781_313.0\"], \"type\": \"scatter\", \"uid\": \"bc346dcf-b29d-41df-8d0d-3bd220981826\", \"x\": [1905.0, 1905.0, 1915.0, 1915.0], \"xaxis\": \"x\", \"y\": [0.0, 0.18181818181818182, 0.18181818181818182, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001816_199.98776_254.0\", \"cluster: 107, component: QE_2017_001816_199.98776_254.0\", \"cluster: 107, component: QE_2017_001816_199.98779_335.0\", \"cluster: 107, component: QE_2017_001816_199.98779_335.0\"], \"type\": \"scatter\", \"uid\": \"39a4b521-120f-4005-afff-09bb94b0ae68\", \"x\": [1935.0, 1935.0, 1945.0, 1945.0], \"xaxis\": \"x\", \"y\": [0.0, 0.25, 0.25, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 107, component: QE_2017_001816_199.98772_359.0\", \"cluster: 107, component: QE_2017_001816_199.98772_359.0\", null, null], \"type\": \"scatter\", \"uid\": \"c765e2ae-51e4-4d64-87d2-f2a19dc3b9af\", \"x\": [1925.0, 1925.0, 1940.0, 1940.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3125, 0.3125, 0.25], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"448d5606-9d3c-4eee-901f-982c104383de\", \"x\": [1910.0, 1910.0, 1932.5, 1932.5], \"xaxis\": \"x\", \"y\": [0.18181818181818182, 0.36363636363636365, 0.36363636363636365, 0.3125], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3531d61a-4866-47ee-a15f-a4380a4c693a\", \"x\": [1890.0, 1890.0, 1921.25, 1921.25], \"xaxis\": \"x\", \"y\": [0.3, 0.42424242424242425, 0.42424242424242425, 0.36363636363636365], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"132ccce0-aae5-4893-b145-0f36d8e4dd90\", \"x\": [1870.0, 1870.0, 1905.625, 1905.625], \"xaxis\": \"x\", \"y\": [0.34146341463414637, 0.47368421052631576, 0.47368421052631576, 0.42424242424242425], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"cd01290b-677e-4371-b571-4fbdf3e5e0fa\", \"x\": [1842.5, 1842.5, 1887.8125, 1887.8125], \"xaxis\": \"x\", \"y\": [0.391304347826087, 0.8214285714285714, 0.8214285714285714, 0.47368421052631576], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 108, component: QE_2017_001815_463.12268_358.0\", \"cluster: 108, component: QE_2017_001815_463.12268_358.0\", \"cluster: 109, component: QE_2017_001815_625.17633_345.0\", \"cluster: 109, component: QE_2017_001815_625.17633_345.0\"], \"type\": \"scatter\", \"uid\": \"e2a16b38-02ab-424c-96be-749b21aaa45e\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6774193548387096, 0.6774193548387096, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 110, component: QE_2017_001815_595.16559_315.0\", \"cluster: 110, component: QE_2017_001815_595.16559_315.0\", null, null], \"type\": \"scatter\", \"uid\": \"2248aa6a-8783-4708-93c5-ff5f2600f7fe\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8947368421052632, 0.8947368421052632, 0.6774193548387096], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 111, component: QE_2017_001815_141.0508_33.0\", \"cluster: 111, component: QE_2017_001815_141.0508_33.0\", \"cluster: 112, component: QE_2017_001815_265.01532_33.0\", \"cluster: 112, component: QE_2017_001815_265.01532_33.0\"], \"type\": \"scatter\", \"uid\": \"7eea2d29-5f9f-4050-8637-ac001e3229ad\", \"x\": [1995.0, 1995.0, 2005.0, 2005.0], \"xaxis\": \"x\", \"y\": [0.0, 1.0, 1.0, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3f93cd16-56d4-47cb-b85c-39e762741a0f\", \"x\": [1972.5, 1972.5, 2000.0, 2000.0], \"xaxis\": \"x\", \"y\": [0.8947368421052632, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 113, component: QE_2017_001815_797.51746_866.0\", \"cluster: 113, component: QE_2017_001815_797.51746_866.0\", null, null], \"type\": \"scatter\", \"uid\": \"7c86fecd-8fa5-4f76-b1f2-38d86f390e73\", \"x\": [1955.0, 1955.0, 1986.25, 1986.25], \"xaxis\": \"x\", \"y\": [0.0, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"427e2a8c-8bb6-4706-a022-90387c8db5f1\", \"x\": [1865.15625, 1865.15625, 1970.625, 1970.625], \"xaxis\": \"x\", \"y\": [0.8214285714285714, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"834a3306-3168-4a17-a368-724d37ab9ff3\", \"x\": [1810.0, 1810.0, 1917.890625, 1917.890625], \"xaxis\": \"x\", \"y\": [0.921875, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8776dda5-4311-4ac0-bd5e-5efde40efff7\", \"x\": [1772.5, 1772.5, 1863.9453125, 1863.9453125], \"xaxis\": \"x\", \"y\": [0.875, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"024a0e20-a930-4c0a-97a9-eec4f0de1325\", \"x\": [1740.0, 1740.0, 1818.22265625, 1818.22265625], \"xaxis\": \"x\", \"y\": [0.9761904761904762, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"b5c40c61-be29-4e98-8065-891b69fe0dec\", \"x\": [1647.65625, 1647.65625, 1779.111328125, 1779.111328125], \"xaxis\": \"x\", \"y\": [0.9846153846153847, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"37f265a9-46ef-44ee-a1d4-2ec95a22fb7e\", \"x\": [1563.4375, 1563.4375, 1713.3837890625, 1713.3837890625], \"xaxis\": \"x\", \"y\": [0.9534883720930233, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"141058a6-87fa-407b-bc23-2ceeec165dde\", \"x\": [1467.8125, 1467.8125, 1638.41064453125, 1638.41064453125], \"xaxis\": \"x\", \"y\": [0.9891304347826086, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"23a2327a-6664-42ce-895c-d601e6ea81a6\", \"x\": [1410.0, 1410.0, 1553.111572265625, 1553.111572265625], \"xaxis\": \"x\", \"y\": [0.75, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"db3b7d99-837a-43a1-bb3f-13305d94a806\", \"x\": [1336.71875, 1336.71875, 1481.5557861328125, 1481.5557861328125], \"xaxis\": \"x\", \"y\": [0.9772727272727273, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"9a40e0ff-7f55-45f5-9341-e2dbc8d17872\", \"x\": [1270.0, 1270.0, 1409.1372680664062, 1409.1372680664062], \"xaxis\": \"x\", \"y\": [0.8461538461538461, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6a3879e3-6841-4e10-b198-bc02f469d634\", \"x\": [1020.869140625, 1020.869140625, 1339.5686340332031, 1339.5686340332031], \"xaxis\": \"x\", \"y\": [0.9882352941176471, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ed9a9154-febe-41fb-800f-9f133c511e48\", \"x\": [734.912109375, 734.912109375, 1180.2188873291016, 1180.2188873291016], \"xaxis\": \"x\", \"y\": [0.9696969696969697, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"c110ce2c-57d4-428c-b4ae-f1e8cf525320\", \"x\": [619.6875, 619.6875, 957.5654983520508, 957.5654983520508], \"xaxis\": \"x\", \"y\": [0.9814814814814815, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1cec25c1-5b32-49af-b55a-6b483b4ec455\", \"x\": [521.875, 521.875, 788.6264991760254, 788.6264991760254], \"xaxis\": \"x\", \"y\": [0.9857142857142858, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"884eb78f-b60c-4e49-95c6-2072e35537d1\", \"x\": [221.85302734375, 221.85302734375, 655.2507495880127, 655.2507495880127], \"xaxis\": \"x\", \"y\": [0.9625, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}],\n",
+       "                        {\"autosize\": false, \"height\": 700, \"hovermode\": \"closest\", \"margin\": {\"b\": 372}, \"showlegend\": false, \"title\": {\"text\": \"TreesRCool\"}, \"width\": 800, \"xaxis\": {\"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showgrid\": false, \"showline\": true, \"showticklabels\": true, \"tickmode\": \"array\", \"ticks\": \"outside\", \"ticktext\": [\"QE_2017_001816_613.4826_738.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001816_792.56232_718.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001815_792.5625_866.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001816_571.47186_717.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001815_278.24762_684.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001816_599.40948_660.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001815_194.11751_218.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001816_408.36832_704.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001815_364.34253_752.0\", \"QE_2017_001816_421.35226_731.0\", \"QE_2017_001816_424.36325_712.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001815_611.16046_309.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001815_231.04973_403.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001814_241.15466_73.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001815_129.12741_349.0\", \"QE_2017_001815_171.14914_420.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001815_209.15352_479.0\", \"QE_2017_001815_209.15349_295.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001816_215.16411_482.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17421_516.0\", \"QE_2017_001816_219.17438_502.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001816_194.11746_133.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001815_320.29486_538.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001814_319.13638_117.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001816_219.10153_382.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001816_291.14493_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001815_251.13873_202.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001816_235.14397_183.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001815_222.07033_315.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001815_247.12865_158.0\", \"QE_2017_001814_260.16037_143.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001814_233.14957_152.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001816_237.12323_53.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001816_229.15451_66.0\", \"QE_2017_001814_182.08116_51.0\", \"QE_2017_001816_182.08116_55.0\", \"QE_2017_001815_194.04474_330.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001816_199.98776_304.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001816_199.98776_254.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_265.01532_33.0\"], \"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0, 1995.0, 2005.0], \"title\": {\"text\": \"Samples\"}, \"type\": \"linear\", \"zeroline\": false}, \"yaxis\": {\"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showgrid\": false, \"showline\": true, \"showticklabels\": true, \"ticks\": \"outside\", \"title\": {\"text\": \"Distance\"}, \"type\": \"linear\", \"zeroline\": false}},\n",
+       "                        {\"showLink\": false, \"linkText\": \"Export to plot.ly\", \"plotlyServerURL\": \"https://plot.ly\"}\n",
+       "                    )\n",
+       "                };\n",
+       "                });\n",
+       "            </script>\n",
+       "        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from BioDendro.plot import dendrogram\n",
+    "\n",
+    "iplot = dendrogram(tree, width=800, height=700, title=\"TreesRCool\", xlabel=\"Samples\", ylabel=\"Distance\")\n",
+    "plotly.offline.iplot(iplot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are some features that we're working on.\n",
+    "\n",
+    "In dendrogram, the `hovertext` parameter allows you to specify arbitrary text for when you hover over the data.\n",
+    "However, the current tree drawing algorithm reorders the internal nodes, and we can't find the correct order for internal node data from the output of that function.\n",
+    "For now know that it exists, and if you figure it out, please let us know!"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -6219,7 +13959,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/quick-start-example.ipynb
+++ b/quick-start-example.ipynb
@@ -8,18 +8,52 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The BioDendro pipeline automates the process of binning and hierarchically clustering\n",
+    "msms components and spectra.\n",
+    "\n",
+    "This notebook shows basic use of the pipeline for the:\n",
+    "- [Python API](#Python-API)\n",
+    "- [Command line API](#Command-line-API)\n",
+    "\n",
+    "\\* API = Application programming interface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Python API\n",
+    "\n",
+    "The python interface allows you to make small changes easily and view intermediate results.\n",
+    "A more detailed explanation of the Python API/pipeline is available in the `longer_example.ipynb` notebook at the BioDendro repository."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#Load modules\n",
+    "# Load modules\n",
     "\n",
     "import os\n",
     "import plotly\n",
     "import BioDendro"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The main `pipeline` function runs the full pipeline (i.e. reading files, clustering, and plotting).\n",
+    "At a minimum the function needs an MGF file and a component list.\n",
+    "Note that by default, the results will be saved to a folder in your current working directory using the name `results_<datetime>` where datetime will be the date and current time of day in `hhmmss` format.\n",
+    "This is to avoid overwriting data in multiple runs.\n",
+    "\n",
+    "To get a list of possible parameters and defaults you can run `help(BioDendro.pipeline)`."
    ]
   },
   {
@@ -31,19 +65,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Help on function pipeline in module BioDendro:\n",
+      "\n",
+      "pipeline(mgf_path, components_path, neutral=False, cutoff=0.6, bin_threshold=0.0008, clustering_method='jaccard', processed='processed.xlsx', results_dir=None, out_html='simple_dendrogram.html', width=900, height=800, quiet=False, scaling=False, filtering=False, eps=0.6, mz_tol=0.002, retention_tol=5, **kwargs)\n",
+      "    Runs the default BioDendro pipeline.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(BioDendro.pipeline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Running BioDendro v0.0.1\n",
       "\n",
-      "- input mgf file = ./MSMS.mgf\n",
-      "- input components file = ./component_list.txt\n",
+      "- input mgf file = MSMS.mgf\n",
+      "- input components file = component_list.txt\n",
       "- neutral = False\n",
       "- cutoff = 0.6\n",
       "- bin_threshold = 0.0008\n",
       "- clustering_method = braycurtis\n",
-      "- output processed file = processed.xlsx\n",
-      "- output results directory = results_20180605130236\n",
-      "- output html dendrogram = simple_dendrogram.html\n",
+      "- output processed file = results_20190417165427/processed.xlsx\n",
+      "- output results directory = results_20190417165427\n",
+      "- output html dendrogram = results_20190417165427/simple_dendrogram.html\n",
       "- dendrogram figure width = 900\n",
-      "- dendrogram figure height = 400\n",
+      "- dendrogram figure height = 800\n",
+      "- scaling = False\n",
+      "- filtering = False\n",
+      "- eps = 0.6\n",
+      "- mz_tolerance = 0.002\n",
+      "- retention_tolerance = 5\n",
       "\n",
       "\n",
       "Processing inputs\n",
@@ -58,20 +118,18 @@
    "source": [
     "# Run the complete BioDendro pipeline\n",
     "\n",
-    "tree = BioDendro.pipeline(\"./MSMS.mgf\", \"./component_list.txt\", clustering_method=\"braycurtis\")"
+    "tree = BioDendro.pipeline(\"MSMS.mgf\", \"component_list.txt\", clustering_method=\"braycurtis\")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# Re-set a new cutoff for clusters\n",
+    "The pipeline function prints out running information for you, including the directory where you can find your results.\n",
+    "Note that the dendrograms and processed files are also saved into this directory, even if you don't specify that in the filename.\n",
     "\n",
-    "tree.cut_tree(cutoff=0.8)"
+    "The pipeline also returns a `Tree` object, which stores most of the results.\n",
+    "We can change the number clusters by specifying a new distance threshold."
    ]
   },
   {
@@ -80,12 +138,81 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEFORE: Cutoff: 0.6 n clusters: 79\n",
+      "AFTER: Cutoff: 0.8 n clusters: 46\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show the number of clusters before adjustment\n",
+    "print(\"BEFORE: Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))\n",
+    "\n",
+    "# Re-set a new cutoff for clusters\n",
+    "tree.cut_tree(cutoff=0.8)\n",
+    "\n",
+    "# Show number of clusters after adjustment\n",
+    "print(\"AFTER: Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So our cluster results are updated to use a higher threshold (i.e. fewer clusters, with more members).\n",
+    "Note that these updated results are not automatically saved to the results folder.\n",
+    "\n",
+    "To save these updated results, we need to create a new folder and write the summaries ourselves.\n",
+    "Previously the pipeline function handled this all for us.\n",
+    "\n",
+    "NOTE: this will overwrite any contents in the specified directory so be careful!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate the out plots and tables of the new clusters.\n",
+    "# exist_ok tells python not to raise an error if the directory already exists.\n",
+    "os.makedirs(\"results\", exist_ok=True)\n",
+    "tree.write_summaries(path=\"results\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can view the interactive tree directly in an IPython notebook using the plotly `notebook_mode`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "text/html": [
-       "<script>requirejs.config({paths: { 'plotly': ['https://cdn.plot.ly/plotly-latest.min']},});if(!window.Plotly) {{require(['plotly'],function(plotly) {window.Plotly=plotly;});}}</script>"
-      ],
-      "text/vnd.plotly.v1+html": [
-       "<script>requirejs.config({paths: { 'plotly': ['https://cdn.plot.ly/plotly-latest.min']},});if(!window.Plotly) {{require(['plotly'],function(plotly) {window.Plotly=plotly;});}}</script>"
+       "        <script type=\"text/javascript\">\n",
+       "        window.PlotlyConfig = {MathJaxConfig: 'local'};\n",
+       "        if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}\n",
+       "        if (typeof require !== 'undefined') {\n",
+       "        require.undef(\"plotly\");\n",
+       "        requirejs.config({\n",
+       "            paths: {\n",
+       "                'plotly': ['https://cdn.plot.ly/plotly-latest.min']\n",
+       "            }\n",
+       "        });\n",
+       "        require(['plotly'], function(Plotly) {\n",
+       "            window._Plotly = Plotly;\n",
+       "        });\n",
+       "        }\n",
+       "        </script>\n",
+       "        "
       ]
      },
      "metadata": {},
@@ -94,153 +221,142 @@
     {
      "data": {
       "application/vnd.plotly.v1+json": {
+       "config": {
+        "linkText": "Export to plot.ly",
+        "plotlyServerURL": "https://plot.ly",
+        "showLink": false
+       },
        "data": [
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 1, component: QE_2017_001816_613.48218_838.0",
+          "cluster: 1, component: QE_2017_001816_613.48218_838.0",
+          "cluster: 1, component: QE_2017_001816_792.56232_718.0",
+          "cluster: 1, component: QE_2017_001816_792.56232_718.0"
+         ],
          "type": "scatter",
+         "uid": "900afdd6-4a52-4718-b321-31f2b7bc2d2a",
          "x": [
-          5,
-          5,
           15,
-          15
+          15,
+          25,
+          25
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.4827586206896552,
-          0.4827586206896552,
+          0.3949579831932773,
+          0.3949579831932773,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 1, component: QE_2017_001816_613.4826_738.0",
+          "cluster: 1, component: QE_2017_001816_613.4826_738.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "80647ae0-f745-497c-bee1-2c031a4faae2",
          "x": [
-          25,
-          25,
+          5,
+          5,
+          20,
+          20
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5116279069767442,
+          0.5116279069767442,
+          0.3949579831932773
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 1, component: QE_2017_001814_596.30963_602.0",
+          "cluster: 1, component: QE_2017_001814_596.30963_602.0",
+          "cluster: 1, component: QE_2017_001815_792.5625_866.0",
+          "cluster: 1, component: QE_2017_001815_792.5625_866.0"
+         ],
+         "type": "scatter",
+         "uid": "212b3555-1a2d-40b1-8071-349e9ee55daa",
+         "x": [
           35,
-          35
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.20279720279720279,
-          0.20279720279720279,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          65,
-          65,
-          75,
-          75
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.1724137931034483,
-          0.1724137931034483,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          55,
-          55,
-          70,
-          70
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.2,
-          0.2,
-          0.1724137931034483
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
+          35,
           45,
-          45,
-          62.5,
-          62.5
+          45
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.30578512396694213,
-          0.30578512396694213,
-          0.2
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          85,
-          85,
-          95,
-          95
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.0847457627118644,
-          0.0847457627118644,
+          0.5555555555555556,
+          0.5555555555555556,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "98918296-36c5-4142-a19a-94c863be3c5d",
+         "x": [
+          12.5,
+          12.5,
+          40,
+          40
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5116279069767442,
+          0.6344086021505376,
+          0.6344086021505376,
+          0.5555555555555556
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001814_335.25784_608.0",
+          "cluster: 2, component: QE_2017_001814_335.25784_608.0",
+          "cluster: 2, component: QE_2017_001816_335.25772_723.0",
+          "cluster: 2, component: QE_2017_001816_335.25772_723.0"
+         ],
+         "type": "scatter",
+         "uid": "16e1f2f0-ffa0-4ecb-b5fc-a7b9d6974566",
          "x": [
           105,
           105,
@@ -250,618 +366,867 @@
          "xaxis": "x",
          "y": [
           0,
-          0.13609467455621302,
-          0.13609467455621302,
+          0.14942528735632185,
+          0.14942528735632185,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001814_335.25772_725.0",
+          "cluster: 2, component: QE_2017_001814_335.25772_725.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e4d3815c-1984-4923-86b4-8d3e735707fc",
          "x": [
-          90,
-          90,
+          95,
+          95,
           110,
           110
          ],
          "xaxis": "x",
          "y": [
-          0.0847457627118644,
-          0.3246753246753247,
-          0.3246753246753247,
-          0.13609467455621302
+          0,
+          0.16483516483516483,
+          0.16483516483516483,
+          0.14942528735632185
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001814_335.25784_628.0",
+          "cluster: 2, component: QE_2017_001814_335.25784_628.0",
+          "cluster: 2, component: QE_2017_001815_335.25745_642.0",
+          "cluster: 2, component: QE_2017_001815_335.25745_642.0"
+         ],
          "type": "scatter",
+         "uid": "441319fe-c637-4644-bc4f-34222295348c",
          "x": [
-          53.75,
-          53.75,
-          100,
-          100
+          125,
+          125,
+          135,
+          135
          ],
          "xaxis": "x",
          "y": [
-          0.30578512396694213,
-          0.3793103448275862,
-          0.3793103448275862,
-          0.3246753246753247
+          0,
+          0.16666666666666666,
+          0.16666666666666666,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "77d6c91e-d635-445c-855d-ee95c74913dc",
          "x": [
-          135,
-          135,
+          102.5,
+          102.5,
+          130,
+          130
+         ],
+         "xaxis": "x",
+         "y": [
+          0.16483516483516483,
+          0.20408163265306123,
+          0.20408163265306123,
+          0.16666666666666666
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001814_261.22073_634.0",
+          "cluster: 2, component: QE_2017_001814_261.22073_634.0",
+          "cluster: 2, component: QE_2017_001815_335.25784_587.0",
+          "cluster: 2, component: QE_2017_001815_335.25784_587.0"
+         ],
+         "type": "scatter",
+         "uid": "e8aefc61-3bfd-4168-8c87-a73de2a31748",
+         "x": [
           145,
-          145
+          145,
+          155,
+          155
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.11731843575418995,
-          0.11731843575418995,
+          0.23076923076923078,
+          0.23076923076923078,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "d1dd079c-41b9-4eae-8407-130264829fee",
          "x": [
-          125,
-          125,
-          140,
-          140
+          116.25,
+          116.25,
+          150,
+          150
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.17045454545454544,
-          0.17045454545454544,
-          0.11731843575418995
+          0.20408163265306123,
+          0.25925925925925924,
+          0.25925925925925924,
+          0.23076923076923078
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001814_353.26889_609.0",
+          "cluster: 2, component: QE_2017_001814_353.26889_609.0",
+          "cluster: 2, component: QE_2017_001815_353.26862_642.0",
+          "cluster: 2, component: QE_2017_001815_353.26862_642.0"
+         ],
          "type": "scatter",
+         "uid": "4c6c1785-7af4-4549-8f27-66ee735d4d94",
          "x": [
-          155,
-          155,
           165,
-          165
+          165,
+          175,
+          175
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.20454545454545456,
-          0.20454545454545456,
+          0.1588785046728972,
+          0.1588785046728972,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001814_335.25772_638.0",
+          "cluster: 2, component: QE_2017_001814_335.25772_638.0",
+          "cluster: 2, component: QE_2017_001815_335.2579_601.0",
+          "cluster: 2, component: QE_2017_001815_335.2579_601.0"
+         ],
          "type": "scatter",
+         "uid": "7df6e633-e5ca-4166-9c40-9c5891aca0f9",
          "x": [
-          132.5,
-          132.5,
-          160,
-          160
+          195,
+          195,
+          205,
+          205
          ],
          "xaxis": "x",
          "y": [
-          0.17045454545454544,
-          0.24022346368715083,
-          0.24022346368715083,
-          0.20454545454545456
+          0,
+          0.1724137931034483,
+          0.1724137931034483,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001815_261.22073_643.0",
+          "cluster: 2, component: QE_2017_001815_261.22073_643.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "175142d0-7c11-40b0-81a3-fde1b0784c52",
          "x": [
-          175,
-          175,
           185,
-          185
+          185,
+          200,
+          200
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.27,
-          0.27,
-          0
+          0.23809523809523808,
+          0.23809523809523808,
+          0.1724137931034483
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "3a96e758-d9ee-4e86-a740-8df758a95735",
          "x": [
-          146.25,
-          146.25,
-          180,
-          180
+          170,
+          170,
+          192.5,
+          192.5
          ],
          "xaxis": "x",
          "y": [
-          0.24022346368715083,
-          0.33689839572192515,
-          0.33689839572192515,
-          0.27
+          0.1588785046728972,
+          0.2765957446808511,
+          0.2765957446808511,
+          0.23809523809523808
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "2db7eada-870d-458e-9811-b3cf68289663",
          "x": [
-          215,
-          215,
+          133.125,
+          133.125,
+          181.25,
+          181.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.25925925925925924,
+          0.3,
+          0.3,
+          0.2765957446808511
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001816_571.47186_717.0",
+          "cluster: 2, component: QE_2017_001816_571.47186_717.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "bb682155-5e28-4375-b24d-83d0e52482ab",
+         "x": [
+          85,
+          85,
+          157.1875,
+          157.1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3829787234042553,
+          0.3829787234042553,
+          0.3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001815_507.27145_607.0",
+          "cluster: 2, component: QE_2017_001815_507.27145_607.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3ff32ddf-b83f-45da-8ca9-b5882aef7d36",
+         "x": [
+          75,
+          75,
+          121.09375,
+          121.09375
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.40229885057471265,
+          0.40229885057471265,
+          0.3829787234042553
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001814_497.31033_643.0",
+          "cluster: 2, component: QE_2017_001814_497.31033_643.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "81708435-a03b-45ca-a67e-285b640b5e59",
+         "x": [
+          65,
+          65,
+          98.046875,
+          98.046875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5368421052631579,
+          0.5368421052631579,
+          0.40229885057471265
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001815_571.4292_870.0",
+          "cluster: 2, component: QE_2017_001815_571.4292_870.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c20eea08-23dd-4184-a86a-d21aaedd8186",
+         "x": [
+          55,
+          55,
+          81.5234375,
+          81.5234375
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6615384615384615,
+          0.6615384615384615,
+          0.5368421052631579
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001814_338.34146_850.0",
+          "cluster: 2, component: QE_2017_001814_338.34146_850.0",
+          "cluster: 2, component: QE_2017_001815_244.19048_762.0",
+          "cluster: 2, component: QE_2017_001815_244.19048_762.0"
+         ],
+         "type": "scatter",
+         "uid": "e5d9e6ef-ac1e-495b-99fd-1f1866379aa3",
+         "x": [
           225,
-          225
+          225,
+          235,
+          235
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.1111111111111111,
-          0.1111111111111111,
+          0.4318181818181818,
+          0.4318181818181818,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001814_353.26868_633.0",
+          "cluster: 2, component: QE_2017_001814_353.26868_633.0",
+          "cluster: 2, component: QE_2017_001816_353.26892_600.0",
+          "cluster: 2, component: QE_2017_001816_353.26892_600.0"
+         ],
          "type": "scatter",
+         "uid": "16131ccc-17d5-4fda-96b8-2a455305a54b",
          "x": [
-          205,
-          205,
-          220,
-          220
+          245,
+          245,
+          255,
+          255
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.14864864864864866,
-          0.14864864864864866,
-          0.1111111111111111
+          0.1348314606741573,
+          0.1348314606741573,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          195,
-          195,
-          212.5,
-          212.5
+         "text": [
+          "cluster: 2, component: QE_2017_001814_279.23157_719.0",
+          "cluster: 2, component: QE_2017_001814_279.23157_719.0",
+          "cluster: 2, component: QE_2017_001815_278.24762_684.0",
+          "cluster: 2, component: QE_2017_001815_278.24762_684.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.20588235294117646,
-          0.20588235294117646,
-          0.14864864864864866
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "fd23ff72-c36d-46a7-9aea-98d2f727fc6b",
          "x": [
-          255,
-          255,
           265,
-          265
+          265,
+          275,
+          275
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.06578947368421052,
-          0.06578947368421052,
+          0.2755905511811024,
+          0.2755905511811024,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "798c9095-b2fc-4b98-a51e-99b6e4cae0ee",
          "x": [
-          245,
-          245,
-          260,
-          260
+          250,
+          250,
+          270,
+          270
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.0728476821192053,
-          0.0728476821192053,
-          0.06578947368421052
+          0.1348314606741573,
+          0.35403726708074534,
+          0.35403726708074534,
+          0.2755905511811024
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001816_337.27338_826.0",
+          "cluster: 2, component: QE_2017_001816_337.27338_826.0",
+          "cluster: 2, component: QE_2017_001816_337.27341_632.0",
+          "cluster: 2, component: QE_2017_001816_337.27341_632.0"
+         ],
          "type": "scatter",
+         "uid": "4866d817-dffd-4b02-84d3-2003c53bf977",
          "x": [
-          235,
-          235,
-          252.5,
-          252.5
+          295,
+          295,
+          305,
+          305
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.1125,
-          0.1125,
-          0.0728476821192053
+          0.22935779816513763,
+          0.22935779816513763,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 2, component: QE_2017_001816_435.25037_666.0",
+          "cluster: 2, component: QE_2017_001816_435.25037_666.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "2ab82583-fa51-4c73-b87b-581f1ff53c5e",
          "x": [
-          275,
-          275,
           285,
-          285
+          285,
+          300,
+          300
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.20930232558139536,
-          0.20930232558139536,
-          0
+          0.37142857142857144,
+          0.37142857142857144,
+          0.22935779816513763
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "c938c3ac-7667-42b1-97ac-35f0dcf5e791",
          "x": [
-          243.75,
-          243.75,
-          280,
-          280
+          260,
+          260,
+          292.5,
+          292.5
          ],
          "xaxis": "x",
          "y": [
-          0.1125,
-          0.2484076433121019,
-          0.2484076433121019,
-          0.20930232558139536
+          0.35403726708074534,
+          0.5238095238095238,
+          0.5238095238095238,
+          0.37142857142857144
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "4f62fb4d-405d-40f9-9430-9fc4c76e8eba",
          "x": [
-          305,
-          305,
-          315,
-          315
+          230,
+          230,
+          276.25,
+          276.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4318181818181818,
+          0.6116504854368932,
+          0.6116504854368932,
+          0.5238095238095238
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 2, component: QE_2017_001816_272.25824_582.0",
+          "cluster: 2, component: QE_2017_001816_272.25824_582.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f760c2c5-cf76-4b3f-beed-649fec72e6c6",
+         "x": [
+          215,
+          215,
+          253.125,
+          253.125
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.14285714285714285,
-          0.14285714285714285,
-          0
+          0.7011494252873564,
+          0.7011494252873564,
+          0.6116504854368932
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "5b1070fc-138b-47b2-b987-df2a9241cea9",
          "x": [
-          295,
-          295,
-          310,
-          310
+          68.26171875,
+          68.26171875,
+          234.0625,
+          234.0625
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.2875,
-          0.2875,
-          0.14285714285714285
+          0.6615384615384615,
+          0.7699115044247787,
+          0.7699115044247787,
+          0.7011494252873564
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "38b89d6b-b808-4060-a3cf-2d6212f1ff44",
          "x": [
-          261.875,
-          261.875,
-          302.5,
-          302.5
+          26.25,
+          26.25,
+          151.162109375,
+          151.162109375
          ],
          "xaxis": "x",
          "y": [
-          0.2484076433121019,
-          0.3383458646616541,
-          0.3383458646616541,
-          0.2875
+          0.6344086021505376,
+          0.84,
+          0.84,
+          0.7699115044247787
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 3, component: QE_2017_001814_601.42426_706.0",
+          "cluster: 3, component: QE_2017_001814_601.42426_706.0",
+          "cluster: 3, component: QE_2017_001816_599.40869_793.0",
+          "cluster: 3, component: QE_2017_001816_599.40869_793.0"
+         ],
          "type": "scatter",
+         "uid": "fc02cb54-ad3d-4476-88c3-c026027411db",
          "x": [
-          203.75,
-          203.75,
-          282.1875,
-          282.1875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.20588235294117646,
-          0.34285714285714286,
-          0.34285714285714286,
-          0.3383458646616541
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          163.125,
-          163.125,
-          242.96875,
-          242.96875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.33689839572192515,
-          0.38562091503267976,
-          0.38562091503267976,
-          0.34285714285714286
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          76.875,
-          76.875,
-          203.046875,
-          203.046875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3793103448275862,
-          0.44516129032258067,
-          0.44516129032258067,
-          0.38562091503267976
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          30,
-          30,
-          139.9609375,
-          139.9609375
-         ],
-         "xaxis": "x",
-         "y": [
-          0.20279720279720279,
-          0.5,
-          0.5,
-          0.44516129032258067
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          10,
-          10,
-          84.98046875,
-          84.98046875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.4827586206896552,
-          0.5789473684210527,
-          0.5789473684210527,
-          0.5
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          335,
-          335,
           345,
-          345
+          345,
+          355,
+          355
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.15270935960591134,
-          0.15270935960591134,
+          0.45985401459854014,
+          0.45985401459854014,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 3, component: QE_2017_001816_599.40948_660.0",
+          "cluster: 3, component: QE_2017_001816_599.40948_660.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "50ec48bd-e562-4276-8d02-b81e621bb178",
          "x": [
-          325,
-          325,
-          340,
-          340
+          335,
+          335,
+          350,
+          350
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.308411214953271,
-          0.308411214953271,
-          0.15270935960591134
+          0.504950495049505,
+          0.504950495049505,
+          0.45985401459854014
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 3, component: QE_2017_001816_583.41382_731.0",
+          "cluster: 3, component: QE_2017_001816_583.41382_731.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "667d91f6-0b01-45d9-a595-dd2d506a3fcc",
+         "x": [
+          325,
+          325,
+          342.5,
+          342.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6101694915254238,
+          0.6101694915254238,
+          0.504950495049505
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 3, component: QE_2017_001814_618.42633_695.0",
+          "cluster: 3, component: QE_2017_001814_618.42633_695.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5bd76524-f86d-4024-abb1-bbb08caa14c6",
+         "x": [
+          315,
+          315,
+          333.75,
+          333.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6666666666666666,
+          0.6666666666666666,
+          0.6101694915254238
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 4, component: QE_2017_001815_618.42773_646.0",
+          "cluster: 4, component: QE_2017_001815_618.42773_646.0",
+          "cluster: 4, component: QE_2017_001816_618.427_682.0",
+          "cluster: 4, component: QE_2017_001816_618.427_682.0"
+         ],
+         "type": "scatter",
+         "uid": "8c8093fa-5ad6-49af-9005-17d6353ae023",
          "x": [
           365,
           365,
@@ -871,273 +1236,374 @@
          "xaxis": "x",
          "y": [
           0,
-          0.075,
-          0.075,
+          0.30997304582210244,
+          0.30997304582210244,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 4, component: QE_2017_001814_583.41406_682.0",
+          "cluster: 4, component: QE_2017_001814_583.41406_682.0",
+          "cluster: 4, component: QE_2017_001815_583.41406_707.0",
+          "cluster: 4, component: QE_2017_001815_583.41406_707.0"
+         ],
          "type": "scatter",
+         "uid": "da8cf932-28b8-4274-92eb-f5c1282e932d",
          "x": [
-          395,
-          395,
           405,
-          405
+          405,
+          415,
+          415
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.15714285714285714,
-          0.15714285714285714,
+          0.35877862595419846,
+          0.35877862595419846,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 4, component: QE_2017_001814_565.4035_722.0",
+          "cluster: 4, component: QE_2017_001814_565.4035_722.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "167dc21d-5a0e-43b9-a0b9-e4276481aa6c",
          "x": [
-          385,
-          385,
-          400,
-          400
+          395,
+          395,
+          410,
+          410
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.1836734693877551,
-          0.1836734693877551,
-          0.15714285714285714
+          0.4336283185840708,
+          0.4336283185840708,
+          0.35877862595419846
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          370,
-          370,
-          392.5,
-          392.5
+         "text": [
+          "cluster: 4, component: QE_2017_001815_583.41388_735.0",
+          "cluster: 4, component: QE_2017_001815_583.41388_735.0",
+          "cluster: 4, component: QE_2017_001815_583.41418_647.0",
+          "cluster: 4, component: QE_2017_001815_583.41418_647.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.075,
-          0.25161290322580643,
-          0.25161290322580643,
-          0.1836734693877551
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "cad84ea3-f324-494b-a96c-84008d525a2a",
          "x": [
-          425,
-          425,
           435,
-          435
+          435,
+          445,
+          445
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.08860759493670886,
-          0.08860759493670886,
+          0.3592233009708738,
+          0.3592233009708738,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 4, component: QE_2017_001814_601.42334_783.0",
+          "cluster: 4, component: QE_2017_001814_601.42334_783.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "301bc086-4ded-47dc-9c60-0a3811c51270",
          "x": [
-          445,
-          445,
+          425,
+          425,
+          440,
+          440
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5344827586206896,
+          0.5344827586206896,
+          0.3592233009708738
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8e86d977-8353-4c1a-b694-28d5c94cf56e",
+         "x": [
+          402.5,
+          402.5,
+          432.5,
+          432.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4336283185840708,
+          0.5802469135802469,
+          0.5802469135802469,
+          0.5344827586206896
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 4, component: QE_2017_001815_568.42627_841.0",
+          "cluster: 4, component: QE_2017_001815_568.42627_841.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9681043b-ff09-4b7e-bcf6-df47f2ef08f4",
+         "x": [
+          385,
+          385,
+          417.5,
+          417.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.618421052631579,
+          0.618421052631579,
+          0.5802469135802469
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "053c2a1b-ef0d-4cdc-9374-4b65aa81f3d0",
+         "x": [
+          370,
+          370,
+          401.25,
+          401.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.30997304582210244,
+          0.6956521739130435,
+          0.6956521739130435,
+          0.618421052631579
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6ccab76e-80ae-405c-a5a1-dca31367e245",
+         "x": [
+          324.375,
+          324.375,
+          385.625,
+          385.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6666666666666666,
+          0.8867924528301887,
+          0.8867924528301887,
+          0.6956521739130435
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ca8e7d85-431b-49b5-b8d5-4eaea2a3e7df",
+         "x": [
+          88.7060546875,
+          88.7060546875,
+          355,
+          355
+         ],
+         "xaxis": "x",
+         "y": [
+          0.84,
+          0.927710843373494,
+          0.927710843373494,
+          0.8867924528301887
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 5, component: QE_2017_001814_194.04424_237.0",
+          "cluster: 5, component: QE_2017_001814_194.04424_237.0",
+          "cluster: 5, component: QE_2017_001815_194.11751_218.0",
+          "cluster: 5, component: QE_2017_001815_194.11751_218.0"
+         ],
+         "type": "scatter",
+         "uid": "a462734c-3623-4816-8ad9-4e660c529574",
+         "x": [
           455,
-          455
+          455,
+          465,
+          465
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.10714285714285714,
-          0.10714285714285714,
+          0.45,
+          0.45,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          430,
-          430,
-          450,
-          450
+         "text": [
+          "cluster: 5, component: QE_2017_001815_194.04471_314.0",
+          "cluster: 5, component: QE_2017_001815_194.04471_314.0",
+          "cluster: 5, component: QE_2017_001815_212.05513_328.0",
+          "cluster: 5, component: QE_2017_001815_212.05513_328.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.08860759493670886,
-          0.17647058823529413,
-          0.17647058823529413,
-          0.10714285714285714
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "b1d728fc-6b95-424a-84ba-e558e08dd96a",
          "x": [
-          475,
-          475,
           485,
-          485
+          485,
+          495,
+          495
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.03225806451612903,
-          0.03225806451612903,
+          0.21311475409836064,
+          0.21311475409836064,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001815_194.04469_299.0",
+          "cluster: 5, component: QE_2017_001815_194.04469_299.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "7eb53966-b3e9-429b-ab5b-166ae7ad2fec",
          "x": [
-          465,
-          465,
-          480,
-          480
+          475,
+          475,
+          490,
+          490
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.18238993710691823,
-          0.18238993710691823,
-          0.03225806451612903
+          0.38636363636363635,
+          0.38636363636363635,
+          0.21311475409836064
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001814_226.07077_397.0",
+          "cluster: 5, component: QE_2017_001814_226.07077_397.0",
+          "cluster: 5, component: QE_2017_001815_194.04471_397.0",
+          "cluster: 5, component: QE_2017_001815_194.04471_397.0"
+         ],
          "type": "scatter",
-         "x": [
-          440,
-          440,
-          472.5,
-          472.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.17647058823529413,
-          0.26627218934911245,
-          0.26627218934911245,
-          0.18238993710691823
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          415,
-          415,
-          456.25,
-          456.25
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.27710843373493976,
-          0.27710843373493976,
-          0.26627218934911245
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          495,
-          495,
-          505,
-          505
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.0975609756097561,
-          0.0975609756097561,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "80843b06-7855-418e-8351-03f4213603b9",
          "x": [
           515,
           515,
@@ -1147,204 +1613,287 @@
          "xaxis": "x",
          "y": [
           0,
-          0.04938271604938271,
-          0.04938271604938271,
+          0.4583333333333333,
+          0.4583333333333333,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 5, component: QE_2017_001815_212.05505_267.0",
+          "cluster: 5, component: QE_2017_001815_212.05505_267.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "df03e521-5150-43ed-8855-adcf73fa53a4",
          "x": [
+          505,
+          505,
+          520,
+          520
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5384615384615384,
+          0.5384615384615384,
+          0.4583333333333333
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0c55dcab-6191-468e-a301-0dca5b42d6d0",
+         "x": [
+          482.5,
+          482.5,
+          512.5,
+          512.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.38636363636363635,
+          0.7183098591549296,
+          0.7183098591549296,
+          0.5384615384615384
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "97187849-8e6c-4b2e-8497-170bffe160da",
+         "x": [
+          460,
+          460,
+          497.5,
+          497.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.45,
+          0.7464788732394366,
+          0.7464788732394366,
+          0.7183098591549296
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 6, component: QE_2017_001816_533.15442_247.0",
+          "cluster: 6, component: QE_2017_001816_533.15442_247.0",
+          "cluster: 6, component: QE_2017_001816_533.15466_222.0",
+          "cluster: 6, component: QE_2017_001816_533.15466_222.0"
+         ],
+         "type": "scatter",
+         "uid": "c723459c-cb08-4fe4-b006-79643edff815",
+         "x": [
+          535,
+          535,
           545,
-          545,
+          545
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.22522522522522523,
+          0.22522522522522523,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 6, component: QE_2017_001815_533.1546_207.0",
+          "cluster: 6, component: QE_2017_001815_533.1546_207.0",
+          "cluster: 6, component: QE_2017_001816_533.1546_271.0",
+          "cluster: 6, component: QE_2017_001816_533.1546_271.0"
+         ],
+         "type": "scatter",
+         "uid": "52c06edc-2603-4e07-8f15-68a816b80bbb",
+         "x": [
           555,
-          555
+          555,
+          565,
+          565
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.033112582781456956,
-          0.033112582781456956,
+          0.29411764705882354,
+          0.29411764705882354,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "43ad92a5-240d-442a-82f8-16952c57acaa",
          "x": [
-          535,
-          535,
-          550,
-          550
+          540,
+          540,
+          560,
+          560
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.0641025641025641,
-          0.0641025641025641,
-          0.033112582781456956
+          0.22522522522522523,
+          0.3333333333333333,
+          0.3333333333333333,
+          0.29411764705882354
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 6, component: QE_2017_001814_347.09097_122.0",
+          "cluster: 6, component: QE_2017_001814_347.09097_122.0",
+          "cluster: 6, component: QE_2017_001815_347.09067_204.0",
+          "cluster: 6, component: QE_2017_001815_347.09067_204.0"
+         ],
          "type": "scatter",
+         "uid": "d8f95438-f3c7-44a5-8d0b-299abeb64243",
          "x": [
-          520,
-          520,
-          542.5,
-          542.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.04938271604938271,
-          0.2125,
-          0.2125,
-          0.0641025641025641
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          500,
-          500,
-          531.25,
-          531.25
-         ],
-         "xaxis": "x",
-         "y": [
-          0.0975609756097561,
-          0.2891566265060241,
-          0.2891566265060241,
-          0.2125
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          435.625,
-          435.625,
-          515.625,
-          515.625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.27710843373493976,
-          0.3372093023255814,
-          0.3372093023255814,
-          0.2891566265060241
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          381.25,
-          381.25,
-          475.625,
-          475.625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.25161290322580643,
-          0.36904761904761907,
-          0.36904761904761907,
-          0.3372093023255814
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          355,
-          355,
-          428.4375,
-          428.4375
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3879781420765027,
-          0.3879781420765027,
-          0.36904761904761907
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          565,
-          565,
           575,
-          575
+          575,
+          585,
+          585
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.08016877637130802,
-          0.08016877637130802,
+          0.34210526315789475,
+          0.34210526315789475,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "aa4adddd-9055-4960-8a49-db1ad9d9e9c7",
+         "x": [
+          550,
+          550,
+          580,
+          580
+         ],
+         "xaxis": "x",
+         "y": [
+          0.3333333333333333,
+          0.7864077669902912,
+          0.7864077669902912,
+          0.34210526315789475
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "258d5e7f-875f-4200-b253-07829ff932c4",
+         "x": [
+          478.75,
+          478.75,
+          565,
+          565
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7464788732394366,
+          0.971830985915493,
+          0.971830985915493,
+          0.7864077669902912
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 7, component: QE_2017_001815_268.10373_58.0",
+          "cluster: 7, component: QE_2017_001815_268.10373_58.0",
+          "cluster: 7, component: QE_2017_001816_269.16055_60.0",
+          "cluster: 7, component: QE_2017_001816_269.16055_60.0"
+         ],
          "type": "scatter",
+         "uid": "c5823f3f-e5a4-446d-b1f3-d9732e5541d8",
          "x": [
           595,
           595,
@@ -1354,20 +1903,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.06806282722513089,
-          0.06806282722513089,
+          0.2692307692307692,
+          0.2692307692307692,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 8, component: QE_2017_001816_408.36832_704.0",
+          "cluster: 8, component: QE_2017_001816_408.36832_704.0",
+          "cluster: 8, component: QE_2017_001816_466.40979_731.0",
+          "cluster: 8, component: QE_2017_001816_466.40979_731.0"
+         ],
          "type": "scatter",
+         "uid": "e38124c9-9bde-452e-9bd0-cd4114b067cb",
          "x": [
           625,
           625,
@@ -1377,20 +1932,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.1111111111111111,
-          0.1111111111111111,
+          0.4166666666666667,
+          0.4166666666666667,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 8, component: QE_2017_001815_364.34189_705.0",
+          "cluster: 8, component: QE_2017_001815_364.34189_705.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "450ad9f8-ffc7-4fb1-86bc-ce7a546c39b2",
          "x": [
           615,
           615,
@@ -1400,89 +1961,55 @@
          "xaxis": "x",
          "y": [
           0,
-          0.12280701754385964,
-          0.12280701754385964,
-          0.1111111111111111
+          0.5238095238095238,
+          0.5238095238095238,
+          0.4166666666666667
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          600,
-          600,
-          622.5,
-          622.5
+         "text": [
+          "cluster: 8, component: QE_2017_001814_364.34244_761.0",
+          "cluster: 8, component: QE_2017_001814_364.34244_761.0",
+          "cluster: 8, component: QE_2017_001815_364.34253_752.0",
+          "cluster: 8, component: QE_2017_001815_364.34253_752.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.06806282722513089,
-          0.14606741573033707,
-          0.14606741573033707,
-          0.12280701754385964
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "2ccac256-7e9b-4dbe-b7d9-3dbd8698162f",
          "x": [
-          585,
-          585,
-          611.25,
-          611.25
+          665,
+          665,
+          675,
+          675
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.2205128205128205,
-          0.2205128205128205,
-          0.14606741573033707
+          0.2222222222222222,
+          0.2222222222222222,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          570,
-          570,
-          598.125,
-          598.125
+         "text": [
+          "cluster: 8, component: QE_2017_001816_421.35226_731.0",
+          "cluster: 8, component: QE_2017_001816_421.35226_731.0",
+          "cluster: 8, component: QE_2017_001816_424.36325_712.0",
+          "cluster: 8, component: QE_2017_001816_424.36325_712.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.08016877637130802,
-          0.3059360730593607,
-          0.3059360730593607,
-          0.2205128205128205
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "4b599f3b-4cb9-4f73-8851-5c1e8b8dd6e6",
          "x": [
           685,
           685,
@@ -1492,273 +2019,229 @@
          "xaxis": "x",
          "y": [
           0,
-          0.043010752688172046,
-          0.043010752688172046,
+          0.2413793103448276,
+          0.2413793103448276,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "5dcc0032-b3c4-44f4-9660-342707c4d9bb",
          "x": [
-          675,
-          675,
+          670,
+          670,
           690,
           690
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.05263157894736842,
-          0.05263157894736842,
-          0.043010752688172046
+          0.2222222222222222,
+          0.44,
+          0.44,
+          0.2413793103448276
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 8, component: QE_2017_001815_482.40488_739.0",
+          "cluster: 8, component: QE_2017_001815_482.40488_739.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "060157b2-6fb5-497f-ba9c-cc655dc05e5d",
          "x": [
-          665,
-          665,
-          682.5,
-          682.5
+          655,
+          655,
+          680,
+          680
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.0582010582010582,
-          0.0582010582010582,
-          0.05263157894736842
+          0.5428571428571428,
+          0.5428571428571428,
+          0.44
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 8, component: QE_2017_001815_408.36853_717.0",
+          "cluster: 8, component: QE_2017_001815_408.36853_717.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "35ba4041-ed1e-4ed9-bf59-2fb105c01137",
          "x": [
-          655,
-          655,
-          673.75,
-          673.75
+          645,
+          645,
+          667.5,
+          667.5
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.06806282722513089,
-          0.06806282722513089,
-          0.0582010582010582
+          0.5757575757575758,
+          0.5757575757575758,
+          0.5428571428571428
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "d0f2f04d-86c1-4ca3-b64a-c40dfe37cf9c",
          "x": [
+          622.5,
+          622.5,
+          656.25,
+          656.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5238095238095238,
+          0.7222222222222222,
+          0.7222222222222222,
+          0.5757575757575758
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5b74af02-b845-46dc-817b-57fca9b41f52",
+         "x": [
+          600,
+          600,
+          639.375,
+          639.375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2692307692307692,
+          0.9636363636363636,
+          0.9636363636363636,
+          0.7222222222222222
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 9, component: QE_2017_001814_611.15997_285.0",
+          "cluster: 9, component: QE_2017_001814_611.15997_285.0",
+          "cluster: 9, component: QE_2017_001815_611.16046_309.0",
+          "cluster: 9, component: QE_2017_001815_611.16046_309.0"
+         ],
+         "type": "scatter",
+         "uid": "ba314393-7b22-4a1e-a56e-d6441f9ec71a",
+         "x": [
+          715,
+          715,
           725,
-          725,
+          725
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2972972972972973,
+          0.2972972972972973,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 10, component: QE_2017_001814_339.10742_366.0",
+          "cluster: 10, component: QE_2017_001814_339.10742_366.0",
+          "cluster: 10, component: QE_2017_001816_339.10733_298.0",
+          "cluster: 10, component: QE_2017_001816_339.10733_298.0"
+         ],
+         "type": "scatter",
+         "uid": "6b58047f-4ef3-4c1c-b5b8-6ded46b2be85",
+         "x": [
           735,
-          735
+          735,
+          745,
+          745
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.030303030303030304,
-          0.030303030303030304,
+          0.28205128205128205,
+          0.28205128205128205,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 10, component: QE_2017_001814_231.04971_516.0",
+          "cluster: 10, component: QE_2017_001814_231.04971_516.0",
+          "cluster: 10, component: QE_2017_001815_231.04971_369.0",
+          "cluster: 10, component: QE_2017_001815_231.04971_369.0"
+         ],
          "type": "scatter",
-         "x": [
-          715,
-          715,
-          730,
-          730
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.05583756345177665,
-          0.05583756345177665,
-          0.030303030303030304
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          705,
-          705,
-          722.5,
-          722.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.07,
-          0.07,
-          0.05583756345177665
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          664.375,
-          664.375,
-          713.75,
-          713.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.06806282722513089,
-          0.08,
-          0.08,
-          0.07
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          755,
-          755,
-          765,
-          765
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.06930693069306931,
-          0.06930693069306931,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          745,
-          745,
-          760,
-          760
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.08571428571428572,
-          0.08571428571428572,
-          0.06930693069306931
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          689.0625,
-          689.0625,
-          752.5,
-          752.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.08,
-          0.23444976076555024,
-          0.23444976076555024,
-          0.08571428571428572
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          645,
-          645,
-          720.78125,
-          720.78125
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.28431372549019607,
-          0.28431372549019607,
-          0.23444976076555024
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "01193cfe-19a6-448a-9bba-92f95427e6bf",
          "x": [
           795,
           795,
@@ -1768,20 +2251,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.11475409836065574,
-          0.11475409836065574,
+          0.24324324324324326,
+          0.24324324324324326,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 10, component: QE_2017_001815_231.04968_315.0",
+          "cluster: 10, component: QE_2017_001815_231.04968_315.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f08f83dc-9211-4518-be54-c990c6ffeb26",
          "x": [
           785,
           785,
@@ -1791,664 +2280,896 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2,
-          0.2,
-          0.11475409836065574
+          0.2571428571428571,
+          0.2571428571428571,
+          0.24324324324324326
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 10, component: QE_2017_001815_231.04973_403.0",
+          "cluster: 10, component: QE_2017_001815_231.04973_403.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "cbf7c2a3-8943-4edc-9ce2-3894637ac406",
          "x": [
-          825,
-          825,
-          835,
-          835
+          775,
+          775,
+          792.5,
+          792.5
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.07317073170731707,
-          0.07317073170731707,
+          0.35135135135135137,
+          0.35135135135135137,
+          0.2571428571428571
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 10, component: QE_2017_001815_340.16019_314.0",
+          "cluster: 10, component: QE_2017_001815_340.16019_314.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5a434408-eeb2-4039-9b83-4434b0dfc682",
+         "x": [
+          765,
+          765,
+          783.75,
+          783.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5272727272727272,
+          0.5272727272727272,
+          0.35135135135135137
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 10, component: QE_2017_001815_314.14453_76.0",
+          "cluster: 10, component: QE_2017_001815_314.14453_76.0",
+          "cluster: 10, component: QE_2017_001816_314.14462_79.0",
+          "cluster: 10, component: QE_2017_001816_314.14462_79.0"
+         ],
+         "type": "scatter",
+         "uid": "58576333-e0f9-4707-b223-4c1d916d14ff",
+         "x": [
+          815,
+          815,
+          825,
+          825
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2682926829268293,
+          0.2682926829268293,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 10, component: QE_2017_001816_310.14957_134.0",
+          "cluster: 10, component: QE_2017_001816_310.14957_134.0",
+          "cluster: 10, component: QE_2017_001816_342.17584_257.0",
+          "cluster: 10, component: QE_2017_001816_342.17584_257.0"
+         ],
          "type": "scatter",
+         "uid": "c4198305-c506-42c8-ad80-82bada973fc0",
          "x": [
-          815,
-          815,
+          835,
+          835,
+          845,
+          845
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.5135135135135135,
+          0.5135135135135135,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "071eb4c3-5338-4286-a3ed-5a79b0ccace5",
+         "x": [
+          820,
+          820,
+          840,
+          840
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2682926829268293,
+          0.6,
+          0.6,
+          0.5135135135135135
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "d2ff346e-3e08-4a87-b497-cf466b37b509",
+         "x": [
+          774.375,
+          774.375,
           830,
           830
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.13636363636363635,
-          0.13636363636363635,
-          0.07317073170731707
+          0.5272727272727272,
+          0.6666666666666666,
+          0.6666666666666666,
+          0.6
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 10, component: QE_2017_001814_498.2543_475.0",
+          "cluster: 10, component: QE_2017_001814_498.2543_475.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9bcad859-057b-44ea-997e-6df53039e66b",
          "x": [
-          845,
-          845,
+          755,
+          755,
+          802.1875,
+          802.1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.75,
+          0.75,
+          0.6666666666666666
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "8c10b958-4da2-4082-9f4a-1be810b72141",
+         "x": [
+          740,
+          740,
+          778.59375,
+          778.59375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.28205128205128205,
+          0.7818181818181819,
+          0.7818181818181819,
+          0.75
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 11, component: QE_2017_001814_241.15466_73.0",
+          "cluster: 11, component: QE_2017_001814_241.15466_73.0",
+          "cluster: 12, component: QE_2017_001815_507.18192_178.0",
+          "cluster: 12, component: QE_2017_001815_507.18192_178.0"
+         ],
+         "type": "scatter",
+         "uid": "3c5c9423-6423-4fed-b1ca-8ffb2a39f5f3",
+         "x": [
           855,
-          855
+          855,
+          865,
+          865
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.20833333333333334,
-          0.20833333333333334,
+          0.84375,
+          0.84375,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "3816bf13-bf1f-4e8b-947b-1fe9095e39cc",
          "x": [
-          822.5,
-          822.5,
-          850,
-          850
+          759.296875,
+          759.296875,
+          860,
+          860
          ],
          "xaxis": "x",
          "y": [
-          0.13636363636363635,
-          0.23316062176165803,
-          0.23316062176165803,
-          0.20833333333333334
+          0.7818181818181819,
+          0.8695652173913043,
+          0.8695652173913043,
+          0.84375
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "d7e9f4b0-b16d-4c27-9154-26a6b76445df",
          "x": [
-          792.5,
-          792.5,
-          836.25,
-          836.25
+          720,
+          720,
+          809.6484375,
+          809.6484375
          ],
          "xaxis": "x",
          "y": [
-          0.2,
-          0.26804123711340205,
-          0.26804123711340205,
-          0.23316062176165803
+          0.2972972972972973,
+          0.9272727272727272,
+          0.9272727272727272,
+          0.8695652173913043
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 13, component: QE_2017_001816_463.12311_410.0",
+          "cluster: 13, component: QE_2017_001816_463.12311_410.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "148b2fff-16ee-4442-b451-1f7f65b6f3d1",
          "x": [
-          775,
-          775,
-          814.375,
-          814.375
+          705,
+          705,
+          764.82421875,
+          764.82421875
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.3140096618357488,
-          0.3140096618357488,
-          0.26804123711340205
+          0.9411764705882353,
+          0.9411764705882353,
+          0.9272727272727272
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 14, component: QE_2017_001814_320.29456_577.0",
+          "cluster: 14, component: QE_2017_001814_320.29456_577.0",
+          "cluster: 14, component: QE_2017_001815_320.29471_563.0",
+          "cluster: 14, component: QE_2017_001815_320.29471_563.0"
+         ],
          "type": "scatter",
+         "uid": "e3901e84-2251-4d39-b136-e5f36667e172",
          "x": [
-          682.890625,
-          682.890625,
-          794.6875,
-          794.6875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.28431372549019607,
-          0.38181818181818183,
-          0.38181818181818183,
-          0.3140096618357488
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          584.0625,
-          584.0625,
-          738.7890625,
-          738.7890625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3059360730593607,
-          0.4358974358974359,
-          0.4358974358974359,
-          0.38181818181818183
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          391.71875,
-          391.71875,
-          661.42578125,
-          661.42578125
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3879781420765027,
-          0.472636815920398,
-          0.472636815920398,
-          0.4358974358974359
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          332.5,
-          332.5,
-          526.572265625,
-          526.572265625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.308411214953271,
-          0.5466666666666666,
-          0.5466666666666666,
-          0.472636815920398
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          885,
-          885,
           895,
-          895
+          895,
+          905,
+          905
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.1232876712328767,
-          0.1232876712328767,
+          0.21951219512195122,
+          0.21951219512195122,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 14, component: QE_2017_001816_338.26062_643.0",
+          "cluster: 14, component: QE_2017_001816_338.26062_643.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "76feede6-6590-49a7-8752-dea919e484e1",
          "x": [
-          875,
-          875,
-          890,
-          890
+          885,
+          885,
+          900,
+          900
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.15270935960591134,
-          0.15270935960591134,
-          0.1232876712328767
+          0.4444444444444444,
+          0.4444444444444444,
+          0.21951219512195122
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(61,153,112)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 14, component: QE_2017_001814_483.27118_651.0",
+          "cluster: 14, component: QE_2017_001814_483.27118_651.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "6d450ee3-9efb-477d-9101-9340c4f10cb3",
          "x": [
-          865,
-          865,
-          882.5,
-          882.5
+          875,
+          875,
+          892.5,
+          892.5
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.23655913978494625,
-          0.23655913978494625,
-          0.15270935960591134
+          0.76,
+          0.76,
+          0.4444444444444444
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 15, component: QE_2017_001815_129.12741_349.0",
+          "cluster: 15, component: QE_2017_001815_129.12741_349.0",
+          "cluster: 15, component: QE_2017_001815_171.14914_420.0",
+          "cluster: 15, component: QE_2017_001815_171.14914_420.0"
+         ],
+         "type": "scatter",
+         "uid": "a384d01d-3916-4988-a7ab-3a63584980f6",
+         "x": [
+          915,
+          915,
+          925,
+          925
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7647058823529411,
+          0.7647058823529411,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c6547899-35be-42ef-8bdd-134d63ac2f45",
+         "x": [
+          883.75,
+          883.75,
+          920,
+          920
+         ],
+         "xaxis": "x",
+         "y": [
+          0.76,
+          0.8235294117647058,
+          0.8235294117647058,
+          0.7647058823529411
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001815_201.16367_442.0",
+          "cluster: 16, component: QE_2017_001815_201.16367_442.0",
+          "cluster: 16, component: QE_2017_001816_201.16362_435.0",
+          "cluster: 16, component: QE_2017_001816_201.16362_435.0"
+         ],
          "type": "scatter",
+         "uid": "fb11c8f3-1fc7-4aaf-8ddf-96a91cd0a639",
          "x": [
+          935,
+          935,
           945,
-          945,
+          945
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.31868131868131866,
+          0.31868131868131866,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001815_209.1535_312.0",
+          "cluster: 16, component: QE_2017_001815_209.1535_312.0",
+          "cluster: 16, component: QE_2017_001816_209.15344_311.0",
+          "cluster: 16, component: QE_2017_001816_209.15344_311.0"
+         ],
+         "type": "scatter",
+         "uid": "e8a32c99-6cc6-4618-9b53-eb4dcdfdb189",
+         "x": [
+          975,
+          975,
+          985,
+          985
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.17073170731707318,
+          0.17073170731707318,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001815_209.15349_295.0",
+          "cluster: 16, component: QE_2017_001815_209.15349_295.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6544609b-3746-4e1e-aa11-846066019548",
+         "x": [
+          965,
+          965,
+          980,
+          980
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.23728813559322035,
+          0.23728813559322035,
+          0.17073170731707318
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001815_209.15352_479.0",
+          "cluster: 16, component: QE_2017_001815_209.15352_479.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "d20fdcb3-b62a-4f12-bc13-b9fd17c4eabd",
+         "x": [
           955,
-          955
+          955,
+          972.5,
+          972.5
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.08108108108108109,
-          0.08108108108108109,
-          0
+          0.288135593220339,
+          0.288135593220339,
+          0.23728813559322035
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001814_243.15892_533.0",
+          "cluster: 16, component: QE_2017_001814_243.15892_533.0",
+          "cluster: 16, component: QE_2017_001814_281.1745_492.0",
+          "cluster: 16, component: QE_2017_001814_281.1745_492.0"
+         ],
          "type": "scatter",
+         "uid": "acbd934b-c586-4282-bc30-9a94a072a7b1",
          "x": [
-          935,
-          935,
-          950,
-          950
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.1509433962264151,
-          0.1509433962264151,
-          0.08108108108108109
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          925,
-          925,
-          942.5,
-          942.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.28846153846153844,
-          0.28846153846153844,
-          0.1509433962264151
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          915,
-          915,
-          933.75,
-          933.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3391304347826087,
-          0.3391304347826087,
-          0.28846153846153844
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          905,
-          905,
-          924.375,
-          924.375
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3939393939393939,
-          0.3939393939393939,
-          0.3391304347826087
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          985,
-          985,
           995,
-          995
+          995,
+          1005,
+          1005
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.10638297872340426,
-          0.10638297872340426,
+          0.21904761904761905,
+          0.21904761904761905,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001815_227.16408_344.0",
+          "cluster: 16, component: QE_2017_001815_227.16408_344.0",
+          "cluster: 16, component: QE_2017_001815_283.19009_564.0",
+          "cluster: 16, component: QE_2017_001815_283.19009_564.0"
+         ],
          "type": "scatter",
+         "uid": "59bdda3e-c64d-4cbe-993e-9fd3fc139f16",
          "x": [
-          975,
-          975,
-          990,
-          990
+          1025,
+          1025,
+          1035,
+          1035
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.21678321678321677,
-          0.21678321678321677,
-          0.10638297872340426
+          0.3088235294117647,
+          0.3088235294117647,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          965,
-          965,
-          982.5,
-          982.5
+         "text": [
+          "cluster: 16, component: QE_2017_001814_293.2106_579.0",
+          "cluster: 16, component: QE_2017_001814_293.2106_579.0",
+          null,
+          null
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.38571428571428573,
-          0.38571428571428573,
-          0.21678321678321677
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "ab749b82-84a2-4e8d-bb50-1e939c6071d5",
          "x": [
-          1005,
-          1005,
           1015,
-          1015
+          1015,
+          1030,
+          1030
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.06382978723404255,
-          0.06382978723404255,
+          0.375,
+          0.375,
+          0.3088235294117647
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "25ba411e-3f0d-475b-acb8-aa03de816e79",
+         "x": [
+          1000,
+          1000,
+          1022.5,
+          1022.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.21904761904761905,
+          0.42857142857142855,
+          0.42857142857142855,
+          0.375
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "a0c2ac04-03c0-41b8-a32d-94afddc8f1e6",
+         "x": [
+          963.75,
+          963.75,
+          1011.25,
+          1011.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.288135593220339,
+          0.48091603053435117,
+          0.48091603053435117,
+          0.42857142857142855
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001814_227.1275_293.0",
+          "cluster: 16, component: QE_2017_001814_227.1275_293.0",
+          "cluster: 16, component: QE_2017_001816_227.12766_295.0",
+          "cluster: 16, component: QE_2017_001816_227.12766_295.0"
+         ],
+         "type": "scatter",
+         "uid": "d6ae791d-db47-4b22-aca9-34df0732eec4",
+         "x": [
+          1055,
+          1055,
+          1065,
+          1065
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.20353982300884957,
+          0.20353982300884957,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001815_207.13785_297.0",
+          "cluster: 16, component: QE_2017_001815_207.13785_297.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "6aa3c245-9fc4-40f5-a3e0-12220ad6acd0",
          "x": [
-          1035,
-          1035,
           1045,
-          1045
+          1045,
+          1060,
+          1060
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.04411764705882353,
-          0.04411764705882353,
-          0
+          0.504950495049505,
+          0.504950495049505,
+          0.20353982300884957
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "1a7b62a9-91c4-4461-8588-c1f05483f05c",
          "x": [
-          1025,
-          1025,
-          1040,
-          1040
+          987.5,
+          987.5,
+          1052.5,
+          1052.5
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.08450704225352113,
-          0.08450704225352113,
-          0.04411764705882353
+          0.48091603053435117,
+          0.5454545454545454,
+          0.5454545454545454,
+          0.504950495049505
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1010,
-          1010,
-          1032.5,
-          1032.5
+         "text": [
+          "cluster: 16, component: QE_2017_001815_181.1221_767.0",
+          "cluster: 16, component: QE_2017_001815_181.1221_767.0",
+          "cluster: 16, component: QE_2017_001816_181.12199_794.0",
+          "cluster: 16, component: QE_2017_001816_181.12199_794.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.06382978723404255,
-          0.09090909090909091,
-          0.09090909090909091,
-          0.08450704225352113
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "514bfea4-6a58-44d5-8299-4f836cdb49d4",
          "x": [
-          1065,
-          1065,
           1075,
-          1075
+          1075,
+          1085,
+          1085
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.056,
-          0.056,
+          0.16666666666666666,
+          0.16666666666666666,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001814_211.16902_440.0",
+          "cluster: 16, component: QE_2017_001814_211.16902_440.0",
+          "cluster: 16, component: QE_2017_001815_211.16913_450.0",
+          "cluster: 16, component: QE_2017_001815_211.16913_450.0"
+         ],
          "type": "scatter",
-         "x": [
-          1055,
-          1055,
-          1070,
-          1070
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.1746031746031746,
-          0.1746031746031746,
-          0.056
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1085,
-          1085,
-          1095,
-          1095
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.038461538461538464,
-          0.038461538461538464,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "3ca24ac9-a453-4aaa-a730-bafcf63a1ff7",
          "x": [
           1115,
           1115,
@@ -2458,20 +3179,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.06666666666666667,
-          0.06666666666666667,
+          0.10638297872340426,
+          0.10638297872340426,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001815_209.0807_405.0",
+          "cluster: 16, component: QE_2017_001815_209.0807_405.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "4478e907-ce84-4ad8-a4f3-fc46226c9f0f",
          "x": [
           1105,
           1105,
@@ -2481,89 +3208,55 @@
          "xaxis": "x",
          "y": [
           0,
-          0.11320754716981132,
-          0.11320754716981132,
-          0.06666666666666667
+          0.11827956989247312,
+          0.11827956989247312,
+          0.10638297872340426
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001816_211.16916_405.0",
+          "cluster: 16, component: QE_2017_001816_211.16916_405.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "34ae726f-ca62-4b87-83d1-36a295578c6c",
          "x": [
-          1090,
-          1090,
+          1095,
+          1095,
           1112.5,
           1112.5
          ],
          "xaxis": "x",
          "y": [
-          0.038461538461538464,
-          0.18518518518518517,
-          0.18518518518518517,
-          0.11320754716981132
+          0,
+          0.17647058823529413,
+          0.17647058823529413,
+          0.11827956989247312
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001815_215.164_550.0",
+          "cluster: 16, component: QE_2017_001815_215.164_550.0",
+          "cluster: 16, component: QE_2017_001816_215.16411_482.0",
+          "cluster: 16, component: QE_2017_001816_215.16411_482.0"
+         ],
          "type": "scatter",
-         "x": [
-          1062.5,
-          1062.5,
-          1101.25,
-          1101.25
-         ],
-         "xaxis": "x",
-         "y": [
-          0.1746031746031746,
-          0.23076923076923078,
-          0.23076923076923078,
-          0.18518518518518517
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1021.25,
-          1021.25,
-          1081.875,
-          1081.875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.09090909090909091,
-          0.29133858267716534,
-          0.29133858267716534,
-          0.23076923076923078
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "58751f36-44e0-442e-a809-2a88ad551cf6",
          "x": [
           1135,
           1135,
@@ -2573,20 +3266,113 @@
          "xaxis": "x",
          "y": [
           0,
-          0.1937984496124031,
-          0.1937984496124031,
+          0.3220338983050847,
+          0.3220338983050847,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "def493cb-2a14-4aa7-b467-d6645a3ec608",
+         "x": [
+          1103.75,
+          1103.75,
+          1140,
+          1140
+         ],
+         "xaxis": "x",
+         "y": [
+          0.17647058823529413,
+          0.41025641025641024,
+          0.41025641025641024,
+          0.3220338983050847
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "12a273a6-f4eb-42ed-a67a-b560185ed127",
+         "x": [
+          1080,
+          1080,
+          1121.875,
+          1121.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0.16666666666666666,
+          0.5932203389830508,
+          0.5932203389830508,
+          0.41025641025641024
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "6e7dabfc-1c0d-43b9-a8d6-d1151ec1f068",
+         "x": [
+          1020,
+          1020,
+          1100.9375,
+          1100.9375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5454545454545454,
+          0.6170212765957447,
+          0.6170212765957447,
+          0.5932203389830508
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001814_219.17416_517.0",
+          "cluster: 16, component: QE_2017_001814_219.17416_517.0",
+          "cluster: 16, component: QE_2017_001815_219.17421_516.0",
+          "cluster: 16, component: QE_2017_001815_219.17421_516.0"
+         ],
+         "type": "scatter",
+         "uid": "4089c5c4-889c-4317-813d-cd45d254f36f",
          "x": [
           1165,
           1165,
@@ -2596,43 +3382,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.05555555555555555,
-          0.05555555555555555,
+          0.14285714285714285,
+          0.14285714285714285,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1155,
-          1155,
-          1170,
-          1170
+         "text": [
+          "cluster: 16, component: QE_2017_001814_219.17401_452.0",
+          "cluster: 16, component: QE_2017_001814_219.17401_452.0",
+          "cluster: 16, component: QE_2017_001814_219.17409_442.0",
+          "cluster: 16, component: QE_2017_001814_219.17409_442.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.1206896551724138,
-          0.1206896551724138,
-          0.05555555555555555
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "67b8c8e2-b9be-4481-9d7d-fa3b19db8d1b",
          "x": [
           1195,
           1195,
@@ -2642,20 +3411,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.13043478260869565,
-          0.13043478260869565,
+          0.18518518518518517,
+          0.18518518518518517,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001816_219.17438_502.0",
+          "cluster: 16, component: QE_2017_001816_219.17438_502.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "672af66b-ecae-43de-b954-0687ede947c7",
          "x": [
           1185,
           1185,
@@ -2665,549 +3440,664 @@
          "xaxis": "x",
          "y": [
           0,
-          0.24,
-          0.24,
-          0.13043478260869565
+          0.2558139534883721,
+          0.2558139534883721,
+          0.18518518518518517
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "21e95ef0-5657-428b-9e4f-a178c5a80f96",
          "x": [
-          1162.5,
-          1162.5,
+          1170,
+          1170,
           1192.5,
           1192.5
          ],
          "xaxis": "x",
          "y": [
-          0.1206896551724138,
-          0.2761904761904762,
-          0.2761904761904762,
-          0.24
+          0.14285714285714285,
+          0.2972972972972973,
+          0.2972972972972973,
+          0.2558139534883721
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 16, component: QE_2017_001815_191.14287_312.0",
+          "cluster: 16, component: QE_2017_001815_191.14287_312.0",
+          "cluster: 16, component: QE_2017_001816_191.14291_404.0",
+          "cluster: 16, component: QE_2017_001816_191.14291_404.0"
+         ],
          "type": "scatter",
+         "uid": "eb8f9bbd-0a6b-42f9-a1b2-ebf2d1b26d7a",
          "x": [
-          1140,
-          1140,
-          1177.5,
-          1177.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0.1937984496124031,
-          0.31746031746031744,
-          0.31746031746031744,
-          0.2761904761904762
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1051.5625,
-          1051.5625,
-          1158.75,
-          1158.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.29133858267716534,
-          0.39568345323741005,
-          0.39568345323741005,
-          0.31746031746031744
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          973.75,
-          973.75,
-          1105.15625,
-          1105.15625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.38571428571428573,
-          0.4492753623188406,
-          0.4492753623188406,
-          0.39568345323741005
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          914.6875,
-          914.6875,
-          1039.453125,
-          1039.453125
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3939393939393939,
-          0.5107913669064749,
-          0.5107913669064749,
-          0.4492753623188406
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          873.75,
-          873.75,
-          977.0703125,
-          977.0703125
-         ],
-         "xaxis": "x",
-         "y": [
-          0.23655913978494625,
-          0.5705521472392638,
-          0.5705521472392638,
-          0.5107913669064749
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          429.5361328125,
-          429.5361328125,
-          925.41015625,
-          925.41015625
-         ],
-         "xaxis": "x",
-         "y": [
-          0.5466666666666666,
-          0.5955056179775281,
-          0.5955056179775281,
-          0.5705521472392638
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(61,153,112)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          47.490234375,
-          47.490234375,
-          677.47314453125,
-          677.47314453125
-         ],
-         "xaxis": "x",
-         "y": [
-          0.5789473684210527,
-          0.7289719626168224,
-          0.7289719626168224,
-          0.5955056179775281
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1215,
-          1215,
           1225,
-          1225
+          1225,
+          1235,
+          1235
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.21666666666666667,
-          0.21666666666666667,
+          0.27472527472527475,
+          0.27472527472527475,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001814_191.14291_389.0",
+          "cluster: 16, component: QE_2017_001814_191.14291_389.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "542cd630-5cc0-4e35-9576-c119d0870a59",
+         "x": [
+          1215,
+          1215,
+          1230,
+          1230
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3333333333333333,
+          0.3333333333333333,
+          0.27472527472527475
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "334acdb1-038b-4647-af66-9ed2e0e33b8e",
+         "x": [
+          1181.25,
+          1181.25,
+          1222.5,
+          1222.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.2972972972972973,
+          0.5151515151515151,
+          0.5151515151515151,
+          0.3333333333333333
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 16, component: QE_2017_001816_137.09584_445.0",
+          "cluster: 16, component: QE_2017_001816_137.09584_445.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b263510b-1a0c-4793-8bca-45aa0880f4f2",
+         "x": [
+          1155,
+          1155,
+          1201.875,
+          1201.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6428571428571429,
+          0.6428571428571429,
+          0.5151515151515151
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9a6ee1e3-0e80-4786-add5-f582a4721c27",
+         "x": [
+          1060.46875,
+          1060.46875,
+          1178.4375,
+          1178.4375
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6170212765957447,
+          0.6907216494845361,
+          0.6907216494845361,
+          0.6428571428571429
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "5ac407a9-be2d-4c1e-a669-6cf26bc9c319",
+         "x": [
+          940,
+          940,
+          1119.453125,
+          1119.453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.31868131868131866,
+          0.7272727272727273,
+          0.7272727272727273,
+          0.6907216494845361
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 17, component: QE_2017_001814_209.08058_363.0",
+          "cluster: 17, component: QE_2017_001814_209.08058_363.0",
+          "cluster: 17, component: QE_2017_001816_207.13779_561.0",
+          "cluster: 17, component: QE_2017_001816_207.13779_561.0"
+         ],
          "type": "scatter",
+         "uid": "4b98120d-e711-41ea-825c-eaa17a172153",
          "x": [
-          1235,
-          1235,
           1245,
-          1245
+          1245,
+          1255,
+          1255
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.16339869281045752,
-          0.16339869281045752,
+          0.7477477477477478,
+          0.7477477477477478,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9a939bd7-522b-4797-be81-1e67fa2a794d",
          "x": [
-          1255,
-          1255,
-          1265,
-          1265
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.20833333333333334,
-          0.20833333333333334,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1240,
-          1240,
-          1260,
-          1260
-         ],
-         "xaxis": "x",
-         "y": [
-          0.16339869281045752,
-          0.24,
-          0.24,
-          0.20833333333333334
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1220,
-          1220,
+          1029.7265625,
+          1029.7265625,
           1250,
           1250
          ],
          "xaxis": "x",
          "y": [
-          0.21666666666666667,
-          0.5657894736842105,
-          0.5657894736842105,
-          0.24
+          0.7272727272727273,
+          0.8409090909090909,
+          0.8409090909090909,
+          0.7477477477477478
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "38173139-87c7-4089-8d35-b07254822400",
          "x": [
+          901.875,
+          901.875,
+          1139.86328125,
+          1139.86328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8235294117647058,
+          0.9767441860465116,
+          0.9767441860465116,
+          0.8409090909090909
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 18, component: QE_2017_001815_333.15173_245.0",
+          "cluster: 18, component: QE_2017_001815_333.15173_245.0",
+          "cluster: 18, component: QE_2017_001816_333.15204_235.0",
+          "cluster: 18, component: QE_2017_001816_333.15204_235.0"
+         ],
+         "type": "scatter",
+         "uid": "6a8170ae-6800-4917-ac7d-646d515f7684",
+         "x": [
+          1265,
+          1265,
           1275,
-          1275,
+          1275
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.7333333333333333,
+          0.7333333333333333,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 19, component: QE_2017_001814_194.1174_244.0",
+          "cluster: 19, component: QE_2017_001814_194.1174_244.0",
+          "cluster: 19, component: QE_2017_001816_194.11746_133.0",
+          "cluster: 19, component: QE_2017_001816_194.11746_133.0"
+         ],
+         "type": "scatter",
+         "uid": "c880c71b-5672-4a85-9216-b83e4d4c36e7",
+         "x": [
           1285,
-          1285
+          1285,
+          1295,
+          1295
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.14285714285714285,
-          0.14285714285714285,
+          0.5555555555555556,
+          0.5555555555555556,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 20, component: QE_2017_001814_320.29471_529.0",
+          "cluster: 20, component: QE_2017_001814_320.29471_529.0",
+          "cluster: 20, component: QE_2017_001815_320.29486_538.0",
+          "cluster: 20, component: QE_2017_001815_320.29486_538.0"
+         ],
          "type": "scatter",
+         "uid": "7f316720-396f-40ae-837c-fa74acefca28",
          "x": [
-          1315,
-          1315,
+          1335,
+          1335,
+          1345,
+          1345
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.2857142857142857,
+          0.2857142857142857,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,220,0)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 20, component: QE_2017_001814_320.29477_539.0",
+          "cluster: 20, component: QE_2017_001814_320.29477_539.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "b62809b4-082f-4cd3-a598-33d1688f8b04",
+         "x": [
           1325,
-          1325
+          1325,
+          1340,
+          1340
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.07042253521126761,
-          0.07042253521126761,
-          0
+          0.4117647058823529,
+          0.4117647058823529,
+          0.2857142857142857
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 20, component: QE_2017_001814_320.29468_638.0",
+          "cluster: 20, component: QE_2017_001814_320.29468_638.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "c4c55694-cb45-4e28-8378-864363649454",
+         "x": [
+          1315,
+          1315,
+          1332.5,
+          1332.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6470588235294118,
+          0.6470588235294118,
+          0.4117647058823529
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 21, component: QE_2017_001816_320.29483_548.0",
+          "cluster: 21, component: QE_2017_001816_320.29483_548.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9b66f41a-bfff-4faf-9595-09f5e0ea4498",
          "x": [
           1305,
           1305,
-          1320,
-          1320
+          1323.75,
+          1323.75
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.10810810810810811,
-          0.10810810810810811,
-          0.07042253521126761
+          0.8857142857142857,
+          0.8857142857142857,
+          0.6470588235294118
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "d385f7fb-2275-43b9-be30-7cc7a85331fb",
          "x": [
-          1295,
-          1295,
-          1312.5,
-          1312.5
+          1290,
+          1290,
+          1314.375,
+          1314.375
          ],
          "xaxis": "x",
          "y": [
-          0,
-          0.15384615384615385,
-          0.15384615384615385,
-          0.10810810810810811
+          0.5555555555555556,
+          0.9090909090909091,
+          0.9090909090909091,
+          0.8857142857142857
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 22, component: QE_2017_001814_241.15384_47.0",
+          "cluster: 22, component: QE_2017_001814_241.15384_47.0",
+          "cluster: 22, component: QE_2017_001814_241.15446_57.0",
+          "cluster: 22, component: QE_2017_001814_241.15446_57.0"
+         ],
          "type": "scatter",
+         "uid": "47587d80-5f6b-4c64-a656-fb185932f5a8",
          "x": [
-          1345,
-          1345,
           1355,
-          1355
+          1355,
+          1365,
+          1365
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.08823529411764706,
-          0.08823529411764706,
+          0.4666666666666667,
+          0.4666666666666667,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 23, component: QE_2017_001815_332.25827_508.0",
+          "cluster: 23, component: QE_2017_001815_332.25827_508.0",
+          "cluster: 23, component: QE_2017_001816_332.25842_487.0",
+          "cluster: 23, component: QE_2017_001816_332.25842_487.0"
+         ],
          "type": "scatter",
+         "uid": "51e2aa67-d7aa-446b-90c7-853b7a197177",
          "x": [
-          1335,
-          1335,
-          1350,
-          1350
+          1385,
+          1385,
+          1395,
+          1395
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.15942028985507245,
-          0.15942028985507245,
-          0.08823529411764706
+          0.5185185185185185,
+          0.5185185185185185,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1303.75,
-          1303.75,
-          1342.5,
-          1342.5
+         "text": [
+          "cluster: 23, component: QE_2017_001814_332.25827_467.0",
+          "cluster: 23, component: QE_2017_001814_332.25827_467.0",
+          null,
+          null
          ],
-         "xaxis": "x",
-         "y": [
-          0.15384615384615385,
-          0.23943661971830985,
-          0.23943661971830985,
-          0.15942028985507245
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "eba793d2-5aff-4d6f-9041-371f8fbe3620",
          "x": [
-          1365,
-          1365,
           1375,
-          1375
+          1375,
+          1390,
+          1390
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.28,
-          0.28,
-          0
+          0.6666666666666666,
+          0.6666666666666666,
+          0.5185185185185185
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "5f914eca-f641-41af-8b99-841b928596fa",
          "x": [
-          1323.125,
-          1323.125,
-          1370,
-          1370
+          1360,
+          1360,
+          1382.5,
+          1382.5
          ],
          "xaxis": "x",
          "y": [
-          0.23943661971830985,
-          0.3176470588235294,
-          0.3176470588235294,
-          0.28
+          0.4666666666666667,
+          0.9354838709677419,
+          0.9354838709677419,
+          0.6666666666666666
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "c3243502-0a75-4ea0-a09f-62f1079c50d1",
          "x": [
-          1280,
-          1280,
-          1346.5625,
-          1346.5625
+          1302.1875,
+          1302.1875,
+          1371.25,
+          1371.25
          ],
          "xaxis": "x",
          "y": [
-          0.14285714285714285,
-          0.5339805825242718,
-          0.5339805825242718,
-          0.3176470588235294
+          0.9090909090909091,
+          0.9555555555555556,
+          0.9555555555555556,
+          0.9354838709677419
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 24, component: QE_2017_001814_319.13638_117.0",
+          "cluster: 24, component: QE_2017_001814_319.13638_117.0",
+          "cluster: 24, component: QE_2017_001816_319.13614_143.0",
+          "cluster: 24, component: QE_2017_001816_319.13614_143.0"
+         ],
          "type": "scatter",
+         "uid": "a6478449-9f94-453e-ade3-914c33e691ba",
          "x": [
           1405,
           1405,
@@ -3217,89 +4107,113 @@
          "xaxis": "x",
          "y": [
           0,
-          0.11428571428571428,
-          0.11428571428571428,
+          0.6,
+          0.6,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 25, component: QE_2017_001815_219.10139_360.0",
+          "cluster: 25, component: QE_2017_001815_219.10139_360.0",
+          "cluster: 25, component: QE_2017_001816_219.10153_382.0",
+          "cluster: 25, component: QE_2017_001816_219.10153_382.0"
+         ],
          "type": "scatter",
+         "uid": "02233bc1-5631-4f86-ae24-2c6883691855",
          "x": [
-          1395,
-          1395,
-          1410,
-          1410
+          1445,
+          1445,
+          1455,
+          1455
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.4153846153846154,
-          0.4153846153846154,
-          0.11428571428571428
+          0.23595505617977527,
+          0.23595505617977527,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1385,
-          1385,
-          1402.5,
-          1402.5
+         "text": [
+          "cluster: 25, component: QE_2017_001815_219.10159_438.0",
+          "cluster: 25, component: QE_2017_001815_219.10159_438.0",
+          null,
+          null
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.475,
-          0.475,
-          0.4153846153846154
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "8ebeb7a4-3f5d-4453-9159-2d25be8a083c",
          "x": [
-          1425,
-          1425,
           1435,
-          1435
+          1435,
+          1450,
+          1450
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.16417910447761194,
-          0.16417910447761194,
-          0
+          0.30275229357798167,
+          0.30275229357798167,
+          0.23595505617977527
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 25, component: QE_2017_001814_251.09117_393.0",
+          "cluster: 25, component: QE_2017_001814_251.09117_393.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "66216145-643d-4aba-a0fe-e9353642da71",
+         "x": [
+          1425,
+          1425,
+          1442.5,
+          1442.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.4845360824742268,
+          0.4845360824742268,
+          0.30275229357798167
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(133,20,75)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 26, component: QE_2017_001814_291.1442_241.0",
+          "cluster: 26, component: QE_2017_001814_291.1442_241.0",
+          "cluster: 26, component: QE_2017_001816_291.14493_243.0",
+          "cluster: 26, component: QE_2017_001816_291.14493_243.0"
+         ],
+         "type": "scatter",
+         "uid": "ae1496ab-8da5-47a4-b13f-65624725ca56",
          "x": [
           1465,
           1465,
@@ -3309,158 +4223,113 @@
          "xaxis": "x",
          "y": [
           0,
-          0.13432835820895522,
-          0.13432835820895522,
+          0.22727272727272727,
+          0.22727272727272727,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 26, component: QE_2017_001815_273.13425_199.0",
+          "cluster: 26, component: QE_2017_001815_273.13425_199.0",
+          "cluster: 26, component: QE_2017_001815_273.13434_243.0",
+          "cluster: 26, component: QE_2017_001815_273.13434_243.0"
+         ],
          "type": "scatter",
+         "uid": "8eae8cd2-b395-4b9e-9900-de4bac8aa45a",
          "x": [
-          1455,
-          1455,
-          1470,
-          1470
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.14285714285714285,
-          0.14285714285714285,
-          0.13432835820895522
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1445,
-          1445,
-          1462.5,
-          1462.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.18840579710144928,
-          0.18840579710144928,
-          0.14285714285714285
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1430,
-          1430,
-          1453.75,
-          1453.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0.16417910447761194,
-          0.38235294117647056,
-          0.38235294117647056,
-          0.18840579710144928
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1485,
-          1485,
           1495,
-          1495
+          1495,
+          1505,
+          1505
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.14666666666666667,
-          0.14666666666666667,
+          0.2,
+          0.2,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 26, component: QE_2017_001816_291.14499_200.0",
+          "cluster: 26, component: QE_2017_001816_291.14499_200.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "c1f9cc4a-cd81-4170-a323-ba29df52f714",
          "x": [
-          1505,
-          1505,
-          1515,
-          1515
+          1485,
+          1485,
+          1500,
+          1500
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.2676056338028169,
-          0.2676056338028169,
-          0
+          0.2653061224489796,
+          0.2653061224489796,
+          0.2
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "f13fc3f8-e8a9-4033-b79f-8af03bb76bc4",
          "x": [
-          1490,
-          1490,
-          1510,
-          1510
+          1470,
+          1470,
+          1492.5,
+          1492.5
          ],
          "xaxis": "x",
          "y": [
-          0.14666666666666667,
-          0.34177215189873417,
-          0.34177215189873417,
-          0.2676056338028169
+          0.22727272727272727,
+          0.34782608695652173,
+          0.34782608695652173,
+          0.2653061224489796
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 27, component: QE_2017_001815_235.14398_226.0",
+          "cluster: 27, component: QE_2017_001815_235.14398_226.0",
+          "cluster: 27, component: QE_2017_001816_235.14397_183.0",
+          "cluster: 27, component: QE_2017_001816_235.14397_183.0"
+         ],
          "type": "scatter",
+         "uid": "ce3a1fed-cab5-4e76-abc2-09f8fc3c77ce",
          "x": [
           1525,
           1525,
@@ -3470,549 +4339,606 @@
          "xaxis": "x",
          "y": [
           0,
-          0.36,
-          0.36,
+          0.35714285714285715,
+          0.35714285714285715,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,65,54)"
+          "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 27, component: QE_2017_001815_251.13873_202.0",
+          "cluster: 27, component: QE_2017_001815_251.13873_202.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "6b6f0d7d-d0d8-4deb-99d1-625d5f30b431",
          "x": [
-          1500,
-          1500,
+          1515,
+          1515,
           1530,
           1530
          ],
          "xaxis": "x",
          "y": [
-          0.34177215189873417,
-          0.4666666666666667,
-          0.4666666666666667,
-          0.36
+          0,
+          0.76,
+          0.76,
+          0.35714285714285715
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1441.875,
-          1441.875,
-          1515,
-          1515
-         ],
-         "xaxis": "x",
-         "y": [
-          0.38235294117647056,
-          0.5294117647058824,
-          0.5294117647058824,
-          0.4666666666666667
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1393.75,
-          1393.75,
-          1478.4375,
-          1478.4375
-         ],
-         "xaxis": "x",
-         "y": [
-          0.475,
-          0.569620253164557,
-          0.569620253164557,
-          0.5294117647058824
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1313.28125,
-          1313.28125,
-          1436.09375,
-          1436.09375
-         ],
-         "xaxis": "x",
-         "y": [
-          0.5339805825242718,
-          0.68,
-          0.68,
-          0.569620253164557
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,65,54)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1235,
-          1235,
-          1374.6875,
-          1374.6875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.5657894736842105,
-          0.7606837606837606,
-          0.7606837606837606,
-          0.68
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "ff49a0b4-05d6-40d6-8565-061f48a88392",
          "x": [
-          362.481689453125,
-          362.481689453125,
-          1304.84375,
-          1304.84375
+          1481.25,
+          1481.25,
+          1522.5,
+          1522.5
          ],
          "xaxis": "x",
          "y": [
-          0.7289719626168224,
-          0.8205128205128205,
-          0.8205128205128205,
-          0.7606837606837606
+          0.34782608695652173,
+          0.8461538461538461,
+          0.8461538461538461,
+          0.76
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(35,205,205)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "84eea364-9295-407e-a78d-5677e4c7f500",
          "x": [
-          1555,
-          1555,
+          1433.75,
+          1433.75,
+          1501.875,
+          1501.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0.4845360824742268,
+          0.978494623655914,
+          0.978494623655914,
+          0.8461538461538461
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(40,35,35)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 28, component: QE_2017_001814_250.10149_516.0",
+          "cluster: 28, component: QE_2017_001814_250.10149_516.0",
+          "cluster: 28, component: QE_2017_001815_222.07033_315.0",
+          "cluster: 28, component: QE_2017_001815_222.07033_315.0"
+         ],
+         "type": "scatter",
+         "uid": "bb6afacc-29cb-4754-b97e-0a447df27913",
+         "x": [
           1565,
-          1565
+          1565,
+          1575,
+          1575
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.4,
-          0.4,
+          0.34065934065934067,
+          0.34065934065934067,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(35,205,205)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 28, component: QE_2017_001816_268.59351_445.0",
+          "cluster: 28, component: QE_2017_001816_268.59351_445.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e66356b2-2c93-439b-a186-be29656d1987",
          "x": [
-          1575,
-          1575,
-          1585,
-          1585
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.4339622641509434,
-          0.4339622641509434,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1560,
-          1560,
-          1580,
-          1580
-         ],
-         "xaxis": "x",
-         "y": [
-          0.4,
-          0.5407407407407407,
-          0.5407407407407407,
-          0.4339622641509434
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1545,
-          1545,
+          1555,
+          1555,
           1570,
           1570
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.5975609756097561,
-          0.5975609756097561,
-          0.5407407407407407
+          0.5294117647058824,
+          0.5294117647058824,
+          0.34065934065934067
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(35,205,205)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 29, component: QE_2017_001814_247.05975_245.0",
+          "cluster: 29, component: QE_2017_001814_247.05975_245.0",
+          "cluster: 29, component: QE_2017_001815_247.0598_242.0",
+          "cluster: 29, component: QE_2017_001815_247.0598_242.0"
+         ],
          "type": "scatter",
+         "uid": "d29dc5f1-0d56-490b-9361-903df3d9bcd8",
          "x": [
+          1585,
+          1585,
           1595,
-          1595,
+          1595
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.21428571428571427,
+          0.21428571428571427,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 29, component: QE_2017_001815_212.03883_181.0",
+          "cluster: 29, component: QE_2017_001815_212.03883_181.0",
+          "cluster: 29, component: QE_2017_001815_214.56488_409.0",
+          "cluster: 29, component: QE_2017_001815_214.56488_409.0"
+         ],
+         "type": "scatter",
+         "uid": "3f8f3820-6c99-43e2-977c-96fc82e37acc",
+         "x": [
+          1615,
+          1615,
+          1625,
+          1625
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.6363636363636364,
+          0.6363636363636364,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 29, component: QE_2017_001816_219.04672_291.0",
+          "cluster: 29, component: QE_2017_001816_219.04672_291.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f841a28a-7d1b-45c2-b862-6cd0138fcea7",
+         "x": [
           1605,
-          1605
+          1605,
+          1620,
+          1620
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.2926208651399491,
-          0.2926208651399491,
+          0.6842105263157895,
+          0.6842105263157895,
+          0.6363636363636364
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(61,153,112)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "bc6bf68c-0e57-4370-99cd-c694d43a3679",
+         "x": [
+          1590,
+          1590,
+          1612.5,
+          1612.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.21428571428571427,
+          0.75,
+          0.75,
+          0.6842105263157895
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f5378df4-c8fc-42d1-8d60-f55e9d7c7b2e",
+         "x": [
+          1562.5,
+          1562.5,
+          1601.25,
+          1601.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5294117647058824,
+          0.8481012658227848,
+          0.8481012658227848,
+          0.75
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 30, component: QE_2017_001815_214.51021_60.0",
+          "cluster: 30, component: QE_2017_001815_214.51021_60.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "382e2005-4a37-41ed-b3c8-b6beb403dc29",
+         "x": [
+          1545,
+          1545,
+          1581.875,
+          1581.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.9111111111111111,
+          0.9111111111111111,
+          0.8481012658227848
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 31, component: QE_2017_001815_246.14465_137.0",
+          "cluster: 31, component: QE_2017_001815_246.14465_137.0",
+          "cluster: 31, component: QE_2017_001815_247.12865_158.0",
+          "cluster: 31, component: QE_2017_001815_247.12865_158.0"
+         ],
+         "type": "scatter",
+         "uid": "ae95d35f-ab8a-43d6-b80e-fdd6ee59d4ad",
+         "x": [
+          1655,
+          1655,
+          1665,
+          1665
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.3333333333333333,
+          0.3333333333333333,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1635,
-          1635,
-          1645,
-          1645
+         "text": [
+          "cluster: 32, component: QE_2017_001814_260.16037_143.0",
+          "cluster: 32, component: QE_2017_001814_260.16037_143.0",
+          "cluster: 32, component: QE_2017_001816_260.16022_145.0",
+          "cluster: 32, component: QE_2017_001816_260.16022_145.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3217391304347826,
-          0.3217391304347826,
-          0
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "b5599c51-9293-40b3-a97c-84f03de62099",
          "x": [
-          1665,
-          1665,
           1675,
-          1675
+          1675,
+          1685,
+          1685
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.3032258064516129,
-          0.3032258064516129,
+          0.16666666666666666,
+          0.16666666666666666,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 32, component: QE_2017_001814_233.14948_126.0",
+          "cluster: 32, component: QE_2017_001814_233.14948_126.0",
+          "cluster: 32, component: QE_2017_001816_233.14955_129.0",
+          "cluster: 32, component: QE_2017_001816_233.14955_129.0"
+         ],
          "type": "scatter",
+         "uid": "75d5d4c0-8010-4b98-8e2b-f45d483859ee",
          "x": [
-          1655,
-          1655,
-          1670,
-          1670
+          1705,
+          1705,
+          1715,
+          1715
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.35766423357664234,
-          0.35766423357664234,
-          0.3032258064516129
+          0.15151515151515152,
+          0.15151515151515152,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1640,
-          1640,
-          1662.5,
-          1662.5
+         "text": [
+          "cluster: 32, component: QE_2017_001814_233.14957_152.0",
+          "cluster: 32, component: QE_2017_001814_233.14957_152.0",
+          null,
+          null
          ],
-         "xaxis": "x",
-         "y": [
-          0.3217391304347826,
-          0.4782608695652174,
-          0.4782608695652174,
-          0.35766423357664234
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "5f296de7-5e5e-414f-bfba-e108f92bb78a",
          "x": [
-          1625,
-          1625,
-          1651.25,
-          1651.25
+          1695,
+          1695,
+          1710,
+          1710
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.5053763440860215,
-          0.5053763440860215,
-          0.4782608695652174
+          0.37142857142857144,
+          0.37142857142857144,
+          0.15151515151515152
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(35,205,205)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e19c25c0-c811-4399-a1d6-93106ab2595c",
          "x": [
-          1615,
-          1615,
-          1638.125,
-          1638.125
+          1680,
+          1680,
+          1702.5,
+          1702.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.16666666666666666,
+          0.7619047619047619,
+          0.7619047619047619,
+          0.37142857142857144
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "89f9b0b5-11c5-4840-bc39-b731529d87c0",
+         "x": [
+          1660,
+          1660,
+          1691.25,
+          1691.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.3333333333333333,
+          0.9183673469387755,
+          0.9183673469387755,
+          0.7619047619047619
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 33, component: QE_2017_001816_132.04436_283.0",
+          "cluster: 33, component: QE_2017_001816_132.04436_283.0",
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "9599c775-6787-437f-91ac-ae8eaa19cb45",
+         "x": [
+          1645,
+          1645,
+          1675.625,
+          1675.625
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.5486725663716814,
-          0.5486725663716814,
-          0.5053763440860215
+          0.9607843137254902,
+          0.9607843137254902,
+          0.9183673469387755
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(35,205,205)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 34, component: QE_2017_001815_260.16016_64.0",
+          "cluster: 34, component: QE_2017_001815_260.16016_64.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "9ecd6f93-6b5c-43d1-a121-291fe3f5e8a3",
          "x": [
-          1600,
-          1600,
-          1626.5625,
-          1626.5625
+          1635,
+          1635,
+          1660.3125,
+          1660.3125
          ],
          "xaxis": "x",
          "y": [
-          0.2926208651399491,
-          0.6454849498327759,
-          0.6454849498327759,
-          0.5486725663716814
+          0,
+          0.9696969696969697,
+          0.9696969696969697,
+          0.9607843137254902
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(35,205,205)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1557.5,
-          1557.5,
-          1613.28125,
-          1613.28125
-         ],
-         "xaxis": "x",
-         "y": [
-          0.5975609756097561,
-          0.7912087912087912,
-          0.7912087912087912,
-          0.6454849498327759
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(133,20,75)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 35, component: QE_2017_001815_221.12837_99.0",
+          "cluster: 35, component: QE_2017_001815_221.12837_99.0",
+          "cluster: 35, component: QE_2017_001816_237.12325_171.0",
+          "cluster: 35, component: QE_2017_001816_237.12325_171.0"
+         ],
          "type": "scatter",
+         "uid": "63fcce9b-925d-49bc-85bf-2fb015faa9b2",
          "x": [
-          1715,
-          1715,
           1725,
-          1725
+          1725,
+          1735,
+          1735
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.40594059405940597,
-          0.40594059405940597,
+          0.5555555555555556,
+          0.5555555555555556,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(133,20,75)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 36, component: QE_2017_001814_237.12305_220.0",
+          "cluster: 36, component: QE_2017_001814_237.12305_220.0",
+          "cluster: 37, component: QE_2017_001816_237.12323_53.0",
+          "cluster: 37, component: QE_2017_001816_237.12323_53.0"
+         ],
          "type": "scatter",
-         "x": [
-          1705,
-          1705,
-          1720,
-          1720
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.42857142857142855,
-          0.42857142857142855,
-          0.40594059405940597
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1695,
-          1695,
-          1712.5,
-          1712.5
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.525,
-          0.525,
-          0.42857142857142855
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(133,20,75)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1685,
-          1685,
-          1703.75,
-          1703.75
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.6036036036036037,
-          0.6036036036036037,
-          0.525
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
+         "uid": "7f75f645-8796-41d9-a17a-b7e8d5c30cf3",
          "x": [
           1745,
           1745,
@@ -4022,20 +4948,55 @@
          "xaxis": "x",
          "y": [
           0,
-          0.3877551020408163,
-          0.3877551020408163,
+          0.8947368421052632,
+          0.8947368421052632,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "643b1673-8cf4-4ab4-9729-7b9dc188c7c0",
+         "x": [
+          1730,
+          1730,
+          1750,
+          1750
+         ],
+         "xaxis": "x",
+         "y": [
+          0.5555555555555556,
+          0.9534883720930233,
+          0.9534883720930233,
+          0.8947368421052632
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 38, component: QE_2017_001814_229.15399_46.0",
+          "cluster: 38, component: QE_2017_001814_229.15399_46.0",
+          "cluster: 38, component: QE_2017_001816_229.15451_66.0",
+          "cluster: 38, component: QE_2017_001816_229.15451_66.0"
+         ],
          "type": "scatter",
+         "uid": "7d382ab4-75f6-41d2-8357-c6244d1244ed",
          "x": [
           1775,
           1775,
@@ -4045,20 +5006,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2066115702479339,
-          0.2066115702479339,
+          0.23809523809523808,
+          0.23809523809523808,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(255,220,0)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 38, component: QE_2017_001816_229.15469_52.0",
+          "cluster: 38, component: QE_2017_001816_229.15469_52.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "42f205ef-9d56-481e-a1a8-3352c85c9bb1",
          "x": [
           1765,
           1765,
@@ -4068,20 +5035,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.3333333333333333,
-          0.3333333333333333,
-          0.2066115702479339
+          0.7777777777777778,
+          0.7777777777777778,
+          0.23809523809523808
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(40,35,35)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 39, component: QE_2017_001814_182.08116_51.0",
+          "cluster: 39, component: QE_2017_001814_182.08116_51.0",
+          "cluster: 39, component: QE_2017_001816_182.08116_55.0",
+          "cluster: 39, component: QE_2017_001816_182.08116_55.0"
+         ],
          "type": "scatter",
+         "uid": "c81193a3-0d50-4fe6-8c1b-a29807308759",
          "x": [
           1795,
           1795,
@@ -4091,20 +5064,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.12631578947368421,
-          0.12631578947368421,
+          0.28,
+          0.28,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(61,153,112)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 40, component: QE_2017_001815_194.04474_330.0",
+          "cluster: 40, component: QE_2017_001815_194.04474_330.0",
+          "cluster: 40, component: QE_2017_001816_212.05518_300.0",
+          "cluster: 40, component: QE_2017_001816_212.05518_300.0"
+         ],
          "type": "scatter",
+         "uid": "f684a936-5ed6-4296-a3af-cc5cea6fc465",
          "x": [
           1815,
           1815,
@@ -4114,20 +5093,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2647058823529412,
-          0.2647058823529412,
+          0.3670886075949367,
+          0.3670886075949367,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "e506e409-ab55-42a6-a1a5-e07f230ec1fc",
          "x": [
           1800,
           1800,
@@ -4136,90 +5121,114 @@
          ],
          "xaxis": "x",
          "y": [
-          0.12631578947368421,
-          0.36470588235294116,
-          0.36470588235294116,
-          0.2647058823529412
+          0.28,
+          0.855072463768116,
+          0.855072463768116,
+          0.3670886075949367
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 41, component: QE_2017_001814_177.05418_236.0",
+          "cluster: 41, component: QE_2017_001814_177.05418_236.0",
+          "cluster: 41, component: QE_2017_001815_177.05444_307.0",
+          "cluster: 41, component: QE_2017_001815_177.05444_307.0"
+         ],
          "type": "scatter",
+         "uid": "8cee954f-6aef-44e9-9d28-050cf14ef5d2",
          "x": [
-          1772.5,
-          1772.5,
-          1810,
-          1810
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3333333333333333,
-          0.48427672955974843,
-          0.48427672955974843,
-          0.36470588235294116
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1750,
-          1750,
-          1791.25,
-          1791.25
-         ],
-         "xaxis": "x",
-         "y": [
-          0.3877551020408163,
-          0.5614035087719298,
-          0.5614035087719298,
-          0.48427672955974843
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1735,
-          1735,
-          1770.625,
-          1770.625
+          1845,
+          1845,
+          1855,
+          1855
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.6346153846153846,
-          0.6346153846153846,
-          0.5614035087719298
+          0.21212121212121213,
+          0.21212121212121213,
+          0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 41, component: QE_2017_001816_177.05449_217.0",
+          "cluster: 41, component: QE_2017_001816_177.05449_217.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "da794c5c-0af5-42f7-b861-4ce9757c2535",
+         "x": [
+          1835,
+          1835,
+          1850,
+          1850
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.24324324324324326,
+          0.24324324324324326,
+          0.21212121212121213
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001816_199.98769_294.0",
+          "cluster: 41, component: QE_2017_001816_199.98769_294.0",
+          "cluster: 41, component: QE_2017_001816_199.98776_304.0",
+          "cluster: 41, component: QE_2017_001816_199.98776_304.0"
+         ],
+         "type": "scatter",
+         "uid": "9ca7910b-3b12-4f7a-8e29-95f23ba02912",
+         "x": [
+          1865,
+          1865,
+          1875,
+          1875
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          0.20588235294117646,
+          0.20588235294117646,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 41, component: QE_2017_001814_199.98778_290.0",
+          "cluster: 41, component: QE_2017_001814_199.98778_290.0",
+          "cluster: 41, component: QE_2017_001815_199.98779_30.0",
+          "cluster: 41, component: QE_2017_001815_199.98779_30.0"
+         ],
+         "type": "scatter",
+         "uid": "6970903c-d606-464e-a94d-9f727c7dbd1d",
          "x": [
           1885,
           1885,
@@ -4229,43 +5238,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.13978494623655913,
-          0.13978494623655913,
+          0.17647058823529413,
+          0.17647058823529413,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1875,
-          1875,
-          1890,
-          1890
+         "text": [
+          "cluster: 41, component: QE_2017_001815_199.98772_326.0",
+          "cluster: 41, component: QE_2017_001815_199.98772_326.0",
+          "cluster: 41, component: QE_2017_001816_199.98781_313.0",
+          "cluster: 41, component: QE_2017_001816_199.98781_313.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.15463917525773196,
-          0.15463917525773196,
-          0.13978494623655913
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "73a5a4de-dcda-4399-868d-60b7e8cc6284",
          "x": [
           1905,
           1905,
@@ -4275,112 +5267,200 @@
          "xaxis": "x",
          "y": [
           0,
-          0.15789473684210525,
-          0.15789473684210525,
+          0.1,
+          0.1,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1882.5,
-          1882.5,
-          1910,
-          1910
+         "text": [
+          "cluster: 41, component: QE_2017_001816_199.98776_254.0",
+          "cluster: 41, component: QE_2017_001816_199.98776_254.0",
+          "cluster: 41, component: QE_2017_001816_199.98779_335.0",
+          "cluster: 41, component: QE_2017_001816_199.98779_335.0"
          ],
-         "xaxis": "x",
-         "y": [
-          0.15463917525773196,
-          0.19230769230769232,
-          0.19230769230769232,
-          0.15789473684210525
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "47655968-4db7-4d3d-a70c-a5f1560a0d8b",
          "x": [
-          1925,
-          1925,
           1935,
-          1935
+          1935,
+          1945,
+          1945
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.21818181818181817,
-          0.21818181818181817,
+          0.14285714285714285,
+          0.14285714285714285,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1896.25,
-          1896.25,
-          1930,
-          1930
+         "text": [
+          "cluster: 41, component: QE_2017_001816_199.98772_359.0",
+          "cluster: 41, component: QE_2017_001816_199.98772_359.0",
+          null,
+          null
          ],
-         "xaxis": "x",
-         "y": [
-          0.19230769230769232,
-          0.24561403508771928,
-          0.24561403508771928,
-          0.21818181818181817
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
          "type": "scatter",
+         "uid": "988ece37-df7f-4850-a321-5f38c325a026",
          "x": [
-          1945,
-          1945,
-          1955,
-          1955
+          1925,
+          1925,
+          1940,
+          1940
          ],
          "xaxis": "x",
          "y": [
           0,
-          0.1504424778761062,
-          0.1504424778761062,
-          0
+          0.18518518518518517,
+          0.18518518518518517,
+          0.14285714285714285
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(255,65,54)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "8be8545f-34b1-4472-8289-25e592fe2f4a",
+         "x": [
+          1910,
+          1910,
+          1932.5,
+          1932.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.1,
+          0.2222222222222222,
+          0.2222222222222222,
+          0.18518518518518517
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4fc31c09-f677-4186-8044-59f81659ce81",
+         "x": [
+          1890,
+          1890,
+          1921.25,
+          1921.25
+         ],
+         "xaxis": "x",
+         "y": [
+          0.17647058823529413,
+          0.2692307692307692,
+          0.2692307692307692,
+          0.2222222222222222
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "73bb0171-dcbc-422b-a756-9f9697da4d87",
+         "x": [
+          1870,
+          1870,
+          1905.625,
+          1905.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.20588235294117646,
+          0.3103448275862069,
+          0.3103448275862069,
+          0.2692307692307692
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(255,65,54)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "100bc174-8198-4d46-bac4-600e40b9e763",
+         "x": [
+          1842.5,
+          1842.5,
+          1887.8125,
+          1887.8125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.24324324324324326,
+          0.696969696969697,
+          0.696969696969697,
+          0.3103448275862069
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(35,205,205)"
+         },
+         "mode": "lines",
+         "text": [
+          "cluster: 42, component: QE_2017_001815_463.12268_358.0",
+          "cluster: 42, component: QE_2017_001815_463.12268_358.0",
+          "cluster: 42, component: QE_2017_001815_625.17633_345.0",
+          "cluster: 42, component: QE_2017_001815_625.17633_345.0"
+         ],
+         "type": "scatter",
+         "uid": "b8919661-459a-4d17-bfd3-a332990ef2e0",
          "x": [
           1975,
           1975,
@@ -4390,20 +5470,26 @@
          "xaxis": "x",
          "y": [
           0,
-          0.16129032258064516,
-          0.16129032258064516,
+          0.5121951219512195,
+          0.5121951219512195,
           0
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 43, component: QE_2017_001815_595.16559_315.0",
+          "cluster: 43, component: QE_2017_001815_595.16559_315.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "fea3a998-fbc4-41d9-8be3-f358c20a9798",
          "x": [
           1965,
           1965,
@@ -4413,249 +5499,546 @@
          "xaxis": "x",
          "y": [
           0,
-          0.2222222222222222,
-          0.2222222222222222,
-          0.16129032258064516
+          0.8095238095238095,
+          0.8095238095238095,
+          0.5121951219512195
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
-          "color": "rgb(255,220,0)"
+          "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 44, component: QE_2017_001815_141.0508_33.0",
+          "cluster: 44, component: QE_2017_001815_141.0508_33.0",
+          "cluster: 45, component: QE_2017_001815_265.01532_33.0",
+          "cluster: 45, component: QE_2017_001815_265.01532_33.0"
+         ],
          "type": "scatter",
+         "uid": "67cc2f88-74ca-4d30-b24d-ea9302a7a005",
          "x": [
-          1950,
-          1950,
+          1995,
+          1995,
+          2005,
+          2005
+         ],
+         "xaxis": "x",
+         "y": [
+          0,
+          1,
+          1,
+          0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "3486d0f3-721b-491b-a460-ae1a58cd564c",
+         "x": [
           1972.5,
-          1972.5
+          1972.5,
+          2000,
+          2000
          ],
          "xaxis": "x",
          "y": [
-          0.1504424778761062,
-          0.26,
-          0.26,
-          0.2222222222222222
+          0.8095238095238095,
+          1,
+          1,
+          1
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1913.125,
-          1913.125,
-          1961.25,
-          1961.25
-         ],
-         "xaxis": "x",
-         "y": [
-          0.24561403508771928,
-          0.2830188679245283,
-          0.2830188679245283,
-          0.26
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1865,
-          1865,
-          1937.1875,
-          1937.1875
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3142857142857143,
-          0.3142857142857143,
-          0.2830188679245283
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1855,
-          1855,
-          1901.09375,
-          1901.09375
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.3786407766990291,
-          0.3786407766990291,
-          0.3142857142857143
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1845,
-          1845,
-          1878.046875,
-          1878.046875
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.4956521739130435,
-          0.4956521739130435,
-          0.3786407766990291
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1835,
-          1835,
-          1861.5234375,
-          1861.5234375
-         ],
-         "xaxis": "x",
-         "y": [
-          0,
-          0.635036496350365,
-          0.635036496350365,
-          0.4956521739130435
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
-         "marker": {
-          "color": "rgb(255,220,0)"
-         },
-         "mode": "lines",
-         "text": null,
-         "type": "scatter",
-         "x": [
-          1752.8125,
-          1752.8125,
-          1848.26171875,
-          1848.26171875
-         ],
-         "xaxis": "x",
-         "y": [
-          0.6346153846153846,
-          0.7281553398058253,
-          0.7281553398058253,
-          0.635036496350365
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          "cluster: 46, component: QE_2017_001815_797.51746_866.0",
+          "cluster: 46, component: QE_2017_001815_797.51746_866.0",
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "0082f047-ad8f-4371-9707-c9caf928051a",
          "x": [
-          1694.375,
-          1694.375,
-          1800.537109375,
-          1800.537109375
+          1955,
+          1955,
+          1986.25,
+          1986.25
          ],
          "xaxis": "x",
          "y": [
-          0.6036036036036037,
-          0.8117647058823529,
-          0.8117647058823529,
-          0.7281553398058253
+          0,
+          1,
+          1,
+          1
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "c9aef6f8-37e9-4d91-a81f-28ea00368963",
          "x": [
-          1585.390625,
-          1585.390625,
-          1747.4560546875,
-          1747.4560546875
+          1865.15625,
+          1865.15625,
+          1970.625,
+          1970.625
          ],
          "xaxis": "x",
          "y": [
-          0.7912087912087912,
-          0.9304347826086956,
-          0.9304347826086956,
-          0.8117647058823529
+          0.696969696969697,
+          1,
+          1,
+          1
          ],
          "yaxis": "y"
         },
         {
-         "hoverinfo": "all",
+         "hoverinfo": "text",
          "marker": {
           "color": "rgb(0,116,217)"
          },
          "mode": "lines",
-         "text": null,
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
          "type": "scatter",
+         "uid": "360a731d-bf72-4730-abb8-5996b6306e89",
          "x": [
-          833.6627197265625,
-          833.6627197265625,
-          1666.42333984375,
-          1666.42333984375
+          1810,
+          1810,
+          1917.890625,
+          1917.890625
          ],
          "xaxis": "x",
          "y": [
-          0.8205128205128205,
-          0.9885057471264368,
-          0.9885057471264368,
-          0.9304347826086956
+          0.855072463768116,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "0f86a6f0-8681-48d7-9351-deec1db28854",
+         "x": [
+          1772.5,
+          1772.5,
+          1863.9453125,
+          1863.9453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7777777777777778,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "7a68b823-9171-498e-8227-8c709513ae5f",
+         "x": [
+          1740,
+          1740,
+          1818.22265625,
+          1818.22265625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9534883720930233,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c8c17d1d-2ac0-4192-ab66-f5d65d6e8ff2",
+         "x": [
+          1647.65625,
+          1647.65625,
+          1779.111328125,
+          1779.111328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9696969696969697,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "4efbedea-ae7f-487d-b17f-6f6bcceaa963",
+         "x": [
+          1563.4375,
+          1563.4375,
+          1713.3837890625,
+          1713.3837890625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9111111111111111,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "2ed6a34d-eec5-4b01-b076-0280551b98b6",
+         "x": [
+          1467.8125,
+          1467.8125,
+          1638.41064453125,
+          1638.41064453125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.978494623655914,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "f263f14c-8a9d-4118-a77b-3166c2dcea13",
+         "x": [
+          1410,
+          1410,
+          1553.111572265625,
+          1553.111572265625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.6,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "59dadcf2-ac1e-4099-b2f3-476126a3480b",
+         "x": [
+          1336.71875,
+          1336.71875,
+          1481.5557861328125,
+          1481.5557861328125
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9555555555555556,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "22a14fe5-eaf9-496c-9e26-9abff40dd64b",
+         "x": [
+          1270,
+          1270,
+          1409.1372680664062,
+          1409.1372680664062
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7333333333333333,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "142174a8-3608-49e1-82fe-7e2474579925",
+         "x": [
+          1020.869140625,
+          1020.869140625,
+          1339.5686340332031,
+          1339.5686340332031
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9767441860465116,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "c65d7ae0-b68d-4066-ade0-1982e19d6c07",
+         "x": [
+          734.912109375,
+          734.912109375,
+          1180.2188873291016,
+          1180.2188873291016
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9411764705882353,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e2f76cb9-dbb7-469a-8c4b-9cf25325f723",
+         "x": [
+          619.6875,
+          619.6875,
+          957.5654983520508,
+          957.5654983520508
+         ],
+         "xaxis": "x",
+         "y": [
+          0.9636363636363636,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "e6ac6b28-d0b2-4a40-8bea-1896ac167c70",
+         "x": [
+          521.875,
+          521.875,
+          788.6264991760254,
+          788.6264991760254
+         ],
+         "xaxis": "x",
+         "y": [
+          0.971830985915493,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "text",
+         "marker": {
+          "color": "rgb(0,116,217)"
+         },
+         "mode": "lines",
+         "text": [
+          null,
+          null,
+          null,
+          null
+         ],
+         "type": "scatter",
+         "uid": "ccb09164-34b2-4b06-afae-e61085b2e529",
+         "x": [
+          221.85302734375,
+          221.85302734375,
+          655.2507495880127,
+          655.2507495880127
+         ],
+         "xaxis": "x",
+         "y": [
+          0.927710843373494,
+          1,
+          1,
+          1
          ],
          "yaxis": "y"
         }
        ],
        "layout": {
         "autosize": false,
-        "height": 500,
+        "height": 800,
         "hovermode": "closest",
+        "margin": {
+         "b": 372
+        },
         "showlegend": false,
-        "title": "BioDendro",
+        "title": {
+         "text": "Component clusters. method = braycurtis, cutoff = 0.8, threshold = 0.0008"
+        },
         "width": 900,
         "xaxis": {
          "mirror": "allticks",
@@ -4666,193 +6049,15 @@
          "tickmode": "array",
          "ticks": "outside",
          "ticktext": [
-          "QE_2017_001814_209.08058_363.0",
-          "QE_2017_001816_207.13779_561.0",
-          "QE_2017_001815_201.16367_442.0",
-          "QE_2017_001816_201.16362_435.0",
-          "QE_2017_001816_137.09584_445.0",
-          "QE_2017_001814_191.14291_389.0",
-          "QE_2017_001815_191.14287_312.0",
-          "QE_2017_001816_191.14291_404.0",
-          "QE_2017_001815_181.1221_767.0",
-          "QE_2017_001816_181.12199_794.0",
-          "QE_2017_001814_227.1275_293.0",
-          "QE_2017_001816_227.12766_295.0",
-          "QE_2017_001814_209.15335_478.0",
-          "QE_2017_001815_209.1535_312.0",
-          "QE_2017_001816_209.15344_311.0",
-          "QE_2017_001815_227.16408_344.0",
-          "QE_2017_001816_209.15341_296.0",
-          "QE_2017_001814_293.2106_579.0",
-          "QE_2017_001815_283.19009_564.0",
-          "QE_2017_001814_219.17416_517.0",
-          "QE_2017_001815_219.17426_497.0",
-          "QE_2017_001814_219.17401_452.0",
-          "QE_2017_001814_219.17409_442.0",
-          "QE_2017_001816_211.16916_405.0",
-          "QE_2017_001815_209.0807_405.0",
-          "QE_2017_001814_211.16902_440.0",
-          "QE_2017_001815_211.16913_450.0",
-          "QE_2017_001814_215.16406_483.0",
-          "QE_2017_001815_215.164_550.0",
-          "QE_2017_001815_207.13785_297.0",
-          "QE_2017_001814_243.15892_533.0",
-          "QE_2017_001814_281.1745_492.0",
-          "QE_2017_001816_268.59351_445.0",
-          "QE_2017_001814_222.07031_314.0",
-          "QE_2017_001814_250.10149_516.0",
-          "QE_2017_001815_214.51021_60.0",
-          "QE_2017_001814_247.05975_245.0",
-          "QE_2017_001815_247.0598_242.0",
-          "QE_2017_001816_219.04672_291.0",
-          "QE_2017_001815_212.03883_181.0",
-          "QE_2017_001815_214.56488_409.0",
-          "QE_2017_001816_132.04436_283.0",
-          "QE_2017_001814_194.1174_244.0",
-          "QE_2017_001815_194.11745_132.0",
-          "QE_2017_001814_194.04424_237.0",
-          "QE_2017_001814_194.1174_217.0",
-          "QE_2017_001816_229.15469_52.0",
-          "QE_2017_001814_229.15399_46.0",
-          "QE_2017_001814_229.15451_65.0",
-          "QE_2017_001815_246.14465_137.0",
-          "QE_2017_001816_247.12863_162.0",
-          "QE_2017_001815_260.16016_140.0",
-          "QE_2017_001816_260.16022_145.0",
-          "QE_2017_001815_233.14944_150.0",
-          "QE_2017_001814_233.14948_126.0",
-          "QE_2017_001816_233.14955_129.0",
-          "QE_2017_001815_194.04469_299.0",
-          "QE_2017_001815_194.04474_327.0",
-          "QE_2017_001816_212.05518_300.0",
-          "QE_2017_001815_194.04471_314.0",
-          "QE_2017_001815_212.05513_328.0",
-          "QE_2017_001815_194.04471_397.0",
-          "QE_2017_001814_226.07077_397.0",
-          "QE_2017_001815_212.05505_267.0",
-          "QE_2017_001815_182.08109_52.0",
-          "QE_2017_001816_199.98772_359.0",
-          "QE_2017_001814_199.98772_303.0",
-          "QE_2017_001815_199.98772_253.0",
-          "QE_2017_001815_199.98779_30.0",
-          "QE_2017_001816_199.98779_335.0",
-          "QE_2017_001816_199.98769_294.0",
-          "QE_2017_001814_199.98778_290.0",
-          "QE_2017_001815_199.98772_326.0",
-          "QE_2017_001816_199.98781_313.0",
-          "QE_2017_001816_177.05449_217.0",
-          "QE_2017_001814_177.05418_236.0",
-          "QE_2017_001815_177.05444_307.0",
-          "QE_2017_001815_260.16016_64.0",
-          "QE_2017_001815_595.16559_315.0",
-          "QE_2017_001815_463.12268_358.0",
-          "QE_2017_001815_625.17633_345.0",
-          "QE_2017_001815_265.01532_33.0",
-          "QE_2017_001815_141.0508_33.0",
-          "QE_2017_001815_797.51746_866.0",
-          "QE_2017_001814_237.12305_220.0",
-          "QE_2017_001815_237.12315_52.0",
-          "QE_2017_001814_251.09117_393.0",
-          "QE_2017_001815_219.10139_360.0",
-          "QE_2017_001815_219.10146_381.0",
-          "QE_2017_001815_219.10159_438.0",
-          "QE_2017_001814_171.14908_419.0",
-          "QE_2017_001814_483.27118_651.0",
-          "QE_2017_001814_129.12737_348.0",
-          "QE_2017_001816_338.26062_643.0",
-          "QE_2017_001814_320.29456_577.0",
-          "QE_2017_001815_320.29471_563.0",
-          "QE_2017_001816_320.29483_548.0",
-          "QE_2017_001815_332.25827_508.0",
-          "QE_2017_001814_332.25842_486.0",
-          "QE_2017_001816_332.25842_487.0",
-          "QE_2017_001815_273.13425_199.0",
-          "QE_2017_001815_273.13434_243.0",
-          "QE_2017_001816_291.14499_200.0",
-          "QE_2017_001814_291.1442_241.0",
-          "QE_2017_001815_291.14493_242.0",
-          "QE_2017_001814_251.13872_201.0",
-          "QE_2017_001815_235.14388_180.0",
-          "QE_2017_001815_235.14398_226.0",
-          "QE_2017_001815_319.13623_118.0",
-          "QE_2017_001816_319.13614_143.0",
-          "QE_2017_001814_320.29468_638.0",
-          "QE_2017_001814_320.29471_529.0",
-          "QE_2017_001814_320.29477_539.0",
-          "QE_2017_001815_221.12837_99.0",
-          "QE_2017_001816_237.12325_171.0",
-          "QE_2017_001814_241.15446_57.0",
-          "QE_2017_001814_241.15384_47.0",
-          "QE_2017_001815_241.15437_67.0",
-          "QE_2017_001814_332.25827_467.0",
-          "QE_2017_001815_333.15173_245.0",
-          "QE_2017_001816_333.15204_235.0",
-          "QE_2017_001814_347.09097_122.0",
-          "QE_2017_001815_347.09067_204.0",
-          "QE_2017_001816_533.15442_247.0",
-          "QE_2017_001816_533.15466_222.0",
-          "QE_2017_001815_533.1546_207.0",
-          "QE_2017_001816_533.1546_271.0",
-          "QE_2017_001815_268.10373_58.0",
-          "QE_2017_001816_269.16055_60.0",
-          "QE_2017_001814_364.34241_751.0",
-          "QE_2017_001814_424.36325_711.0",
-          "QE_2017_001814_364.34244_761.0",
-          "QE_2017_001814_421.35211_732.0",
-          "QE_2017_001815_364.34189_705.0",
-          "QE_2017_001814_408.3681_703.0",
-          "QE_2017_001816_466.40979_731.0",
-          "QE_2017_001815_408.36853_717.0",
-          "QE_2017_001815_482.40488_739.0",
-          "QE_2017_001815_507.18192_178.0",
-          "QE_2017_001816_463.12311_410.0",
-          "QE_2017_001814_611.15997_285.0",
-          "QE_2017_001816_611.16064_309.0",
-          "QE_2017_001814_339.10742_366.0",
-          "QE_2017_001816_339.10733_298.0",
-          "QE_2017_001814_231.04967_404.0",
-          "QE_2017_001815_231.04968_315.0",
-          "QE_2017_001814_231.04971_516.0",
-          "QE_2017_001815_231.04971_369.0",
-          "QE_2017_001815_314.14453_76.0",
-          "QE_2017_001816_314.14462_79.0",
-          "QE_2017_001816_310.14957_134.0",
-          "QE_2017_001816_342.17584_257.0",
-          "QE_2017_001814_498.2543_475.0",
-          "QE_2017_001815_340.16019_314.0",
-          "QE_2017_001814_618.42633_695.0",
-          "QE_2017_001814_601.42426_706.0",
-          "QE_2017_001816_583.41382_731.0",
-          "QE_2017_001814_599.40918_659.0",
-          "QE_2017_001816_599.40869_793.0",
-          "QE_2017_001815_618.42773_646.0",
-          "QE_2017_001816_618.427_682.0",
-          "QE_2017_001815_568.42627_841.0",
-          "QE_2017_001814_601.42334_783.0",
-          "QE_2017_001815_583.41388_735.0",
-          "QE_2017_001815_583.41418_647.0",
-          "QE_2017_001814_565.4035_722.0",
-          "QE_2017_001814_583.41406_682.0",
-          "QE_2017_001815_583.41406_707.0",
-          "QE_2017_001815_792.5625_866.0",
-          "QE_2017_001814_596.30963_602.0",
+          "QE_2017_001816_613.4826_738.0",
           "QE_2017_001816_613.48218_838.0",
-          "QE_2017_001814_792.56207_723.0",
-          "QE_2017_001815_613.4826_734.0",
-          "QE_2017_001816_272.25824_582.0",
-          "QE_2017_001814_338.34146_850.0",
-          "QE_2017_001815_244.19048_762.0",
-          "QE_2017_001816_435.25037_666.0",
-          "QE_2017_001816_337.27338_826.0",
-          "QE_2017_001816_337.27341_632.0",
-          "QE_2017_001814_353.26868_633.0",
-          "QE_2017_001816_353.26892_600.0",
-          "QE_2017_001814_278.24756_683.0",
-          "QE_2017_001814_279.23157_719.0",
+          "QE_2017_001816_792.56232_718.0",
+          "QE_2017_001814_596.30963_602.0",
+          "QE_2017_001815_792.5625_866.0",
           "QE_2017_001815_571.4292_870.0",
           "QE_2017_001814_497.31033_643.0",
           "QE_2017_001815_507.27145_607.0",
-          "QE_2017_001815_571.47168_711.0",
+          "QE_2017_001816_571.47186_717.0",
           "QE_2017_001814_335.25772_725.0",
           "QE_2017_001814_335.25784_608.0",
           "QE_2017_001816_335.25772_723.0",
@@ -4864,7 +6069,187 @@
           "QE_2017_001815_353.26862_642.0",
           "QE_2017_001815_261.22073_643.0",
           "QE_2017_001814_335.25772_638.0",
-          "QE_2017_001815_335.2579_601.0"
+          "QE_2017_001815_335.2579_601.0",
+          "QE_2017_001816_272.25824_582.0",
+          "QE_2017_001814_338.34146_850.0",
+          "QE_2017_001815_244.19048_762.0",
+          "QE_2017_001814_353.26868_633.0",
+          "QE_2017_001816_353.26892_600.0",
+          "QE_2017_001814_279.23157_719.0",
+          "QE_2017_001815_278.24762_684.0",
+          "QE_2017_001816_435.25037_666.0",
+          "QE_2017_001816_337.27338_826.0",
+          "QE_2017_001816_337.27341_632.0",
+          "QE_2017_001814_618.42633_695.0",
+          "QE_2017_001816_583.41382_731.0",
+          "QE_2017_001816_599.40948_660.0",
+          "QE_2017_001814_601.42426_706.0",
+          "QE_2017_001816_599.40869_793.0",
+          "QE_2017_001815_618.42773_646.0",
+          "QE_2017_001816_618.427_682.0",
+          "QE_2017_001815_568.42627_841.0",
+          "QE_2017_001814_565.4035_722.0",
+          "QE_2017_001814_583.41406_682.0",
+          "QE_2017_001815_583.41406_707.0",
+          "QE_2017_001814_601.42334_783.0",
+          "QE_2017_001815_583.41388_735.0",
+          "QE_2017_001815_583.41418_647.0",
+          "QE_2017_001814_194.04424_237.0",
+          "QE_2017_001815_194.11751_218.0",
+          "QE_2017_001815_194.04469_299.0",
+          "QE_2017_001815_194.04471_314.0",
+          "QE_2017_001815_212.05513_328.0",
+          "QE_2017_001815_212.05505_267.0",
+          "QE_2017_001814_226.07077_397.0",
+          "QE_2017_001815_194.04471_397.0",
+          "QE_2017_001816_533.15442_247.0",
+          "QE_2017_001816_533.15466_222.0",
+          "QE_2017_001815_533.1546_207.0",
+          "QE_2017_001816_533.1546_271.0",
+          "QE_2017_001814_347.09097_122.0",
+          "QE_2017_001815_347.09067_204.0",
+          "QE_2017_001815_268.10373_58.0",
+          "QE_2017_001816_269.16055_60.0",
+          "QE_2017_001815_364.34189_705.0",
+          "QE_2017_001816_408.36832_704.0",
+          "QE_2017_001816_466.40979_731.0",
+          "QE_2017_001815_408.36853_717.0",
+          "QE_2017_001815_482.40488_739.0",
+          "QE_2017_001814_364.34244_761.0",
+          "QE_2017_001815_364.34253_752.0",
+          "QE_2017_001816_421.35226_731.0",
+          "QE_2017_001816_424.36325_712.0",
+          "QE_2017_001816_463.12311_410.0",
+          "QE_2017_001814_611.15997_285.0",
+          "QE_2017_001815_611.16046_309.0",
+          "QE_2017_001814_339.10742_366.0",
+          "QE_2017_001816_339.10733_298.0",
+          "QE_2017_001814_498.2543_475.0",
+          "QE_2017_001815_340.16019_314.0",
+          "QE_2017_001815_231.04973_403.0",
+          "QE_2017_001815_231.04968_315.0",
+          "QE_2017_001814_231.04971_516.0",
+          "QE_2017_001815_231.04971_369.0",
+          "QE_2017_001815_314.14453_76.0",
+          "QE_2017_001816_314.14462_79.0",
+          "QE_2017_001816_310.14957_134.0",
+          "QE_2017_001816_342.17584_257.0",
+          "QE_2017_001814_241.15466_73.0",
+          "QE_2017_001815_507.18192_178.0",
+          "QE_2017_001814_483.27118_651.0",
+          "QE_2017_001816_338.26062_643.0",
+          "QE_2017_001814_320.29456_577.0",
+          "QE_2017_001815_320.29471_563.0",
+          "QE_2017_001815_129.12741_349.0",
+          "QE_2017_001815_171.14914_420.0",
+          "QE_2017_001815_201.16367_442.0",
+          "QE_2017_001816_201.16362_435.0",
+          "QE_2017_001815_209.15352_479.0",
+          "QE_2017_001815_209.15349_295.0",
+          "QE_2017_001815_209.1535_312.0",
+          "QE_2017_001816_209.15344_311.0",
+          "QE_2017_001814_243.15892_533.0",
+          "QE_2017_001814_281.1745_492.0",
+          "QE_2017_001814_293.2106_579.0",
+          "QE_2017_001815_227.16408_344.0",
+          "QE_2017_001815_283.19009_564.0",
+          "QE_2017_001815_207.13785_297.0",
+          "QE_2017_001814_227.1275_293.0",
+          "QE_2017_001816_227.12766_295.0",
+          "QE_2017_001815_181.1221_767.0",
+          "QE_2017_001816_181.12199_794.0",
+          "QE_2017_001816_211.16916_405.0",
+          "QE_2017_001815_209.0807_405.0",
+          "QE_2017_001814_211.16902_440.0",
+          "QE_2017_001815_211.16913_450.0",
+          "QE_2017_001815_215.164_550.0",
+          "QE_2017_001816_215.16411_482.0",
+          "QE_2017_001816_137.09584_445.0",
+          "QE_2017_001814_219.17416_517.0",
+          "QE_2017_001815_219.17421_516.0",
+          "QE_2017_001816_219.17438_502.0",
+          "QE_2017_001814_219.17401_452.0",
+          "QE_2017_001814_219.17409_442.0",
+          "QE_2017_001814_191.14291_389.0",
+          "QE_2017_001815_191.14287_312.0",
+          "QE_2017_001816_191.14291_404.0",
+          "QE_2017_001814_209.08058_363.0",
+          "QE_2017_001816_207.13779_561.0",
+          "QE_2017_001815_333.15173_245.0",
+          "QE_2017_001816_333.15204_235.0",
+          "QE_2017_001814_194.1174_244.0",
+          "QE_2017_001816_194.11746_133.0",
+          "QE_2017_001816_320.29483_548.0",
+          "QE_2017_001814_320.29468_638.0",
+          "QE_2017_001814_320.29477_539.0",
+          "QE_2017_001814_320.29471_529.0",
+          "QE_2017_001815_320.29486_538.0",
+          "QE_2017_001814_241.15384_47.0",
+          "QE_2017_001814_241.15446_57.0",
+          "QE_2017_001814_332.25827_467.0",
+          "QE_2017_001815_332.25827_508.0",
+          "QE_2017_001816_332.25842_487.0",
+          "QE_2017_001814_319.13638_117.0",
+          "QE_2017_001816_319.13614_143.0",
+          "QE_2017_001814_251.09117_393.0",
+          "QE_2017_001815_219.10159_438.0",
+          "QE_2017_001815_219.10139_360.0",
+          "QE_2017_001816_219.10153_382.0",
+          "QE_2017_001814_291.1442_241.0",
+          "QE_2017_001816_291.14493_243.0",
+          "QE_2017_001816_291.14499_200.0",
+          "QE_2017_001815_273.13425_199.0",
+          "QE_2017_001815_273.13434_243.0",
+          "QE_2017_001815_251.13873_202.0",
+          "QE_2017_001815_235.14398_226.0",
+          "QE_2017_001816_235.14397_183.0",
+          "QE_2017_001815_214.51021_60.0",
+          "QE_2017_001816_268.59351_445.0",
+          "QE_2017_001814_250.10149_516.0",
+          "QE_2017_001815_222.07033_315.0",
+          "QE_2017_001814_247.05975_245.0",
+          "QE_2017_001815_247.0598_242.0",
+          "QE_2017_001816_219.04672_291.0",
+          "QE_2017_001815_212.03883_181.0",
+          "QE_2017_001815_214.56488_409.0",
+          "QE_2017_001815_260.16016_64.0",
+          "QE_2017_001816_132.04436_283.0",
+          "QE_2017_001815_246.14465_137.0",
+          "QE_2017_001815_247.12865_158.0",
+          "QE_2017_001814_260.16037_143.0",
+          "QE_2017_001816_260.16022_145.0",
+          "QE_2017_001814_233.14957_152.0",
+          "QE_2017_001814_233.14948_126.0",
+          "QE_2017_001816_233.14955_129.0",
+          "QE_2017_001815_221.12837_99.0",
+          "QE_2017_001816_237.12325_171.0",
+          "QE_2017_001814_237.12305_220.0",
+          "QE_2017_001816_237.12323_53.0",
+          "QE_2017_001816_229.15469_52.0",
+          "QE_2017_001814_229.15399_46.0",
+          "QE_2017_001816_229.15451_66.0",
+          "QE_2017_001814_182.08116_51.0",
+          "QE_2017_001816_182.08116_55.0",
+          "QE_2017_001815_194.04474_330.0",
+          "QE_2017_001816_212.05518_300.0",
+          "QE_2017_001816_177.05449_217.0",
+          "QE_2017_001814_177.05418_236.0",
+          "QE_2017_001815_177.05444_307.0",
+          "QE_2017_001816_199.98769_294.0",
+          "QE_2017_001816_199.98776_304.0",
+          "QE_2017_001814_199.98778_290.0",
+          "QE_2017_001815_199.98779_30.0",
+          "QE_2017_001815_199.98772_326.0",
+          "QE_2017_001816_199.98781_313.0",
+          "QE_2017_001816_199.98772_359.0",
+          "QE_2017_001816_199.98776_254.0",
+          "QE_2017_001816_199.98779_335.0",
+          "QE_2017_001815_797.51746_866.0",
+          "QE_2017_001815_595.16559_315.0",
+          "QE_2017_001815_463.12268_358.0",
+          "QE_2017_001815_625.17633_345.0",
+          "QE_2017_001815_141.0508_33.0",
+          "QE_2017_001815_265.01532_33.0"
          ],
          "tickvals": [
           5,
@@ -5065,9 +6450,13 @@
           1955,
           1965,
           1975,
-          1985
+          1985,
+          1995,
+          2005
          ],
-         "title": "sample",
+         "title": {
+          "text": "Components"
+         },
          "type": "linear",
          "zeroline": false
         },
@@ -5078,17 +6467,35 @@
          "showline": true,
          "showticklabels": true,
          "ticks": "outside",
-         "title": "distance",
+         "title": {
+          "text": "Distance"
+         },
          "type": "linear",
          "zeroline": false
         }
        }
       },
       "text/html": [
-       "<div id=\"55249d27-5d02-4667-98e0-721ba98f2a91\" style=\"height: 500px; width: 900px;\" class=\"plotly-graph-div\"></div><script type=\"text/javascript\">require([\"plotly\"], function(Plotly) { window.PLOTLYENV=window.PLOTLYENV || {};window.PLOTLYENV.BASE_URL=\"https://plot.ly\";Plotly.newPlot(\"55249d27-5d02-4667-98e0-721ba98f2a91\", [{\"type\": \"scatter\", \"x\": [5.0, 5.0, 15.0, 15.0], \"y\": [0.0, 0.4827586206896552, 0.4827586206896552, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [25.0, 25.0, 35.0, 35.0], \"y\": [0.0, 0.20279720279720279, 0.20279720279720279, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [65.0, 65.0, 75.0, 75.0], \"y\": [0.0, 0.1724137931034483, 0.1724137931034483, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [55.0, 55.0, 70.0, 70.0], \"y\": [0.0, 0.2, 0.2, 0.1724137931034483], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [45.0, 45.0, 62.5, 62.5], \"y\": [0.0, 0.30578512396694213, 0.30578512396694213, 0.2], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [85.0, 85.0, 95.0, 95.0], \"y\": [0.0, 0.0847457627118644, 0.0847457627118644, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [105.0, 105.0, 115.0, 115.0], \"y\": [0.0, 0.13609467455621302, 0.13609467455621302, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [90.0, 90.0, 110.0, 110.0], \"y\": [0.0847457627118644, 0.3246753246753247, 0.3246753246753247, 0.13609467455621302], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [53.75, 53.75, 100.0, 100.0], \"y\": [0.30578512396694213, 0.3793103448275862, 0.3793103448275862, 0.3246753246753247], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [135.0, 135.0, 145.0, 145.0], \"y\": [0.0, 0.11731843575418995, 0.11731843575418995, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [125.0, 125.0, 140.0, 140.0], \"y\": [0.0, 0.17045454545454544, 0.17045454545454544, 0.11731843575418995], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [155.0, 155.0, 165.0, 165.0], \"y\": [0.0, 0.20454545454545456, 0.20454545454545456, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [132.5, 132.5, 160.0, 160.0], \"y\": [0.17045454545454544, 0.24022346368715083, 0.24022346368715083, 0.20454545454545456], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [175.0, 175.0, 185.0, 185.0], \"y\": [0.0, 0.27, 0.27, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [146.25, 146.25, 180.0, 180.0], \"y\": [0.24022346368715083, 0.33689839572192515, 0.33689839572192515, 0.27], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [215.0, 215.0, 225.0, 225.0], \"y\": [0.0, 0.1111111111111111, 0.1111111111111111, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [205.0, 205.0, 220.0, 220.0], \"y\": [0.0, 0.14864864864864866, 0.14864864864864866, 0.1111111111111111], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [195.0, 195.0, 212.5, 212.5], \"y\": [0.0, 0.20588235294117646, 0.20588235294117646, 0.14864864864864866], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [255.0, 255.0, 265.0, 265.0], \"y\": [0.0, 0.06578947368421052, 0.06578947368421052, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [245.0, 245.0, 260.0, 260.0], \"y\": [0.0, 0.0728476821192053, 0.0728476821192053, 0.06578947368421052], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [235.0, 235.0, 252.5, 252.5], \"y\": [0.0, 0.1125, 0.1125, 0.0728476821192053], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [275.0, 275.0, 285.0, 285.0], \"y\": [0.0, 0.20930232558139536, 0.20930232558139536, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [243.75, 243.75, 280.0, 280.0], \"y\": [0.1125, 0.2484076433121019, 0.2484076433121019, 0.20930232558139536], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [305.0, 305.0, 315.0, 315.0], \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [295.0, 295.0, 310.0, 310.0], \"y\": [0.0, 0.2875, 0.2875, 0.14285714285714285], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [261.875, 261.875, 302.5, 302.5], \"y\": [0.2484076433121019, 0.3383458646616541, 0.3383458646616541, 0.2875], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [203.75, 203.75, 282.1875, 282.1875], \"y\": [0.20588235294117646, 0.34285714285714286, 0.34285714285714286, 0.3383458646616541], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [163.125, 163.125, 242.96875, 242.96875], \"y\": [0.33689839572192515, 0.38562091503267976, 0.38562091503267976, 0.34285714285714286], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [76.875, 76.875, 203.046875, 203.046875], \"y\": [0.3793103448275862, 0.44516129032258067, 0.44516129032258067, 0.38562091503267976], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [30.0, 30.0, 139.9609375, 139.9609375], \"y\": [0.20279720279720279, 0.5, 0.5, 0.44516129032258067], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [10.0, 10.0, 84.98046875, 84.98046875], \"y\": [0.4827586206896552, 0.5789473684210527, 0.5789473684210527, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [335.0, 335.0, 345.0, 345.0], \"y\": [0.0, 0.15270935960591134, 0.15270935960591134, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [325.0, 325.0, 340.0, 340.0], \"y\": [0.0, 0.308411214953271, 0.308411214953271, 0.15270935960591134], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [365.0, 365.0, 375.0, 375.0], \"y\": [0.0, 0.075, 0.075, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [395.0, 395.0, 405.0, 405.0], \"y\": [0.0, 0.15714285714285714, 0.15714285714285714, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [385.0, 385.0, 400.0, 400.0], \"y\": [0.0, 0.1836734693877551, 0.1836734693877551, 0.15714285714285714], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [370.0, 370.0, 392.5, 392.5], \"y\": [0.075, 0.25161290322580643, 0.25161290322580643, 0.1836734693877551], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [425.0, 425.0, 435.0, 435.0], \"y\": [0.0, 0.08860759493670886, 0.08860759493670886, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [445.0, 445.0, 455.0, 455.0], \"y\": [0.0, 0.10714285714285714, 0.10714285714285714, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [430.0, 430.0, 450.0, 450.0], \"y\": [0.08860759493670886, 0.17647058823529413, 0.17647058823529413, 0.10714285714285714], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [475.0, 475.0, 485.0, 485.0], \"y\": [0.0, 0.03225806451612903, 0.03225806451612903, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [465.0, 465.0, 480.0, 480.0], \"y\": [0.0, 0.18238993710691823, 0.18238993710691823, 0.03225806451612903], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [440.0, 440.0, 472.5, 472.5], \"y\": [0.17647058823529413, 0.26627218934911245, 0.26627218934911245, 0.18238993710691823], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [415.0, 415.0, 456.25, 456.25], \"y\": [0.0, 0.27710843373493976, 0.27710843373493976, 0.26627218934911245], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [495.0, 495.0, 505.0, 505.0], \"y\": [0.0, 0.0975609756097561, 0.0975609756097561, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [515.0, 515.0, 525.0, 525.0], \"y\": [0.0, 0.04938271604938271, 0.04938271604938271, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [545.0, 545.0, 555.0, 555.0], \"y\": [0.0, 0.033112582781456956, 0.033112582781456956, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [535.0, 535.0, 550.0, 550.0], \"y\": [0.0, 0.0641025641025641, 0.0641025641025641, 0.033112582781456956], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [520.0, 520.0, 542.5, 542.5], \"y\": [0.04938271604938271, 0.2125, 0.2125, 0.0641025641025641], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [500.0, 500.0, 531.25, 531.25], \"y\": [0.0975609756097561, 0.2891566265060241, 0.2891566265060241, 0.2125], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [435.625, 435.625, 515.625, 515.625], \"y\": [0.27710843373493976, 0.3372093023255814, 0.3372093023255814, 0.2891566265060241], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [381.25, 381.25, 475.625, 475.625], \"y\": [0.25161290322580643, 0.36904761904761907, 0.36904761904761907, 0.3372093023255814], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [355.0, 355.0, 428.4375, 428.4375], \"y\": [0.0, 0.3879781420765027, 0.3879781420765027, 0.36904761904761907], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [565.0, 565.0, 575.0, 575.0], \"y\": [0.0, 0.08016877637130802, 0.08016877637130802, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [595.0, 595.0, 605.0, 605.0], \"y\": [0.0, 0.06806282722513089, 0.06806282722513089, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [625.0, 625.0, 635.0, 635.0], \"y\": [0.0, 0.1111111111111111, 0.1111111111111111, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [615.0, 615.0, 630.0, 630.0], \"y\": [0.0, 0.12280701754385964, 0.12280701754385964, 0.1111111111111111], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [600.0, 600.0, 622.5, 622.5], \"y\": [0.06806282722513089, 0.14606741573033707, 0.14606741573033707, 0.12280701754385964], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [585.0, 585.0, 611.25, 611.25], \"y\": [0.0, 0.2205128205128205, 0.2205128205128205, 0.14606741573033707], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [570.0, 570.0, 598.125, 598.125], \"y\": [0.08016877637130802, 0.3059360730593607, 0.3059360730593607, 0.2205128205128205], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [685.0, 685.0, 695.0, 695.0], \"y\": [0.0, 0.043010752688172046, 0.043010752688172046, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [675.0, 675.0, 690.0, 690.0], \"y\": [0.0, 0.05263157894736842, 0.05263157894736842, 0.043010752688172046], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [665.0, 665.0, 682.5, 682.5], \"y\": [0.0, 0.0582010582010582, 0.0582010582010582, 0.05263157894736842], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [655.0, 655.0, 673.75, 673.75], \"y\": [0.0, 0.06806282722513089, 0.06806282722513089, 0.0582010582010582], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [725.0, 725.0, 735.0, 735.0], \"y\": [0.0, 0.030303030303030304, 0.030303030303030304, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [715.0, 715.0, 730.0, 730.0], \"y\": [0.0, 0.05583756345177665, 0.05583756345177665, 0.030303030303030304], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [705.0, 705.0, 722.5, 722.5], \"y\": [0.0, 0.07, 0.07, 0.05583756345177665], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [664.375, 664.375, 713.75, 713.75], \"y\": [0.06806282722513089, 0.08, 0.08, 0.07], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [755.0, 755.0, 765.0, 765.0], \"y\": [0.0, 0.06930693069306931, 0.06930693069306931, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [745.0, 745.0, 760.0, 760.0], \"y\": [0.0, 0.08571428571428572, 0.08571428571428572, 0.06930693069306931], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [689.0625, 689.0625, 752.5, 752.5], \"y\": [0.08, 0.23444976076555024, 0.23444976076555024, 0.08571428571428572], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [645.0, 645.0, 720.78125, 720.78125], \"y\": [0.0, 0.28431372549019607, 0.28431372549019607, 0.23444976076555024], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [795.0, 795.0, 805.0, 805.0], \"y\": [0.0, 0.11475409836065574, 0.11475409836065574, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [785.0, 785.0, 800.0, 800.0], \"y\": [0.0, 0.2, 0.2, 0.11475409836065574], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [825.0, 825.0, 835.0, 835.0], \"y\": [0.0, 0.07317073170731707, 0.07317073170731707, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [815.0, 815.0, 830.0, 830.0], \"y\": [0.0, 0.13636363636363635, 0.13636363636363635, 0.07317073170731707], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [845.0, 845.0, 855.0, 855.0], \"y\": [0.0, 0.20833333333333334, 0.20833333333333334, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [822.5, 822.5, 850.0, 850.0], \"y\": [0.13636363636363635, 0.23316062176165803, 0.23316062176165803, 0.20833333333333334], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [792.5, 792.5, 836.25, 836.25], \"y\": [0.2, 0.26804123711340205, 0.26804123711340205, 0.23316062176165803], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [775.0, 775.0, 814.375, 814.375], \"y\": [0.0, 0.3140096618357488, 0.3140096618357488, 0.26804123711340205], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [682.890625, 682.890625, 794.6875, 794.6875], \"y\": [0.28431372549019607, 0.38181818181818183, 0.38181818181818183, 0.3140096618357488], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [584.0625, 584.0625, 738.7890625, 738.7890625], \"y\": [0.3059360730593607, 0.4358974358974359, 0.4358974358974359, 0.38181818181818183], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [391.71875, 391.71875, 661.42578125, 661.42578125], \"y\": [0.3879781420765027, 0.472636815920398, 0.472636815920398, 0.4358974358974359], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [332.5, 332.5, 526.572265625, 526.572265625], \"y\": [0.308411214953271, 0.5466666666666666, 0.5466666666666666, 0.472636815920398], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [885.0, 885.0, 895.0, 895.0], \"y\": [0.0, 0.1232876712328767, 0.1232876712328767, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [875.0, 875.0, 890.0, 890.0], \"y\": [0.0, 0.15270935960591134, 0.15270935960591134, 0.1232876712328767], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [865.0, 865.0, 882.5, 882.5], \"y\": [0.0, 0.23655913978494625, 0.23655913978494625, 0.15270935960591134], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [945.0, 945.0, 955.0, 955.0], \"y\": [0.0, 0.08108108108108109, 0.08108108108108109, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [935.0, 935.0, 950.0, 950.0], \"y\": [0.0, 0.1509433962264151, 0.1509433962264151, 0.08108108108108109], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [925.0, 925.0, 942.5, 942.5], \"y\": [0.0, 0.28846153846153844, 0.28846153846153844, 0.1509433962264151], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [915.0, 915.0, 933.75, 933.75], \"y\": [0.0, 0.3391304347826087, 0.3391304347826087, 0.28846153846153844], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [905.0, 905.0, 924.375, 924.375], \"y\": [0.0, 0.3939393939393939, 0.3939393939393939, 0.3391304347826087], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [985.0, 985.0, 995.0, 995.0], \"y\": [0.0, 0.10638297872340426, 0.10638297872340426, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [975.0, 975.0, 990.0, 990.0], \"y\": [0.0, 0.21678321678321677, 0.21678321678321677, 0.10638297872340426], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [965.0, 965.0, 982.5, 982.5], \"y\": [0.0, 0.38571428571428573, 0.38571428571428573, 0.21678321678321677], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1005.0, 1005.0, 1015.0, 1015.0], \"y\": [0.0, 0.06382978723404255, 0.06382978723404255, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1035.0, 1035.0, 1045.0, 1045.0], \"y\": [0.0, 0.04411764705882353, 0.04411764705882353, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1025.0, 1025.0, 1040.0, 1040.0], \"y\": [0.0, 0.08450704225352113, 0.08450704225352113, 0.04411764705882353], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1010.0, 1010.0, 1032.5, 1032.5], \"y\": [0.06382978723404255, 0.09090909090909091, 0.09090909090909091, 0.08450704225352113], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1065.0, 1065.0, 1075.0, 1075.0], \"y\": [0.0, 0.056, 0.056, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1055.0, 1055.0, 1070.0, 1070.0], \"y\": [0.0, 0.1746031746031746, 0.1746031746031746, 0.056], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1085.0, 1085.0, 1095.0, 1095.0], \"y\": [0.0, 0.038461538461538464, 0.038461538461538464, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"y\": [0.0, 0.06666666666666667, 0.06666666666666667, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1105.0, 1105.0, 1120.0, 1120.0], \"y\": [0.0, 0.11320754716981132, 0.11320754716981132, 0.06666666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1090.0, 1090.0, 1112.5, 1112.5], \"y\": [0.038461538461538464, 0.18518518518518517, 0.18518518518518517, 0.11320754716981132], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1062.5, 1062.5, 1101.25, 1101.25], \"y\": [0.1746031746031746, 0.23076923076923078, 0.23076923076923078, 0.18518518518518517], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1021.25, 1021.25, 1081.875, 1081.875], \"y\": [0.09090909090909091, 0.29133858267716534, 0.29133858267716534, 0.23076923076923078], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1135.0, 1135.0, 1145.0, 1145.0], \"y\": [0.0, 0.1937984496124031, 0.1937984496124031, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1165.0, 1165.0, 1175.0, 1175.0], \"y\": [0.0, 0.05555555555555555, 0.05555555555555555, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1155.0, 1155.0, 1170.0, 1170.0], \"y\": [0.0, 0.1206896551724138, 0.1206896551724138, 0.05555555555555555], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1195.0, 1195.0, 1205.0, 1205.0], \"y\": [0.0, 0.13043478260869565, 0.13043478260869565, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1185.0, 1185.0, 1200.0, 1200.0], \"y\": [0.0, 0.24, 0.24, 0.13043478260869565], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1162.5, 1162.5, 1192.5, 1192.5], \"y\": [0.1206896551724138, 0.2761904761904762, 0.2761904761904762, 0.24], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1140.0, 1140.0, 1177.5, 1177.5], \"y\": [0.1937984496124031, 0.31746031746031744, 0.31746031746031744, 0.2761904761904762], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1051.5625, 1051.5625, 1158.75, 1158.75], \"y\": [0.29133858267716534, 0.39568345323741005, 0.39568345323741005, 0.31746031746031744], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [973.75, 973.75, 1105.15625, 1105.15625], \"y\": [0.38571428571428573, 0.4492753623188406, 0.4492753623188406, 0.39568345323741005], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [914.6875, 914.6875, 1039.453125, 1039.453125], \"y\": [0.3939393939393939, 0.5107913669064749, 0.5107913669064749, 0.4492753623188406], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [873.75, 873.75, 977.0703125, 977.0703125], \"y\": [0.23655913978494625, 0.5705521472392638, 0.5705521472392638, 0.5107913669064749], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [429.5361328125, 429.5361328125, 925.41015625, 925.41015625], \"y\": [0.5466666666666666, 0.5955056179775281, 0.5955056179775281, 0.5705521472392638], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [47.490234375, 47.490234375, 677.47314453125, 677.47314453125], \"y\": [0.5789473684210527, 0.7289719626168224, 0.7289719626168224, 0.5955056179775281], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1215.0, 1215.0, 1225.0, 1225.0], \"y\": [0.0, 0.21666666666666667, 0.21666666666666667, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1235.0, 1235.0, 1245.0, 1245.0], \"y\": [0.0, 0.16339869281045752, 0.16339869281045752, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1255.0, 1255.0, 1265.0, 1265.0], \"y\": [0.0, 0.20833333333333334, 0.20833333333333334, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1240.0, 1240.0, 1260.0, 1260.0], \"y\": [0.16339869281045752, 0.24, 0.24, 0.20833333333333334], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1220.0, 1220.0, 1250.0, 1250.0], \"y\": [0.21666666666666667, 0.5657894736842105, 0.5657894736842105, 0.24], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1275.0, 1275.0, 1285.0, 1285.0], \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1315.0, 1315.0, 1325.0, 1325.0], \"y\": [0.0, 0.07042253521126761, 0.07042253521126761, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1305.0, 1305.0, 1320.0, 1320.0], \"y\": [0.0, 0.10810810810810811, 0.10810810810810811, 0.07042253521126761], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1295.0, 1295.0, 1312.5, 1312.5], \"y\": [0.0, 0.15384615384615385, 0.15384615384615385, 0.10810810810810811], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1345.0, 1345.0, 1355.0, 1355.0], \"y\": [0.0, 0.08823529411764706, 0.08823529411764706, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1335.0, 1335.0, 1350.0, 1350.0], \"y\": [0.0, 0.15942028985507245, 0.15942028985507245, 0.08823529411764706], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1303.75, 1303.75, 1342.5, 1342.5], \"y\": [0.15384615384615385, 0.23943661971830985, 0.23943661971830985, 0.15942028985507245], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1365.0, 1365.0, 1375.0, 1375.0], \"y\": [0.0, 0.28, 0.28, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1323.125, 1323.125, 1370.0, 1370.0], \"y\": [0.23943661971830985, 0.3176470588235294, 0.3176470588235294, 0.28], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1280.0, 1280.0, 1346.5625, 1346.5625], \"y\": [0.14285714285714285, 0.5339805825242718, 0.5339805825242718, 0.3176470588235294], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"y\": [0.0, 0.11428571428571428, 0.11428571428571428, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1395.0, 1395.0, 1410.0, 1410.0], \"y\": [0.0, 0.4153846153846154, 0.4153846153846154, 0.11428571428571428], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1385.0, 1385.0, 1402.5, 1402.5], \"y\": [0.0, 0.475, 0.475, 0.4153846153846154], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1425.0, 1425.0, 1435.0, 1435.0], \"y\": [0.0, 0.16417910447761194, 0.16417910447761194, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1465.0, 1465.0, 1475.0, 1475.0], \"y\": [0.0, 0.13432835820895522, 0.13432835820895522, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1455.0, 1455.0, 1470.0, 1470.0], \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.13432835820895522], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1445.0, 1445.0, 1462.5, 1462.5], \"y\": [0.0, 0.18840579710144928, 0.18840579710144928, 0.14285714285714285], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1430.0, 1430.0, 1453.75, 1453.75], \"y\": [0.16417910447761194, 0.38235294117647056, 0.38235294117647056, 0.18840579710144928], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1485.0, 1485.0, 1495.0, 1495.0], \"y\": [0.0, 0.14666666666666667, 0.14666666666666667, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1505.0, 1505.0, 1515.0, 1515.0], \"y\": [0.0, 0.2676056338028169, 0.2676056338028169, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1490.0, 1490.0, 1510.0, 1510.0], \"y\": [0.14666666666666667, 0.34177215189873417, 0.34177215189873417, 0.2676056338028169], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"y\": [0.0, 0.36, 0.36, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1500.0, 1500.0, 1530.0, 1530.0], \"y\": [0.34177215189873417, 0.4666666666666667, 0.4666666666666667, 0.36], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1441.875, 1441.875, 1515.0, 1515.0], \"y\": [0.38235294117647056, 0.5294117647058824, 0.5294117647058824, 0.4666666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1393.75, 1393.75, 1478.4375, 1478.4375], \"y\": [0.475, 0.569620253164557, 0.569620253164557, 0.5294117647058824], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1313.28125, 1313.28125, 1436.09375, 1436.09375], \"y\": [0.5339805825242718, 0.68, 0.68, 0.569620253164557], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1235.0, 1235.0, 1374.6875, 1374.6875], \"y\": [0.5657894736842105, 0.7606837606837606, 0.7606837606837606, 0.68], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [362.481689453125, 362.481689453125, 1304.84375, 1304.84375], \"y\": [0.7289719626168224, 0.8205128205128205, 0.8205128205128205, 0.7606837606837606], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1555.0, 1555.0, 1565.0, 1565.0], \"y\": [0.0, 0.4, 0.4, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1575.0, 1575.0, 1585.0, 1585.0], \"y\": [0.0, 0.4339622641509434, 0.4339622641509434, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1560.0, 1560.0, 1580.0, 1580.0], \"y\": [0.4, 0.5407407407407407, 0.5407407407407407, 0.4339622641509434], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1545.0, 1545.0, 1570.0, 1570.0], \"y\": [0.0, 0.5975609756097561, 0.5975609756097561, 0.5407407407407407], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1595.0, 1595.0, 1605.0, 1605.0], \"y\": [0.0, 0.2926208651399491, 0.2926208651399491, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1635.0, 1635.0, 1645.0, 1645.0], \"y\": [0.0, 0.3217391304347826, 0.3217391304347826, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1665.0, 1665.0, 1675.0, 1675.0], \"y\": [0.0, 0.3032258064516129, 0.3032258064516129, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1655.0, 1655.0, 1670.0, 1670.0], \"y\": [0.0, 0.35766423357664234, 0.35766423357664234, 0.3032258064516129], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1640.0, 1640.0, 1662.5, 1662.5], \"y\": [0.3217391304347826, 0.4782608695652174, 0.4782608695652174, 0.35766423357664234], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1625.0, 1625.0, 1651.25, 1651.25], \"y\": [0.0, 0.5053763440860215, 0.5053763440860215, 0.4782608695652174], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1615.0, 1615.0, 1638.125, 1638.125], \"y\": [0.0, 0.5486725663716814, 0.5486725663716814, 0.5053763440860215], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1600.0, 1600.0, 1626.5625, 1626.5625], \"y\": [0.2926208651399491, 0.6454849498327759, 0.6454849498327759, 0.5486725663716814], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1557.5, 1557.5, 1613.28125, 1613.28125], \"y\": [0.5975609756097561, 0.7912087912087912, 0.7912087912087912, 0.6454849498327759], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1715.0, 1715.0, 1725.0, 1725.0], \"y\": [0.0, 0.40594059405940597, 0.40594059405940597, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1705.0, 1705.0, 1720.0, 1720.0], \"y\": [0.0, 0.42857142857142855, 0.42857142857142855, 0.40594059405940597], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1695.0, 1695.0, 1712.5, 1712.5], \"y\": [0.0, 0.525, 0.525, 0.42857142857142855], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1685.0, 1685.0, 1703.75, 1703.75], \"y\": [0.0, 0.6036036036036037, 0.6036036036036037, 0.525], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1745.0, 1745.0, 1755.0, 1755.0], \"y\": [0.0, 0.3877551020408163, 0.3877551020408163, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1775.0, 1775.0, 1785.0, 1785.0], \"y\": [0.0, 0.2066115702479339, 0.2066115702479339, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1765.0, 1765.0, 1780.0, 1780.0], \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.2066115702479339], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"y\": [0.0, 0.12631578947368421, 0.12631578947368421, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"y\": [0.0, 0.2647058823529412, 0.2647058823529412, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1800.0, 1800.0, 1820.0, 1820.0], \"y\": [0.12631578947368421, 0.36470588235294116, 0.36470588235294116, 0.2647058823529412], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1772.5, 1772.5, 1810.0, 1810.0], \"y\": [0.3333333333333333, 0.48427672955974843, 0.48427672955974843, 0.36470588235294116], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1750.0, 1750.0, 1791.25, 1791.25], \"y\": [0.3877551020408163, 0.5614035087719298, 0.5614035087719298, 0.48427672955974843], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1735.0, 1735.0, 1770.625, 1770.625], \"y\": [0.0, 0.6346153846153846, 0.6346153846153846, 0.5614035087719298], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"y\": [0.0, 0.13978494623655913, 0.13978494623655913, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1875.0, 1875.0, 1890.0, 1890.0], \"y\": [0.0, 0.15463917525773196, 0.15463917525773196, 0.13978494623655913], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1905.0, 1905.0, 1915.0, 1915.0], \"y\": [0.0, 0.15789473684210525, 0.15789473684210525, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1882.5, 1882.5, 1910.0, 1910.0], \"y\": [0.15463917525773196, 0.19230769230769232, 0.19230769230769232, 0.15789473684210525], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1925.0, 1925.0, 1935.0, 1935.0], \"y\": [0.0, 0.21818181818181817, 0.21818181818181817, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1896.25, 1896.25, 1930.0, 1930.0], \"y\": [0.19230769230769232, 0.24561403508771928, 0.24561403508771928, 0.21818181818181817], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1945.0, 1945.0, 1955.0, 1955.0], \"y\": [0.0, 0.1504424778761062, 0.1504424778761062, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"y\": [0.0, 0.16129032258064516, 0.16129032258064516, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"y\": [0.0, 0.2222222222222222, 0.2222222222222222, 0.16129032258064516], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1950.0, 1950.0, 1972.5, 1972.5], \"y\": [0.1504424778761062, 0.26, 0.26, 0.2222222222222222], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1913.125, 1913.125, 1961.25, 1961.25], \"y\": [0.24561403508771928, 0.2830188679245283, 0.2830188679245283, 0.26], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1865.0, 1865.0, 1937.1875, 1937.1875], \"y\": [0.0, 0.3142857142857143, 0.3142857142857143, 0.2830188679245283], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1855.0, 1855.0, 1901.09375, 1901.09375], \"y\": [0.0, 0.3786407766990291, 0.3786407766990291, 0.3142857142857143], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1845.0, 1845.0, 1878.046875, 1878.046875], \"y\": [0.0, 0.4956521739130435, 0.4956521739130435, 0.3786407766990291], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1835.0, 1835.0, 1861.5234375, 1861.5234375], \"y\": [0.0, 0.635036496350365, 0.635036496350365, 0.4956521739130435], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1752.8125, 1752.8125, 1848.26171875, 1848.26171875], \"y\": [0.6346153846153846, 0.7281553398058253, 0.7281553398058253, 0.635036496350365], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1694.375, 1694.375, 1800.537109375, 1800.537109375], \"y\": [0.6036036036036037, 0.8117647058823529, 0.8117647058823529, 0.7281553398058253], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1585.390625, 1585.390625, 1747.4560546875, 1747.4560546875], \"y\": [0.7912087912087912, 0.9304347826086956, 0.9304347826086956, 0.8117647058823529], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [833.6627197265625, 833.6627197265625, 1666.42333984375, 1666.42333984375], \"y\": [0.8205128205128205, 0.9885057471264368, 0.9885057471264368, 0.9304347826086956], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}], {\"xaxis\": {\"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0], \"ticktext\": [\"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001814_209.15335_478.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001816_209.15341_296.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17426_497.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001814_215.16406_483.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_222.07031_314.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001815_194.11745_132.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001814_194.1174_217.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001814_229.15451_65.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001816_247.12863_162.0\", \"QE_2017_001815_260.16016_140.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001815_233.14944_150.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04474_327.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001815_182.08109_52.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001814_199.98772_303.0\", \"QE_2017_001815_199.98772_253.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_265.01532_33.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001815_237.12315_52.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001815_219.10146_381.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001814_171.14908_419.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001814_129.12737_348.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001814_332.25842_486.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001815_291.14493_242.0\", \"QE_2017_001814_251.13872_201.0\", \"QE_2017_001815_235.14388_180.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001815_319.13623_118.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001815_241.15437_67.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001814_364.34241_751.0\", \"QE_2017_001814_424.36325_711.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001814_421.35211_732.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001814_408.3681_703.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001816_611.16064_309.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_231.04967_404.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001814_599.40918_659.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001815_792.5625_866.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001814_792.56207_723.0\", \"QE_2017_001815_613.4826_734.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_278.24756_683.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001815_571.47168_711.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\"], \"tickmode\": \"array\", \"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"sample\"}, \"yaxis\": {\"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"distance\"}, \"showlegend\": false, \"autosize\": false, \"hovermode\": \"closest\", \"width\": 900, \"height\": 500, \"title\": \"BioDendro\"}, {\"showLink\": true, \"linkText\": \"Export to plot.ly\"})});</script>"
-      ],
-      "text/vnd.plotly.v1+html": [
-       "<div id=\"55249d27-5d02-4667-98e0-721ba98f2a91\" style=\"height: 500px; width: 900px;\" class=\"plotly-graph-div\"></div><script type=\"text/javascript\">require([\"plotly\"], function(Plotly) { window.PLOTLYENV=window.PLOTLYENV || {};window.PLOTLYENV.BASE_URL=\"https://plot.ly\";Plotly.newPlot(\"55249d27-5d02-4667-98e0-721ba98f2a91\", [{\"type\": \"scatter\", \"x\": [5.0, 5.0, 15.0, 15.0], \"y\": [0.0, 0.4827586206896552, 0.4827586206896552, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [25.0, 25.0, 35.0, 35.0], \"y\": [0.0, 0.20279720279720279, 0.20279720279720279, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [65.0, 65.0, 75.0, 75.0], \"y\": [0.0, 0.1724137931034483, 0.1724137931034483, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [55.0, 55.0, 70.0, 70.0], \"y\": [0.0, 0.2, 0.2, 0.1724137931034483], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [45.0, 45.0, 62.5, 62.5], \"y\": [0.0, 0.30578512396694213, 0.30578512396694213, 0.2], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [85.0, 85.0, 95.0, 95.0], \"y\": [0.0, 0.0847457627118644, 0.0847457627118644, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [105.0, 105.0, 115.0, 115.0], \"y\": [0.0, 0.13609467455621302, 0.13609467455621302, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [90.0, 90.0, 110.0, 110.0], \"y\": [0.0847457627118644, 0.3246753246753247, 0.3246753246753247, 0.13609467455621302], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [53.75, 53.75, 100.0, 100.0], \"y\": [0.30578512396694213, 0.3793103448275862, 0.3793103448275862, 0.3246753246753247], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [135.0, 135.0, 145.0, 145.0], \"y\": [0.0, 0.11731843575418995, 0.11731843575418995, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [125.0, 125.0, 140.0, 140.0], \"y\": [0.0, 0.17045454545454544, 0.17045454545454544, 0.11731843575418995], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [155.0, 155.0, 165.0, 165.0], \"y\": [0.0, 0.20454545454545456, 0.20454545454545456, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [132.5, 132.5, 160.0, 160.0], \"y\": [0.17045454545454544, 0.24022346368715083, 0.24022346368715083, 0.20454545454545456], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [175.0, 175.0, 185.0, 185.0], \"y\": [0.0, 0.27, 0.27, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [146.25, 146.25, 180.0, 180.0], \"y\": [0.24022346368715083, 0.33689839572192515, 0.33689839572192515, 0.27], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [215.0, 215.0, 225.0, 225.0], \"y\": [0.0, 0.1111111111111111, 0.1111111111111111, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [205.0, 205.0, 220.0, 220.0], \"y\": [0.0, 0.14864864864864866, 0.14864864864864866, 0.1111111111111111], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [195.0, 195.0, 212.5, 212.5], \"y\": [0.0, 0.20588235294117646, 0.20588235294117646, 0.14864864864864866], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [255.0, 255.0, 265.0, 265.0], \"y\": [0.0, 0.06578947368421052, 0.06578947368421052, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [245.0, 245.0, 260.0, 260.0], \"y\": [0.0, 0.0728476821192053, 0.0728476821192053, 0.06578947368421052], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [235.0, 235.0, 252.5, 252.5], \"y\": [0.0, 0.1125, 0.1125, 0.0728476821192053], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [275.0, 275.0, 285.0, 285.0], \"y\": [0.0, 0.20930232558139536, 0.20930232558139536, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [243.75, 243.75, 280.0, 280.0], \"y\": [0.1125, 0.2484076433121019, 0.2484076433121019, 0.20930232558139536], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [305.0, 305.0, 315.0, 315.0], \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [295.0, 295.0, 310.0, 310.0], \"y\": [0.0, 0.2875, 0.2875, 0.14285714285714285], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [261.875, 261.875, 302.5, 302.5], \"y\": [0.2484076433121019, 0.3383458646616541, 0.3383458646616541, 0.2875], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [203.75, 203.75, 282.1875, 282.1875], \"y\": [0.20588235294117646, 0.34285714285714286, 0.34285714285714286, 0.3383458646616541], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [163.125, 163.125, 242.96875, 242.96875], \"y\": [0.33689839572192515, 0.38562091503267976, 0.38562091503267976, 0.34285714285714286], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [76.875, 76.875, 203.046875, 203.046875], \"y\": [0.3793103448275862, 0.44516129032258067, 0.44516129032258067, 0.38562091503267976], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [30.0, 30.0, 139.9609375, 139.9609375], \"y\": [0.20279720279720279, 0.5, 0.5, 0.44516129032258067], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [10.0, 10.0, 84.98046875, 84.98046875], \"y\": [0.4827586206896552, 0.5789473684210527, 0.5789473684210527, 0.5], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [335.0, 335.0, 345.0, 345.0], \"y\": [0.0, 0.15270935960591134, 0.15270935960591134, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [325.0, 325.0, 340.0, 340.0], \"y\": [0.0, 0.308411214953271, 0.308411214953271, 0.15270935960591134], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [365.0, 365.0, 375.0, 375.0], \"y\": [0.0, 0.075, 0.075, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [395.0, 395.0, 405.0, 405.0], \"y\": [0.0, 0.15714285714285714, 0.15714285714285714, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [385.0, 385.0, 400.0, 400.0], \"y\": [0.0, 0.1836734693877551, 0.1836734693877551, 0.15714285714285714], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [370.0, 370.0, 392.5, 392.5], \"y\": [0.075, 0.25161290322580643, 0.25161290322580643, 0.1836734693877551], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [425.0, 425.0, 435.0, 435.0], \"y\": [0.0, 0.08860759493670886, 0.08860759493670886, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [445.0, 445.0, 455.0, 455.0], \"y\": [0.0, 0.10714285714285714, 0.10714285714285714, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [430.0, 430.0, 450.0, 450.0], \"y\": [0.08860759493670886, 0.17647058823529413, 0.17647058823529413, 0.10714285714285714], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [475.0, 475.0, 485.0, 485.0], \"y\": [0.0, 0.03225806451612903, 0.03225806451612903, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [465.0, 465.0, 480.0, 480.0], \"y\": [0.0, 0.18238993710691823, 0.18238993710691823, 0.03225806451612903], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [440.0, 440.0, 472.5, 472.5], \"y\": [0.17647058823529413, 0.26627218934911245, 0.26627218934911245, 0.18238993710691823], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [415.0, 415.0, 456.25, 456.25], \"y\": [0.0, 0.27710843373493976, 0.27710843373493976, 0.26627218934911245], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [495.0, 495.0, 505.0, 505.0], \"y\": [0.0, 0.0975609756097561, 0.0975609756097561, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [515.0, 515.0, 525.0, 525.0], \"y\": [0.0, 0.04938271604938271, 0.04938271604938271, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [545.0, 545.0, 555.0, 555.0], \"y\": [0.0, 0.033112582781456956, 0.033112582781456956, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [535.0, 535.0, 550.0, 550.0], \"y\": [0.0, 0.0641025641025641, 0.0641025641025641, 0.033112582781456956], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [520.0, 520.0, 542.5, 542.5], \"y\": [0.04938271604938271, 0.2125, 0.2125, 0.0641025641025641], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [500.0, 500.0, 531.25, 531.25], \"y\": [0.0975609756097561, 0.2891566265060241, 0.2891566265060241, 0.2125], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [435.625, 435.625, 515.625, 515.625], \"y\": [0.27710843373493976, 0.3372093023255814, 0.3372093023255814, 0.2891566265060241], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [381.25, 381.25, 475.625, 475.625], \"y\": [0.25161290322580643, 0.36904761904761907, 0.36904761904761907, 0.3372093023255814], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [355.0, 355.0, 428.4375, 428.4375], \"y\": [0.0, 0.3879781420765027, 0.3879781420765027, 0.36904761904761907], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [565.0, 565.0, 575.0, 575.0], \"y\": [0.0, 0.08016877637130802, 0.08016877637130802, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [595.0, 595.0, 605.0, 605.0], \"y\": [0.0, 0.06806282722513089, 0.06806282722513089, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [625.0, 625.0, 635.0, 635.0], \"y\": [0.0, 0.1111111111111111, 0.1111111111111111, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [615.0, 615.0, 630.0, 630.0], \"y\": [0.0, 0.12280701754385964, 0.12280701754385964, 0.1111111111111111], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [600.0, 600.0, 622.5, 622.5], \"y\": [0.06806282722513089, 0.14606741573033707, 0.14606741573033707, 0.12280701754385964], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [585.0, 585.0, 611.25, 611.25], \"y\": [0.0, 0.2205128205128205, 0.2205128205128205, 0.14606741573033707], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [570.0, 570.0, 598.125, 598.125], \"y\": [0.08016877637130802, 0.3059360730593607, 0.3059360730593607, 0.2205128205128205], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [685.0, 685.0, 695.0, 695.0], \"y\": [0.0, 0.043010752688172046, 0.043010752688172046, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [675.0, 675.0, 690.0, 690.0], \"y\": [0.0, 0.05263157894736842, 0.05263157894736842, 0.043010752688172046], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [665.0, 665.0, 682.5, 682.5], \"y\": [0.0, 0.0582010582010582, 0.0582010582010582, 0.05263157894736842], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [655.0, 655.0, 673.75, 673.75], \"y\": [0.0, 0.06806282722513089, 0.06806282722513089, 0.0582010582010582], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [725.0, 725.0, 735.0, 735.0], \"y\": [0.0, 0.030303030303030304, 0.030303030303030304, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [715.0, 715.0, 730.0, 730.0], \"y\": [0.0, 0.05583756345177665, 0.05583756345177665, 0.030303030303030304], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [705.0, 705.0, 722.5, 722.5], \"y\": [0.0, 0.07, 0.07, 0.05583756345177665], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [664.375, 664.375, 713.75, 713.75], \"y\": [0.06806282722513089, 0.08, 0.08, 0.07], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [755.0, 755.0, 765.0, 765.0], \"y\": [0.0, 0.06930693069306931, 0.06930693069306931, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [745.0, 745.0, 760.0, 760.0], \"y\": [0.0, 0.08571428571428572, 0.08571428571428572, 0.06930693069306931], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [689.0625, 689.0625, 752.5, 752.5], \"y\": [0.08, 0.23444976076555024, 0.23444976076555024, 0.08571428571428572], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [645.0, 645.0, 720.78125, 720.78125], \"y\": [0.0, 0.28431372549019607, 0.28431372549019607, 0.23444976076555024], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [795.0, 795.0, 805.0, 805.0], \"y\": [0.0, 0.11475409836065574, 0.11475409836065574, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [785.0, 785.0, 800.0, 800.0], \"y\": [0.0, 0.2, 0.2, 0.11475409836065574], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [825.0, 825.0, 835.0, 835.0], \"y\": [0.0, 0.07317073170731707, 0.07317073170731707, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [815.0, 815.0, 830.0, 830.0], \"y\": [0.0, 0.13636363636363635, 0.13636363636363635, 0.07317073170731707], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [845.0, 845.0, 855.0, 855.0], \"y\": [0.0, 0.20833333333333334, 0.20833333333333334, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [822.5, 822.5, 850.0, 850.0], \"y\": [0.13636363636363635, 0.23316062176165803, 0.23316062176165803, 0.20833333333333334], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [792.5, 792.5, 836.25, 836.25], \"y\": [0.2, 0.26804123711340205, 0.26804123711340205, 0.23316062176165803], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [775.0, 775.0, 814.375, 814.375], \"y\": [0.0, 0.3140096618357488, 0.3140096618357488, 0.26804123711340205], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [682.890625, 682.890625, 794.6875, 794.6875], \"y\": [0.28431372549019607, 0.38181818181818183, 0.38181818181818183, 0.3140096618357488], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [584.0625, 584.0625, 738.7890625, 738.7890625], \"y\": [0.3059360730593607, 0.4358974358974359, 0.4358974358974359, 0.38181818181818183], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [391.71875, 391.71875, 661.42578125, 661.42578125], \"y\": [0.3879781420765027, 0.472636815920398, 0.472636815920398, 0.4358974358974359], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [332.5, 332.5, 526.572265625, 526.572265625], \"y\": [0.308411214953271, 0.5466666666666666, 0.5466666666666666, 0.472636815920398], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [885.0, 885.0, 895.0, 895.0], \"y\": [0.0, 0.1232876712328767, 0.1232876712328767, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [875.0, 875.0, 890.0, 890.0], \"y\": [0.0, 0.15270935960591134, 0.15270935960591134, 0.1232876712328767], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [865.0, 865.0, 882.5, 882.5], \"y\": [0.0, 0.23655913978494625, 0.23655913978494625, 0.15270935960591134], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [945.0, 945.0, 955.0, 955.0], \"y\": [0.0, 0.08108108108108109, 0.08108108108108109, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [935.0, 935.0, 950.0, 950.0], \"y\": [0.0, 0.1509433962264151, 0.1509433962264151, 0.08108108108108109], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [925.0, 925.0, 942.5, 942.5], \"y\": [0.0, 0.28846153846153844, 0.28846153846153844, 0.1509433962264151], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [915.0, 915.0, 933.75, 933.75], \"y\": [0.0, 0.3391304347826087, 0.3391304347826087, 0.28846153846153844], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [905.0, 905.0, 924.375, 924.375], \"y\": [0.0, 0.3939393939393939, 0.3939393939393939, 0.3391304347826087], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [985.0, 985.0, 995.0, 995.0], \"y\": [0.0, 0.10638297872340426, 0.10638297872340426, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [975.0, 975.0, 990.0, 990.0], \"y\": [0.0, 0.21678321678321677, 0.21678321678321677, 0.10638297872340426], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [965.0, 965.0, 982.5, 982.5], \"y\": [0.0, 0.38571428571428573, 0.38571428571428573, 0.21678321678321677], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1005.0, 1005.0, 1015.0, 1015.0], \"y\": [0.0, 0.06382978723404255, 0.06382978723404255, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1035.0, 1035.0, 1045.0, 1045.0], \"y\": [0.0, 0.04411764705882353, 0.04411764705882353, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1025.0, 1025.0, 1040.0, 1040.0], \"y\": [0.0, 0.08450704225352113, 0.08450704225352113, 0.04411764705882353], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1010.0, 1010.0, 1032.5, 1032.5], \"y\": [0.06382978723404255, 0.09090909090909091, 0.09090909090909091, 0.08450704225352113], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1065.0, 1065.0, 1075.0, 1075.0], \"y\": [0.0, 0.056, 0.056, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1055.0, 1055.0, 1070.0, 1070.0], \"y\": [0.0, 0.1746031746031746, 0.1746031746031746, 0.056], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1085.0, 1085.0, 1095.0, 1095.0], \"y\": [0.0, 0.038461538461538464, 0.038461538461538464, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"y\": [0.0, 0.06666666666666667, 0.06666666666666667, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1105.0, 1105.0, 1120.0, 1120.0], \"y\": [0.0, 0.11320754716981132, 0.11320754716981132, 0.06666666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1090.0, 1090.0, 1112.5, 1112.5], \"y\": [0.038461538461538464, 0.18518518518518517, 0.18518518518518517, 0.11320754716981132], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1062.5, 1062.5, 1101.25, 1101.25], \"y\": [0.1746031746031746, 0.23076923076923078, 0.23076923076923078, 0.18518518518518517], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1021.25, 1021.25, 1081.875, 1081.875], \"y\": [0.09090909090909091, 0.29133858267716534, 0.29133858267716534, 0.23076923076923078], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1135.0, 1135.0, 1145.0, 1145.0], \"y\": [0.0, 0.1937984496124031, 0.1937984496124031, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1165.0, 1165.0, 1175.0, 1175.0], \"y\": [0.0, 0.05555555555555555, 0.05555555555555555, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1155.0, 1155.0, 1170.0, 1170.0], \"y\": [0.0, 0.1206896551724138, 0.1206896551724138, 0.05555555555555555], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1195.0, 1195.0, 1205.0, 1205.0], \"y\": [0.0, 0.13043478260869565, 0.13043478260869565, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1185.0, 1185.0, 1200.0, 1200.0], \"y\": [0.0, 0.24, 0.24, 0.13043478260869565], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1162.5, 1162.5, 1192.5, 1192.5], \"y\": [0.1206896551724138, 0.2761904761904762, 0.2761904761904762, 0.24], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1140.0, 1140.0, 1177.5, 1177.5], \"y\": [0.1937984496124031, 0.31746031746031744, 0.31746031746031744, 0.2761904761904762], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1051.5625, 1051.5625, 1158.75, 1158.75], \"y\": [0.29133858267716534, 0.39568345323741005, 0.39568345323741005, 0.31746031746031744], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [973.75, 973.75, 1105.15625, 1105.15625], \"y\": [0.38571428571428573, 0.4492753623188406, 0.4492753623188406, 0.39568345323741005], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [914.6875, 914.6875, 1039.453125, 1039.453125], \"y\": [0.3939393939393939, 0.5107913669064749, 0.5107913669064749, 0.4492753623188406], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [873.75, 873.75, 977.0703125, 977.0703125], \"y\": [0.23655913978494625, 0.5705521472392638, 0.5705521472392638, 0.5107913669064749], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [429.5361328125, 429.5361328125, 925.41015625, 925.41015625], \"y\": [0.5466666666666666, 0.5955056179775281, 0.5955056179775281, 0.5705521472392638], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [47.490234375, 47.490234375, 677.47314453125, 677.47314453125], \"y\": [0.5789473684210527, 0.7289719626168224, 0.7289719626168224, 0.5955056179775281], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1215.0, 1215.0, 1225.0, 1225.0], \"y\": [0.0, 0.21666666666666667, 0.21666666666666667, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1235.0, 1235.0, 1245.0, 1245.0], \"y\": [0.0, 0.16339869281045752, 0.16339869281045752, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1255.0, 1255.0, 1265.0, 1265.0], \"y\": [0.0, 0.20833333333333334, 0.20833333333333334, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1240.0, 1240.0, 1260.0, 1260.0], \"y\": [0.16339869281045752, 0.24, 0.24, 0.20833333333333334], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1220.0, 1220.0, 1250.0, 1250.0], \"y\": [0.21666666666666667, 0.5657894736842105, 0.5657894736842105, 0.24], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1275.0, 1275.0, 1285.0, 1285.0], \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1315.0, 1315.0, 1325.0, 1325.0], \"y\": [0.0, 0.07042253521126761, 0.07042253521126761, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1305.0, 1305.0, 1320.0, 1320.0], \"y\": [0.0, 0.10810810810810811, 0.10810810810810811, 0.07042253521126761], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1295.0, 1295.0, 1312.5, 1312.5], \"y\": [0.0, 0.15384615384615385, 0.15384615384615385, 0.10810810810810811], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1345.0, 1345.0, 1355.0, 1355.0], \"y\": [0.0, 0.08823529411764706, 0.08823529411764706, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1335.0, 1335.0, 1350.0, 1350.0], \"y\": [0.0, 0.15942028985507245, 0.15942028985507245, 0.08823529411764706], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1303.75, 1303.75, 1342.5, 1342.5], \"y\": [0.15384615384615385, 0.23943661971830985, 0.23943661971830985, 0.15942028985507245], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1365.0, 1365.0, 1375.0, 1375.0], \"y\": [0.0, 0.28, 0.28, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1323.125, 1323.125, 1370.0, 1370.0], \"y\": [0.23943661971830985, 0.3176470588235294, 0.3176470588235294, 0.28], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1280.0, 1280.0, 1346.5625, 1346.5625], \"y\": [0.14285714285714285, 0.5339805825242718, 0.5339805825242718, 0.3176470588235294], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"y\": [0.0, 0.11428571428571428, 0.11428571428571428, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1395.0, 1395.0, 1410.0, 1410.0], \"y\": [0.0, 0.4153846153846154, 0.4153846153846154, 0.11428571428571428], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1385.0, 1385.0, 1402.5, 1402.5], \"y\": [0.0, 0.475, 0.475, 0.4153846153846154], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1425.0, 1425.0, 1435.0, 1435.0], \"y\": [0.0, 0.16417910447761194, 0.16417910447761194, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1465.0, 1465.0, 1475.0, 1475.0], \"y\": [0.0, 0.13432835820895522, 0.13432835820895522, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1455.0, 1455.0, 1470.0, 1470.0], \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.13432835820895522], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1445.0, 1445.0, 1462.5, 1462.5], \"y\": [0.0, 0.18840579710144928, 0.18840579710144928, 0.14285714285714285], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1430.0, 1430.0, 1453.75, 1453.75], \"y\": [0.16417910447761194, 0.38235294117647056, 0.38235294117647056, 0.18840579710144928], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1485.0, 1485.0, 1495.0, 1495.0], \"y\": [0.0, 0.14666666666666667, 0.14666666666666667, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1505.0, 1505.0, 1515.0, 1515.0], \"y\": [0.0, 0.2676056338028169, 0.2676056338028169, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1490.0, 1490.0, 1510.0, 1510.0], \"y\": [0.14666666666666667, 0.34177215189873417, 0.34177215189873417, 0.2676056338028169], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"y\": [0.0, 0.36, 0.36, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1500.0, 1500.0, 1530.0, 1530.0], \"y\": [0.34177215189873417, 0.4666666666666667, 0.4666666666666667, 0.36], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1441.875, 1441.875, 1515.0, 1515.0], \"y\": [0.38235294117647056, 0.5294117647058824, 0.5294117647058824, 0.4666666666666667], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1393.75, 1393.75, 1478.4375, 1478.4375], \"y\": [0.475, 0.569620253164557, 0.569620253164557, 0.5294117647058824], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1313.28125, 1313.28125, 1436.09375, 1436.09375], \"y\": [0.5339805825242718, 0.68, 0.68, 0.569620253164557], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1235.0, 1235.0, 1374.6875, 1374.6875], \"y\": [0.5657894736842105, 0.7606837606837606, 0.7606837606837606, 0.68], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [362.481689453125, 362.481689453125, 1304.84375, 1304.84375], \"y\": [0.7289719626168224, 0.8205128205128205, 0.8205128205128205, 0.7606837606837606], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1555.0, 1555.0, 1565.0, 1565.0], \"y\": [0.0, 0.4, 0.4, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1575.0, 1575.0, 1585.0, 1585.0], \"y\": [0.0, 0.4339622641509434, 0.4339622641509434, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1560.0, 1560.0, 1580.0, 1580.0], \"y\": [0.4, 0.5407407407407407, 0.5407407407407407, 0.4339622641509434], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1545.0, 1545.0, 1570.0, 1570.0], \"y\": [0.0, 0.5975609756097561, 0.5975609756097561, 0.5407407407407407], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1595.0, 1595.0, 1605.0, 1605.0], \"y\": [0.0, 0.2926208651399491, 0.2926208651399491, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1635.0, 1635.0, 1645.0, 1645.0], \"y\": [0.0, 0.3217391304347826, 0.3217391304347826, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1665.0, 1665.0, 1675.0, 1675.0], \"y\": [0.0, 0.3032258064516129, 0.3032258064516129, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1655.0, 1655.0, 1670.0, 1670.0], \"y\": [0.0, 0.35766423357664234, 0.35766423357664234, 0.3032258064516129], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1640.0, 1640.0, 1662.5, 1662.5], \"y\": [0.3217391304347826, 0.4782608695652174, 0.4782608695652174, 0.35766423357664234], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1625.0, 1625.0, 1651.25, 1651.25], \"y\": [0.0, 0.5053763440860215, 0.5053763440860215, 0.4782608695652174], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1615.0, 1615.0, 1638.125, 1638.125], \"y\": [0.0, 0.5486725663716814, 0.5486725663716814, 0.5053763440860215], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1600.0, 1600.0, 1626.5625, 1626.5625], \"y\": [0.2926208651399491, 0.6454849498327759, 0.6454849498327759, 0.5486725663716814], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1557.5, 1557.5, 1613.28125, 1613.28125], \"y\": [0.5975609756097561, 0.7912087912087912, 0.7912087912087912, 0.6454849498327759], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1715.0, 1715.0, 1725.0, 1725.0], \"y\": [0.0, 0.40594059405940597, 0.40594059405940597, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1705.0, 1705.0, 1720.0, 1720.0], \"y\": [0.0, 0.42857142857142855, 0.42857142857142855, 0.40594059405940597], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1695.0, 1695.0, 1712.5, 1712.5], \"y\": [0.0, 0.525, 0.525, 0.42857142857142855], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1685.0, 1685.0, 1703.75, 1703.75], \"y\": [0.0, 0.6036036036036037, 0.6036036036036037, 0.525], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1745.0, 1745.0, 1755.0, 1755.0], \"y\": [0.0, 0.3877551020408163, 0.3877551020408163, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1775.0, 1775.0, 1785.0, 1785.0], \"y\": [0.0, 0.2066115702479339, 0.2066115702479339, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1765.0, 1765.0, 1780.0, 1780.0], \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.2066115702479339], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"y\": [0.0, 0.12631578947368421, 0.12631578947368421, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"y\": [0.0, 0.2647058823529412, 0.2647058823529412, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1800.0, 1800.0, 1820.0, 1820.0], \"y\": [0.12631578947368421, 0.36470588235294116, 0.36470588235294116, 0.2647058823529412], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1772.5, 1772.5, 1810.0, 1810.0], \"y\": [0.3333333333333333, 0.48427672955974843, 0.48427672955974843, 0.36470588235294116], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1750.0, 1750.0, 1791.25, 1791.25], \"y\": [0.3877551020408163, 0.5614035087719298, 0.5614035087719298, 0.48427672955974843], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1735.0, 1735.0, 1770.625, 1770.625], \"y\": [0.0, 0.6346153846153846, 0.6346153846153846, 0.5614035087719298], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"y\": [0.0, 0.13978494623655913, 0.13978494623655913, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1875.0, 1875.0, 1890.0, 1890.0], \"y\": [0.0, 0.15463917525773196, 0.15463917525773196, 0.13978494623655913], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1905.0, 1905.0, 1915.0, 1915.0], \"y\": [0.0, 0.15789473684210525, 0.15789473684210525, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1882.5, 1882.5, 1910.0, 1910.0], \"y\": [0.15463917525773196, 0.19230769230769232, 0.19230769230769232, 0.15789473684210525], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1925.0, 1925.0, 1935.0, 1935.0], \"y\": [0.0, 0.21818181818181817, 0.21818181818181817, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1896.25, 1896.25, 1930.0, 1930.0], \"y\": [0.19230769230769232, 0.24561403508771928, 0.24561403508771928, 0.21818181818181817], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1945.0, 1945.0, 1955.0, 1955.0], \"y\": [0.0, 0.1504424778761062, 0.1504424778761062, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"y\": [0.0, 0.16129032258064516, 0.16129032258064516, 0.0], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"y\": [0.0, 0.2222222222222222, 0.2222222222222222, 0.16129032258064516], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1950.0, 1950.0, 1972.5, 1972.5], \"y\": [0.1504424778761062, 0.26, 0.26, 0.2222222222222222], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1913.125, 1913.125, 1961.25, 1961.25], \"y\": [0.24561403508771928, 0.2830188679245283, 0.2830188679245283, 0.26], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1865.0, 1865.0, 1937.1875, 1937.1875], \"y\": [0.0, 0.3142857142857143, 0.3142857142857143, 0.2830188679245283], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1855.0, 1855.0, 1901.09375, 1901.09375], \"y\": [0.0, 0.3786407766990291, 0.3786407766990291, 0.3142857142857143], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1845.0, 1845.0, 1878.046875, 1878.046875], \"y\": [0.0, 0.4956521739130435, 0.4956521739130435, 0.3786407766990291], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1835.0, 1835.0, 1861.5234375, 1861.5234375], \"y\": [0.0, 0.635036496350365, 0.635036496350365, 0.4956521739130435], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1752.8125, 1752.8125, 1848.26171875, 1848.26171875], \"y\": [0.6346153846153846, 0.7281553398058253, 0.7281553398058253, 0.635036496350365], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1694.375, 1694.375, 1800.537109375, 1800.537109375], \"y\": [0.6036036036036037, 0.8117647058823529, 0.8117647058823529, 0.7281553398058253], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [1585.390625, 1585.390625, 1747.4560546875, 1747.4560546875], \"y\": [0.7912087912087912, 0.9304347826086956, 0.9304347826086956, 0.8117647058823529], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}, {\"type\": \"scatter\", \"x\": [833.6627197265625, 833.6627197265625, 1666.42333984375, 1666.42333984375], \"y\": [0.8205128205128205, 0.9885057471264368, 0.9885057471264368, 0.9304347826086956], \"mode\": \"lines\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"text\": null, \"hoverinfo\": \"all\", \"xaxis\": \"x\", \"yaxis\": \"y\"}], {\"xaxis\": {\"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0], \"ticktext\": [\"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001814_209.15335_478.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001816_209.15341_296.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17426_497.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001814_215.16406_483.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_222.07031_314.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001815_194.11745_132.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001814_194.1174_217.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001814_229.15451_65.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001816_247.12863_162.0\", \"QE_2017_001815_260.16016_140.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001815_233.14944_150.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04474_327.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001815_182.08109_52.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001814_199.98772_303.0\", \"QE_2017_001815_199.98772_253.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_265.01532_33.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001815_237.12315_52.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001815_219.10146_381.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001814_171.14908_419.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001814_129.12737_348.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001814_332.25842_486.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001815_291.14493_242.0\", \"QE_2017_001814_251.13872_201.0\", \"QE_2017_001815_235.14388_180.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001815_319.13623_118.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001815_241.15437_67.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001814_364.34241_751.0\", \"QE_2017_001814_424.36325_711.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001814_421.35211_732.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001814_408.3681_703.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001816_611.16064_309.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_231.04967_404.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001814_599.40918_659.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001815_792.5625_866.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001814_792.56207_723.0\", \"QE_2017_001815_613.4826_734.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_278.24756_683.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001815_571.47168_711.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\"], \"tickmode\": \"array\", \"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"sample\"}, \"yaxis\": {\"type\": \"linear\", \"ticks\": \"outside\", \"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showticklabels\": true, \"zeroline\": false, \"showgrid\": false, \"showline\": true, \"title\": \"distance\"}, \"showlegend\": false, \"autosize\": false, \"hovermode\": \"closest\", \"width\": 900, \"height\": 500, \"title\": \"BioDendro\"}, {\"showLink\": true, \"linkText\": \"Export to plot.ly\"})});</script>"
+       "<div>\n",
+       "        \n",
+       "        \n",
+       "            <div id=\"a24d765d-166e-4847-b3a9-be5331ccd82f\" class=\"plotly-graph-div\"></div>\n",
+       "            <script type=\"text/javascript\">\n",
+       "                require([\"plotly\"], function(Plotly) {\n",
+       "                    window.PLOTLYENV=window.PLOTLYENV || {};\n",
+       "                    window.PLOTLYENV.BASE_URL='https://plot.ly';\n",
+       "                    \n",
+       "                if (document.getElementById(\"a24d765d-166e-4847-b3a9-be5331ccd82f\")) {\n",
+       "                    Plotly.newPlot(\n",
+       "                        'a24d765d-166e-4847-b3a9-be5331ccd82f',\n",
+       "                        [{\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 1, component: QE_2017_001816_613.48218_838.0\", \"cluster: 1, component: QE_2017_001816_613.48218_838.0\", \"cluster: 1, component: QE_2017_001816_792.56232_718.0\", \"cluster: 1, component: QE_2017_001816_792.56232_718.0\"], \"type\": \"scatter\", \"uid\": \"e04707f1-3f18-4676-9efc-d8f46e7ef473\", \"x\": [15.0, 15.0, 25.0, 25.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3949579831932773, 0.3949579831932773, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 1, component: QE_2017_001816_613.4826_738.0\", \"cluster: 1, component: QE_2017_001816_613.4826_738.0\", null, null], \"type\": \"scatter\", \"uid\": \"6558c380-4225-41a3-b0be-4b1a547a2e5a\", \"x\": [5.0, 5.0, 20.0, 20.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5116279069767442, 0.5116279069767442, 0.3949579831932773], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 1, component: QE_2017_001814_596.30963_602.0\", \"cluster: 1, component: QE_2017_001814_596.30963_602.0\", \"cluster: 1, component: QE_2017_001815_792.5625_866.0\", \"cluster: 1, component: QE_2017_001815_792.5625_866.0\"], \"type\": \"scatter\", \"uid\": \"aad9ad25-6ecb-415e-8548-eb45d107054a\", \"x\": [35.0, 35.0, 45.0, 45.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5555555555555556, 0.5555555555555556, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"014b7330-9c00-4833-a25a-2fa3e9e979e1\", \"x\": [12.5, 12.5, 40.0, 40.0], \"xaxis\": \"x\", \"y\": [0.5116279069767442, 0.6344086021505376, 0.6344086021505376, 0.5555555555555556], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_335.25784_608.0\", \"cluster: 2, component: QE_2017_001814_335.25784_608.0\", \"cluster: 2, component: QE_2017_001816_335.25772_723.0\", \"cluster: 2, component: QE_2017_001816_335.25772_723.0\"], \"type\": \"scatter\", \"uid\": \"0f40f4fd-cc8e-49aa-aab9-c2385b7a62aa\", \"x\": [105.0, 105.0, 115.0, 115.0], \"xaxis\": \"x\", \"y\": [0.0, 0.14942528735632185, 0.14942528735632185, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_335.25772_725.0\", \"cluster: 2, component: QE_2017_001814_335.25772_725.0\", null, null], \"type\": \"scatter\", \"uid\": \"27209082-865f-4da1-a5c3-c424e84c542a\", \"x\": [95.0, 95.0, 110.0, 110.0], \"xaxis\": \"x\", \"y\": [0.0, 0.16483516483516483, 0.16483516483516483, 0.14942528735632185], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_335.25784_628.0\", \"cluster: 2, component: QE_2017_001814_335.25784_628.0\", \"cluster: 2, component: QE_2017_001815_335.25745_642.0\", \"cluster: 2, component: QE_2017_001815_335.25745_642.0\"], \"type\": \"scatter\", \"uid\": \"6519bffe-2987-4e20-803c-7772a7486043\", \"x\": [125.0, 125.0, 135.0, 135.0], \"xaxis\": \"x\", \"y\": [0.0, 0.16666666666666666, 0.16666666666666666, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6d21c5ff-06f6-4526-a7f6-1be5959f1399\", \"x\": [102.5, 102.5, 130.0, 130.0], \"xaxis\": \"x\", \"y\": [0.16483516483516483, 0.20408163265306123, 0.20408163265306123, 0.16666666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_261.22073_634.0\", \"cluster: 2, component: QE_2017_001814_261.22073_634.0\", \"cluster: 2, component: QE_2017_001815_335.25784_587.0\", \"cluster: 2, component: QE_2017_001815_335.25784_587.0\"], \"type\": \"scatter\", \"uid\": \"b1f6b835-1306-4b9c-9730-831c5e5119f6\", \"x\": [145.0, 145.0, 155.0, 155.0], \"xaxis\": \"x\", \"y\": [0.0, 0.23076923076923078, 0.23076923076923078, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"dbce6abf-82bd-440d-bfd2-5adaa5fc9c1f\", \"x\": [116.25, 116.25, 150.0, 150.0], \"xaxis\": \"x\", \"y\": [0.20408163265306123, 0.25925925925925924, 0.25925925925925924, 0.23076923076923078], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_353.26889_609.0\", \"cluster: 2, component: QE_2017_001814_353.26889_609.0\", \"cluster: 2, component: QE_2017_001815_353.26862_642.0\", \"cluster: 2, component: QE_2017_001815_353.26862_642.0\"], \"type\": \"scatter\", \"uid\": \"05abae0a-a83a-4dea-aa56-e79abdf8bdeb\", \"x\": [165.0, 165.0, 175.0, 175.0], \"xaxis\": \"x\", \"y\": [0.0, 0.1588785046728972, 0.1588785046728972, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_335.25772_638.0\", \"cluster: 2, component: QE_2017_001814_335.25772_638.0\", \"cluster: 2, component: QE_2017_001815_335.2579_601.0\", \"cluster: 2, component: QE_2017_001815_335.2579_601.0\"], \"type\": \"scatter\", \"uid\": \"132bcb70-b5d0-49e9-b3e1-ef123c45f0cb\", \"x\": [195.0, 195.0, 205.0, 205.0], \"xaxis\": \"x\", \"y\": [0.0, 0.1724137931034483, 0.1724137931034483, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001815_261.22073_643.0\", \"cluster: 2, component: QE_2017_001815_261.22073_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"c6d4111f-b1c3-4f39-9efc-115c3019ae41\", \"x\": [185.0, 185.0, 200.0, 200.0], \"xaxis\": \"x\", \"y\": [0.0, 0.23809523809523808, 0.23809523809523808, 0.1724137931034483], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"cbbd4956-1a4f-4556-8aa1-c22a243fecb2\", \"x\": [170.0, 170.0, 192.5, 192.5], \"xaxis\": \"x\", \"y\": [0.1588785046728972, 0.2765957446808511, 0.2765957446808511, 0.23809523809523808], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"60aa22fd-64da-4523-8ae1-74e4d6ba78b3\", \"x\": [133.125, 133.125, 181.25, 181.25], \"xaxis\": \"x\", \"y\": [0.25925925925925924, 0.3, 0.3, 0.2765957446808511], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001816_571.47186_717.0\", \"cluster: 2, component: QE_2017_001816_571.47186_717.0\", null, null], \"type\": \"scatter\", \"uid\": \"f85f341b-3d8b-4a50-96f6-3fef6f68a91c\", \"x\": [85.0, 85.0, 157.1875, 157.1875], \"xaxis\": \"x\", \"y\": [0.0, 0.3829787234042553, 0.3829787234042553, 0.3], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001815_507.27145_607.0\", \"cluster: 2, component: QE_2017_001815_507.27145_607.0\", null, null], \"type\": \"scatter\", \"uid\": \"2717bdf1-63b9-4b78-8ba5-1ebe12dacca8\", \"x\": [75.0, 75.0, 121.09375, 121.09375], \"xaxis\": \"x\", \"y\": [0.0, 0.40229885057471265, 0.40229885057471265, 0.3829787234042553], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_497.31033_643.0\", \"cluster: 2, component: QE_2017_001814_497.31033_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"785866f9-76fd-4dbb-a85f-f833cb8a8f76\", \"x\": [65.0, 65.0, 98.046875, 98.046875], \"xaxis\": \"x\", \"y\": [0.0, 0.5368421052631579, 0.5368421052631579, 0.40229885057471265], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001815_571.4292_870.0\", \"cluster: 2, component: QE_2017_001815_571.4292_870.0\", null, null], \"type\": \"scatter\", \"uid\": \"7219cb63-4af0-41f7-be9e-f6d523ba4a07\", \"x\": [55.0, 55.0, 81.5234375, 81.5234375], \"xaxis\": \"x\", \"y\": [0.0, 0.6615384615384615, 0.6615384615384615, 0.5368421052631579], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_338.34146_850.0\", \"cluster: 2, component: QE_2017_001814_338.34146_850.0\", \"cluster: 2, component: QE_2017_001815_244.19048_762.0\", \"cluster: 2, component: QE_2017_001815_244.19048_762.0\"], \"type\": \"scatter\", \"uid\": \"b7313768-6fa1-4c88-8b12-c146088c8c7f\", \"x\": [225.0, 225.0, 235.0, 235.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4318181818181818, 0.4318181818181818, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_353.26868_633.0\", \"cluster: 2, component: QE_2017_001814_353.26868_633.0\", \"cluster: 2, component: QE_2017_001816_353.26892_600.0\", \"cluster: 2, component: QE_2017_001816_353.26892_600.0\"], \"type\": \"scatter\", \"uid\": \"9d52cec0-0b3f-4744-8c76-122ca41de85b\", \"x\": [245.0, 245.0, 255.0, 255.0], \"xaxis\": \"x\", \"y\": [0.0, 0.1348314606741573, 0.1348314606741573, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001814_279.23157_719.0\", \"cluster: 2, component: QE_2017_001814_279.23157_719.0\", \"cluster: 2, component: QE_2017_001815_278.24762_684.0\", \"cluster: 2, component: QE_2017_001815_278.24762_684.0\"], \"type\": \"scatter\", \"uid\": \"35992feb-1d09-4ec8-8aa1-d16cc26682a6\", \"x\": [265.0, 265.0, 275.0, 275.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2755905511811024, 0.2755905511811024, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5ace4e25-b33f-44b1-af1a-98c4cfb5af69\", \"x\": [250.0, 250.0, 270.0, 270.0], \"xaxis\": \"x\", \"y\": [0.1348314606741573, 0.35403726708074534, 0.35403726708074534, 0.2755905511811024], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001816_337.27338_826.0\", \"cluster: 2, component: QE_2017_001816_337.27338_826.0\", \"cluster: 2, component: QE_2017_001816_337.27341_632.0\", \"cluster: 2, component: QE_2017_001816_337.27341_632.0\"], \"type\": \"scatter\", \"uid\": \"e9d3aa5e-561f-4bd8-8573-8ae000deeedd\", \"x\": [295.0, 295.0, 305.0, 305.0], \"xaxis\": \"x\", \"y\": [0.0, 0.22935779816513763, 0.22935779816513763, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001816_435.25037_666.0\", \"cluster: 2, component: QE_2017_001816_435.25037_666.0\", null, null], \"type\": \"scatter\", \"uid\": \"16dab24e-7c2d-4296-8e4a-5c5cc958c2bb\", \"x\": [285.0, 285.0, 300.0, 300.0], \"xaxis\": \"x\", \"y\": [0.0, 0.37142857142857144, 0.37142857142857144, 0.22935779816513763], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a0eb460f-61f4-4f41-bdce-4a650f72571e\", \"x\": [260.0, 260.0, 292.5, 292.5], \"xaxis\": \"x\", \"y\": [0.35403726708074534, 0.5238095238095238, 0.5238095238095238, 0.37142857142857144], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"10db7526-f410-423a-b208-d8bc60de44fa\", \"x\": [230.0, 230.0, 276.25, 276.25], \"xaxis\": \"x\", \"y\": [0.4318181818181818, 0.6116504854368932, 0.6116504854368932, 0.5238095238095238], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 2, component: QE_2017_001816_272.25824_582.0\", \"cluster: 2, component: QE_2017_001816_272.25824_582.0\", null, null], \"type\": \"scatter\", \"uid\": \"c3a3aa72-5cd3-47c2-863d-c67b72311a28\", \"x\": [215.0, 215.0, 253.125, 253.125], \"xaxis\": \"x\", \"y\": [0.0, 0.7011494252873564, 0.7011494252873564, 0.6116504854368932], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"73fc06af-f1ca-4f69-b5bb-40a693e7882f\", \"x\": [68.26171875, 68.26171875, 234.0625, 234.0625], \"xaxis\": \"x\", \"y\": [0.6615384615384615, 0.7699115044247787, 0.7699115044247787, 0.7011494252873564], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5b05f304-ff1e-423f-991f-f0a9308ed448\", \"x\": [26.25, 26.25, 151.162109375, 151.162109375], \"xaxis\": \"x\", \"y\": [0.6344086021505376, 0.84, 0.84, 0.7699115044247787], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 3, component: QE_2017_001814_601.42426_706.0\", \"cluster: 3, component: QE_2017_001814_601.42426_706.0\", \"cluster: 3, component: QE_2017_001816_599.40869_793.0\", \"cluster: 3, component: QE_2017_001816_599.40869_793.0\"], \"type\": \"scatter\", \"uid\": \"0832b7ab-b8b8-4d8a-8689-364e00060647\", \"x\": [345.0, 345.0, 355.0, 355.0], \"xaxis\": \"x\", \"y\": [0.0, 0.45985401459854014, 0.45985401459854014, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 3, component: QE_2017_001816_599.40948_660.0\", \"cluster: 3, component: QE_2017_001816_599.40948_660.0\", null, null], \"type\": \"scatter\", \"uid\": \"2cd16c3d-f127-4bfd-aa5f-c9c7a4501d2c\", \"x\": [335.0, 335.0, 350.0, 350.0], \"xaxis\": \"x\", \"y\": [0.0, 0.504950495049505, 0.504950495049505, 0.45985401459854014], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 3, component: QE_2017_001816_583.41382_731.0\", \"cluster: 3, component: QE_2017_001816_583.41382_731.0\", null, null], \"type\": \"scatter\", \"uid\": \"10b862d8-9148-4e23-b25c-74191e46f0f6\", \"x\": [325.0, 325.0, 342.5, 342.5], \"xaxis\": \"x\", \"y\": [0.0, 0.6101694915254238, 0.6101694915254238, 0.504950495049505], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 3, component: QE_2017_001814_618.42633_695.0\", \"cluster: 3, component: QE_2017_001814_618.42633_695.0\", null, null], \"type\": \"scatter\", \"uid\": \"35dd4f88-bd22-44cb-b9a0-5fc118bd5cae\", \"x\": [315.0, 315.0, 333.75, 333.75], \"xaxis\": \"x\", \"y\": [0.0, 0.6666666666666666, 0.6666666666666666, 0.6101694915254238], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 4, component: QE_2017_001815_618.42773_646.0\", \"cluster: 4, component: QE_2017_001815_618.42773_646.0\", \"cluster: 4, component: QE_2017_001816_618.427_682.0\", \"cluster: 4, component: QE_2017_001816_618.427_682.0\"], \"type\": \"scatter\", \"uid\": \"154d27d9-5f29-454d-a494-6bae18b5c64b\", \"x\": [365.0, 365.0, 375.0, 375.0], \"xaxis\": \"x\", \"y\": [0.0, 0.30997304582210244, 0.30997304582210244, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 4, component: QE_2017_001814_583.41406_682.0\", \"cluster: 4, component: QE_2017_001814_583.41406_682.0\", \"cluster: 4, component: QE_2017_001815_583.41406_707.0\", \"cluster: 4, component: QE_2017_001815_583.41406_707.0\"], \"type\": \"scatter\", \"uid\": \"37de30e7-99a2-49b3-8166-e293d7b6be41\", \"x\": [405.0, 405.0, 415.0, 415.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35877862595419846, 0.35877862595419846, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 4, component: QE_2017_001814_565.4035_722.0\", \"cluster: 4, component: QE_2017_001814_565.4035_722.0\", null, null], \"type\": \"scatter\", \"uid\": \"471c9401-8695-489c-a938-3efdefd55fb8\", \"x\": [395.0, 395.0, 410.0, 410.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4336283185840708, 0.4336283185840708, 0.35877862595419846], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 4, component: QE_2017_001815_583.41388_735.0\", \"cluster: 4, component: QE_2017_001815_583.41388_735.0\", \"cluster: 4, component: QE_2017_001815_583.41418_647.0\", \"cluster: 4, component: QE_2017_001815_583.41418_647.0\"], \"type\": \"scatter\", \"uid\": \"2432d844-c861-4610-b7a9-b04982545d0e\", \"x\": [435.0, 435.0, 445.0, 445.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3592233009708738, 0.3592233009708738, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 4, component: QE_2017_001814_601.42334_783.0\", \"cluster: 4, component: QE_2017_001814_601.42334_783.0\", null, null], \"type\": \"scatter\", \"uid\": \"d8978792-1612-4fe3-93bc-9e70ca92a32b\", \"x\": [425.0, 425.0, 440.0, 440.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5344827586206896, 0.5344827586206896, 0.3592233009708738], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"abadbb04-7d86-477e-bb77-cb3edd3b83d7\", \"x\": [402.5, 402.5, 432.5, 432.5], \"xaxis\": \"x\", \"y\": [0.4336283185840708, 0.5802469135802469, 0.5802469135802469, 0.5344827586206896], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 4, component: QE_2017_001815_568.42627_841.0\", \"cluster: 4, component: QE_2017_001815_568.42627_841.0\", null, null], \"type\": \"scatter\", \"uid\": \"84127564-95ca-41c0-9a94-f6c90ee0d6e2\", \"x\": [385.0, 385.0, 417.5, 417.5], \"xaxis\": \"x\", \"y\": [0.0, 0.618421052631579, 0.618421052631579, 0.5802469135802469], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"da49621e-ec03-454f-829c-3566f103cd7d\", \"x\": [370.0, 370.0, 401.25, 401.25], \"xaxis\": \"x\", \"y\": [0.30997304582210244, 0.6956521739130435, 0.6956521739130435, 0.618421052631579], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6e35c41c-091f-44bd-9d9d-2463ee7f00dd\", \"x\": [324.375, 324.375, 385.625, 385.625], \"xaxis\": \"x\", \"y\": [0.6666666666666666, 0.8867924528301887, 0.8867924528301887, 0.6956521739130435], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1996c47e-1c19-4555-9aab-a0f8464936c9\", \"x\": [88.7060546875, 88.7060546875, 355.0, 355.0], \"xaxis\": \"x\", \"y\": [0.84, 0.927710843373494, 0.927710843373494, 0.8867924528301887], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_194.04424_237.0\", \"cluster: 5, component: QE_2017_001814_194.04424_237.0\", \"cluster: 5, component: QE_2017_001815_194.11751_218.0\", \"cluster: 5, component: QE_2017_001815_194.11751_218.0\"], \"type\": \"scatter\", \"uid\": \"71606a38-f143-446e-882e-7dda588985f6\", \"x\": [455.0, 455.0, 465.0, 465.0], \"xaxis\": \"x\", \"y\": [0.0, 0.45, 0.45, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_194.04471_314.0\", \"cluster: 5, component: QE_2017_001815_194.04471_314.0\", \"cluster: 5, component: QE_2017_001815_212.05513_328.0\", \"cluster: 5, component: QE_2017_001815_212.05513_328.0\"], \"type\": \"scatter\", \"uid\": \"f6fbe8c4-7166-446e-8cb6-1893e461e195\", \"x\": [485.0, 485.0, 495.0, 495.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21311475409836064, 0.21311475409836064, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_194.04469_299.0\", \"cluster: 5, component: QE_2017_001815_194.04469_299.0\", null, null], \"type\": \"scatter\", \"uid\": \"f0b13481-9f02-4cf5-b0a8-5df6c3a12a53\", \"x\": [475.0, 475.0, 490.0, 490.0], \"xaxis\": \"x\", \"y\": [0.0, 0.38636363636363635, 0.38636363636363635, 0.21311475409836064], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001814_226.07077_397.0\", \"cluster: 5, component: QE_2017_001814_226.07077_397.0\", \"cluster: 5, component: QE_2017_001815_194.04471_397.0\", \"cluster: 5, component: QE_2017_001815_194.04471_397.0\"], \"type\": \"scatter\", \"uid\": \"6b8ab40c-181c-421f-9a77-59528b765db3\", \"x\": [515.0, 515.0, 525.0, 525.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4583333333333333, 0.4583333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 5, component: QE_2017_001815_212.05505_267.0\", \"cluster: 5, component: QE_2017_001815_212.05505_267.0\", null, null], \"type\": \"scatter\", \"uid\": \"2888255c-b2a6-45c4-81f7-dfff4123554e\", \"x\": [505.0, 505.0, 520.0, 520.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5384615384615384, 0.5384615384615384, 0.4583333333333333], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5b5b3051-51f3-4d31-808d-5170466c2f9f\", \"x\": [482.5, 482.5, 512.5, 512.5], \"xaxis\": \"x\", \"y\": [0.38636363636363635, 0.7183098591549296, 0.7183098591549296, 0.5384615384615384], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a41963dc-501e-4a70-b6ca-6edc687cc0de\", \"x\": [460.0, 460.0, 497.5, 497.5], \"xaxis\": \"x\", \"y\": [0.45, 0.7464788732394366, 0.7464788732394366, 0.7183098591549296], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 6, component: QE_2017_001816_533.15442_247.0\", \"cluster: 6, component: QE_2017_001816_533.15442_247.0\", \"cluster: 6, component: QE_2017_001816_533.15466_222.0\", \"cluster: 6, component: QE_2017_001816_533.15466_222.0\"], \"type\": \"scatter\", \"uid\": \"4d343c97-7d97-42e3-ac82-6692e860a54d\", \"x\": [535.0, 535.0, 545.0, 545.0], \"xaxis\": \"x\", \"y\": [0.0, 0.22522522522522523, 0.22522522522522523, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 6, component: QE_2017_001815_533.1546_207.0\", \"cluster: 6, component: QE_2017_001815_533.1546_207.0\", \"cluster: 6, component: QE_2017_001816_533.1546_271.0\", \"cluster: 6, component: QE_2017_001816_533.1546_271.0\"], \"type\": \"scatter\", \"uid\": \"6b5210d3-469e-4859-a67f-45847d29a811\", \"x\": [555.0, 555.0, 565.0, 565.0], \"xaxis\": \"x\", \"y\": [0.0, 0.29411764705882354, 0.29411764705882354, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3c187a42-1e91-4c21-831f-3f1c89d53c32\", \"x\": [540.0, 540.0, 560.0, 560.0], \"xaxis\": \"x\", \"y\": [0.22522522522522523, 0.3333333333333333, 0.3333333333333333, 0.29411764705882354], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 6, component: QE_2017_001814_347.09097_122.0\", \"cluster: 6, component: QE_2017_001814_347.09097_122.0\", \"cluster: 6, component: QE_2017_001815_347.09067_204.0\", \"cluster: 6, component: QE_2017_001815_347.09067_204.0\"], \"type\": \"scatter\", \"uid\": \"f7b58571-e099-4285-a135-e4480967e727\", \"x\": [575.0, 575.0, 585.0, 585.0], \"xaxis\": \"x\", \"y\": [0.0, 0.34210526315789475, 0.34210526315789475, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"295eaa6d-44ba-45b0-b632-910d64b65cac\", \"x\": [550.0, 550.0, 580.0, 580.0], \"xaxis\": \"x\", \"y\": [0.3333333333333333, 0.7864077669902912, 0.7864077669902912, 0.34210526315789475], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"55faf26c-d591-4acc-ba99-892aea5cb253\", \"x\": [478.75, 478.75, 565.0, 565.0], \"xaxis\": \"x\", \"y\": [0.7464788732394366, 0.971830985915493, 0.971830985915493, 0.7864077669902912], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 7, component: QE_2017_001815_268.10373_58.0\", \"cluster: 7, component: QE_2017_001815_268.10373_58.0\", \"cluster: 7, component: QE_2017_001816_269.16055_60.0\", \"cluster: 7, component: QE_2017_001816_269.16055_60.0\"], \"type\": \"scatter\", \"uid\": \"93cef3d7-fc52-4fa0-8bd0-c379502a1c88\", \"x\": [595.0, 595.0, 605.0, 605.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2692307692307692, 0.2692307692307692, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001816_408.36832_704.0\", \"cluster: 8, component: QE_2017_001816_408.36832_704.0\", \"cluster: 8, component: QE_2017_001816_466.40979_731.0\", \"cluster: 8, component: QE_2017_001816_466.40979_731.0\"], \"type\": \"scatter\", \"uid\": \"426baccf-5da9-4154-af50-531b296fbf86\", \"x\": [625.0, 625.0, 635.0, 635.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4166666666666667, 0.4166666666666667, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001815_364.34189_705.0\", \"cluster: 8, component: QE_2017_001815_364.34189_705.0\", null, null], \"type\": \"scatter\", \"uid\": \"68784238-fe87-48e9-a6c5-3898dcec8540\", \"x\": [615.0, 615.0, 630.0, 630.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5238095238095238, 0.5238095238095238, 0.4166666666666667], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001814_364.34244_761.0\", \"cluster: 8, component: QE_2017_001814_364.34244_761.0\", \"cluster: 8, component: QE_2017_001815_364.34253_752.0\", \"cluster: 8, component: QE_2017_001815_364.34253_752.0\"], \"type\": \"scatter\", \"uid\": \"09ac3ac6-5f04-4db1-a3dc-4f2bb1288dbf\", \"x\": [665.0, 665.0, 675.0, 675.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2222222222222222, 0.2222222222222222, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001816_421.35226_731.0\", \"cluster: 8, component: QE_2017_001816_421.35226_731.0\", \"cluster: 8, component: QE_2017_001816_424.36325_712.0\", \"cluster: 8, component: QE_2017_001816_424.36325_712.0\"], \"type\": \"scatter\", \"uid\": \"b3f6f255-d1b9-48f6-9b6f-edc5bab3e8a9\", \"x\": [685.0, 685.0, 695.0, 695.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2413793103448276, 0.2413793103448276, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"21a2bfe4-d98a-45d9-90d4-31783593d476\", \"x\": [670.0, 670.0, 690.0, 690.0], \"xaxis\": \"x\", \"y\": [0.2222222222222222, 0.44, 0.44, 0.2413793103448276], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001815_482.40488_739.0\", \"cluster: 8, component: QE_2017_001815_482.40488_739.0\", null, null], \"type\": \"scatter\", \"uid\": \"81c2021d-590a-49b8-afc8-33fb30fa8f4e\", \"x\": [655.0, 655.0, 680.0, 680.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5428571428571428, 0.5428571428571428, 0.44], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 8, component: QE_2017_001815_408.36853_717.0\", \"cluster: 8, component: QE_2017_001815_408.36853_717.0\", null, null], \"type\": \"scatter\", \"uid\": \"e546d39c-13e6-45ed-a5a7-5a0650486600\", \"x\": [645.0, 645.0, 667.5, 667.5], \"xaxis\": \"x\", \"y\": [0.0, 0.5757575757575758, 0.5757575757575758, 0.5428571428571428], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"5c71d496-c516-48b4-9ba8-b5f529dd8ae2\", \"x\": [622.5, 622.5, 656.25, 656.25], \"xaxis\": \"x\", \"y\": [0.5238095238095238, 0.7222222222222222, 0.7222222222222222, 0.5757575757575758], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"86a2b23b-2143-46ec-881b-b119205a0434\", \"x\": [600.0, 600.0, 639.375, 639.375], \"xaxis\": \"x\", \"y\": [0.2692307692307692, 0.9636363636363636, 0.9636363636363636, 0.7222222222222222], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 9, component: QE_2017_001814_611.15997_285.0\", \"cluster: 9, component: QE_2017_001814_611.15997_285.0\", \"cluster: 9, component: QE_2017_001815_611.16046_309.0\", \"cluster: 9, component: QE_2017_001815_611.16046_309.0\"], \"type\": \"scatter\", \"uid\": \"ea37224a-86d2-4750-b997-cbbed36e98ea\", \"x\": [715.0, 715.0, 725.0, 725.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2972972972972973, 0.2972972972972973, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_339.10742_366.0\", \"cluster: 10, component: QE_2017_001814_339.10742_366.0\", \"cluster: 10, component: QE_2017_001816_339.10733_298.0\", \"cluster: 10, component: QE_2017_001816_339.10733_298.0\"], \"type\": \"scatter\", \"uid\": \"f5d8d761-0a4a-491f-853f-0780122eb671\", \"x\": [735.0, 735.0, 745.0, 745.0], \"xaxis\": \"x\", \"y\": [0.0, 0.28205128205128205, 0.28205128205128205, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_231.04971_516.0\", \"cluster: 10, component: QE_2017_001814_231.04971_516.0\", \"cluster: 10, component: QE_2017_001815_231.04971_369.0\", \"cluster: 10, component: QE_2017_001815_231.04971_369.0\"], \"type\": \"scatter\", \"uid\": \"1b575683-6d71-4386-81a8-ce4652597d66\", \"x\": [795.0, 795.0, 805.0, 805.0], \"xaxis\": \"x\", \"y\": [0.0, 0.24324324324324326, 0.24324324324324326, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001815_231.04968_315.0\", \"cluster: 10, component: QE_2017_001815_231.04968_315.0\", null, null], \"type\": \"scatter\", \"uid\": \"1b37ab93-fe06-4c56-8381-a93c4df1deb8\", \"x\": [785.0, 785.0, 800.0, 800.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2571428571428571, 0.2571428571428571, 0.24324324324324326], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001815_231.04973_403.0\", \"cluster: 10, component: QE_2017_001815_231.04973_403.0\", null, null], \"type\": \"scatter\", \"uid\": \"cd1702cc-9848-45b8-96d7-2b3ad8d6eaa9\", \"x\": [775.0, 775.0, 792.5, 792.5], \"xaxis\": \"x\", \"y\": [0.0, 0.35135135135135137, 0.35135135135135137, 0.2571428571428571], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001815_340.16019_314.0\", \"cluster: 10, component: QE_2017_001815_340.16019_314.0\", null, null], \"type\": \"scatter\", \"uid\": \"3da87f05-2646-492f-8375-0d0fd039f82b\", \"x\": [765.0, 765.0, 783.75, 783.75], \"xaxis\": \"x\", \"y\": [0.0, 0.5272727272727272, 0.5272727272727272, 0.35135135135135137], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001815_314.14453_76.0\", \"cluster: 10, component: QE_2017_001815_314.14453_76.0\", \"cluster: 10, component: QE_2017_001816_314.14462_79.0\", \"cluster: 10, component: QE_2017_001816_314.14462_79.0\"], \"type\": \"scatter\", \"uid\": \"385fab74-e407-4599-99ea-01381c5c86cf\", \"x\": [815.0, 815.0, 825.0, 825.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2682926829268293, 0.2682926829268293, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001816_310.14957_134.0\", \"cluster: 10, component: QE_2017_001816_310.14957_134.0\", \"cluster: 10, component: QE_2017_001816_342.17584_257.0\", \"cluster: 10, component: QE_2017_001816_342.17584_257.0\"], \"type\": \"scatter\", \"uid\": \"cc1c600d-6c70-44f1-929f-d2aa2eac01a9\", \"x\": [835.0, 835.0, 845.0, 845.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5135135135135135, 0.5135135135135135, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7c6d720d-f78a-46ab-b03f-02f61d6ae3b3\", \"x\": [820.0, 820.0, 840.0, 840.0], \"xaxis\": \"x\", \"y\": [0.2682926829268293, 0.6, 0.6, 0.5135135135135135], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"bbfb30e4-e8f8-4054-ac42-58cf07402f9e\", \"x\": [774.375, 774.375, 830.0, 830.0], \"xaxis\": \"x\", \"y\": [0.5272727272727272, 0.6666666666666666, 0.6666666666666666, 0.6], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 10, component: QE_2017_001814_498.2543_475.0\", \"cluster: 10, component: QE_2017_001814_498.2543_475.0\", null, null], \"type\": \"scatter\", \"uid\": \"10452408-58c5-4108-b38b-4de4abda59e5\", \"x\": [755.0, 755.0, 802.1875, 802.1875], \"xaxis\": \"x\", \"y\": [0.0, 0.75, 0.75, 0.6666666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"91befb2c-3a7b-4c26-92e5-669bc09644a5\", \"x\": [740.0, 740.0, 778.59375, 778.59375], \"xaxis\": \"x\", \"y\": [0.28205128205128205, 0.7818181818181819, 0.7818181818181819, 0.75], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 11, component: QE_2017_001814_241.15466_73.0\", \"cluster: 11, component: QE_2017_001814_241.15466_73.0\", \"cluster: 12, component: QE_2017_001815_507.18192_178.0\", \"cluster: 12, component: QE_2017_001815_507.18192_178.0\"], \"type\": \"scatter\", \"uid\": \"b9e5ca11-b376-4c8c-9c4c-6fe41c690a75\", \"x\": [855.0, 855.0, 865.0, 865.0], \"xaxis\": \"x\", \"y\": [0.0, 0.84375, 0.84375, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f3531b63-dab8-420f-aed9-ae0bb5c510a6\", \"x\": [759.296875, 759.296875, 860.0, 860.0], \"xaxis\": \"x\", \"y\": [0.7818181818181819, 0.8695652173913043, 0.8695652173913043, 0.84375], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e1b8ed88-34a6-4f81-8998-71299ff20412\", \"x\": [720.0, 720.0, 809.6484375, 809.6484375], \"xaxis\": \"x\", \"y\": [0.2972972972972973, 0.9272727272727272, 0.9272727272727272, 0.8695652173913043], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 13, component: QE_2017_001816_463.12311_410.0\", \"cluster: 13, component: QE_2017_001816_463.12311_410.0\", null, null], \"type\": \"scatter\", \"uid\": \"e5dc36f8-d059-438d-a67d-0a1f737335f1\", \"x\": [705.0, 705.0, 764.82421875, 764.82421875], \"xaxis\": \"x\", \"y\": [0.0, 0.9411764705882353, 0.9411764705882353, 0.9272727272727272], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 14, component: QE_2017_001814_320.29456_577.0\", \"cluster: 14, component: QE_2017_001814_320.29456_577.0\", \"cluster: 14, component: QE_2017_001815_320.29471_563.0\", \"cluster: 14, component: QE_2017_001815_320.29471_563.0\"], \"type\": \"scatter\", \"uid\": \"784687a0-d4ff-4d81-9502-953ef35bf768\", \"x\": [895.0, 895.0, 905.0, 905.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21951219512195122, 0.21951219512195122, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 14, component: QE_2017_001816_338.26062_643.0\", \"cluster: 14, component: QE_2017_001816_338.26062_643.0\", null, null], \"type\": \"scatter\", \"uid\": \"d0665054-71f7-428a-bfd0-f5422900d864\", \"x\": [885.0, 885.0, 900.0, 900.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4444444444444444, 0.4444444444444444, 0.21951219512195122], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 14, component: QE_2017_001814_483.27118_651.0\", \"cluster: 14, component: QE_2017_001814_483.27118_651.0\", null, null], \"type\": \"scatter\", \"uid\": \"6e27bcc2-3086-4760-aba9-f8c28bac5303\", \"x\": [875.0, 875.0, 892.5, 892.5], \"xaxis\": \"x\", \"y\": [0.0, 0.76, 0.76, 0.4444444444444444], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 15, component: QE_2017_001815_129.12741_349.0\", \"cluster: 15, component: QE_2017_001815_129.12741_349.0\", \"cluster: 15, component: QE_2017_001815_171.14914_420.0\", \"cluster: 15, component: QE_2017_001815_171.14914_420.0\"], \"type\": \"scatter\", \"uid\": \"67bb6713-06f0-4409-942b-906e084c14a0\", \"x\": [915.0, 915.0, 925.0, 925.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7647058823529411, 0.7647058823529411, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"51631f81-97aa-4d7e-8a79-f554ce036776\", \"x\": [883.75, 883.75, 920.0, 920.0], \"xaxis\": \"x\", \"y\": [0.76, 0.8235294117647058, 0.8235294117647058, 0.7647058823529411], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_201.16367_442.0\", \"cluster: 16, component: QE_2017_001815_201.16367_442.0\", \"cluster: 16, component: QE_2017_001816_201.16362_435.0\", \"cluster: 16, component: QE_2017_001816_201.16362_435.0\"], \"type\": \"scatter\", \"uid\": \"987fa4dc-a000-4b25-b34f-e3cac074aa1c\", \"x\": [935.0, 935.0, 945.0, 945.0], \"xaxis\": \"x\", \"y\": [0.0, 0.31868131868131866, 0.31868131868131866, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_209.1535_312.0\", \"cluster: 16, component: QE_2017_001815_209.1535_312.0\", \"cluster: 16, component: QE_2017_001816_209.15344_311.0\", \"cluster: 16, component: QE_2017_001816_209.15344_311.0\"], \"type\": \"scatter\", \"uid\": \"e213a548-072a-4f77-8875-57c788c5dfa0\", \"x\": [975.0, 975.0, 985.0, 985.0], \"xaxis\": \"x\", \"y\": [0.0, 0.17073170731707318, 0.17073170731707318, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_209.15349_295.0\", \"cluster: 16, component: QE_2017_001815_209.15349_295.0\", null, null], \"type\": \"scatter\", \"uid\": \"330945c2-c71a-4155-892a-4ccc072cb24d\", \"x\": [965.0, 965.0, 980.0, 980.0], \"xaxis\": \"x\", \"y\": [0.0, 0.23728813559322035, 0.23728813559322035, 0.17073170731707318], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_209.15352_479.0\", \"cluster: 16, component: QE_2017_001815_209.15352_479.0\", null, null], \"type\": \"scatter\", \"uid\": \"669d4b58-a8c6-4cbe-b79e-2361207ab753\", \"x\": [955.0, 955.0, 972.5, 972.5], \"xaxis\": \"x\", \"y\": [0.0, 0.288135593220339, 0.288135593220339, 0.23728813559322035], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_243.15892_533.0\", \"cluster: 16, component: QE_2017_001814_243.15892_533.0\", \"cluster: 16, component: QE_2017_001814_281.1745_492.0\", \"cluster: 16, component: QE_2017_001814_281.1745_492.0\"], \"type\": \"scatter\", \"uid\": \"ef5a2a57-be67-40d4-98cd-31c466c8fc03\", \"x\": [995.0, 995.0, 1005.0, 1005.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21904761904761905, 0.21904761904761905, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_227.16408_344.0\", \"cluster: 16, component: QE_2017_001815_227.16408_344.0\", \"cluster: 16, component: QE_2017_001815_283.19009_564.0\", \"cluster: 16, component: QE_2017_001815_283.19009_564.0\"], \"type\": \"scatter\", \"uid\": \"04877542-72ee-412f-84a3-d93ca0cde15c\", \"x\": [1025.0, 1025.0, 1035.0, 1035.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3088235294117647, 0.3088235294117647, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_293.2106_579.0\", \"cluster: 16, component: QE_2017_001814_293.2106_579.0\", null, null], \"type\": \"scatter\", \"uid\": \"c3f1b1ed-8c39-44b1-b9dd-f8014907bcbb\", \"x\": [1015.0, 1015.0, 1030.0, 1030.0], \"xaxis\": \"x\", \"y\": [0.0, 0.375, 0.375, 0.3088235294117647], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6b73a96d-2cea-459a-921c-19ed17b579cd\", \"x\": [1000.0, 1000.0, 1022.5, 1022.5], \"xaxis\": \"x\", \"y\": [0.21904761904761905, 0.42857142857142855, 0.42857142857142855, 0.375], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"61695574-eca4-4164-9eac-6dc73109b0dd\", \"x\": [963.75, 963.75, 1011.25, 1011.25], \"xaxis\": \"x\", \"y\": [0.288135593220339, 0.48091603053435117, 0.48091603053435117, 0.42857142857142855], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_227.1275_293.0\", \"cluster: 16, component: QE_2017_001814_227.1275_293.0\", \"cluster: 16, component: QE_2017_001816_227.12766_295.0\", \"cluster: 16, component: QE_2017_001816_227.12766_295.0\"], \"type\": \"scatter\", \"uid\": \"1fcd0555-3389-44f6-b4af-965bf571fb35\", \"x\": [1055.0, 1055.0, 1065.0, 1065.0], \"xaxis\": \"x\", \"y\": [0.0, 0.20353982300884957, 0.20353982300884957, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_207.13785_297.0\", \"cluster: 16, component: QE_2017_001815_207.13785_297.0\", null, null], \"type\": \"scatter\", \"uid\": \"5e617208-b1e7-4b7d-8753-d20cf7f641c8\", \"x\": [1045.0, 1045.0, 1060.0, 1060.0], \"xaxis\": \"x\", \"y\": [0.0, 0.504950495049505, 0.504950495049505, 0.20353982300884957], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8e1f309f-f78c-404e-8275-35949c5a70be\", \"x\": [987.5, 987.5, 1052.5, 1052.5], \"xaxis\": \"x\", \"y\": [0.48091603053435117, 0.5454545454545454, 0.5454545454545454, 0.504950495049505], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_181.1221_767.0\", \"cluster: 16, component: QE_2017_001815_181.1221_767.0\", \"cluster: 16, component: QE_2017_001816_181.12199_794.0\", \"cluster: 16, component: QE_2017_001816_181.12199_794.0\"], \"type\": \"scatter\", \"uid\": \"73ae093b-09e2-4b25-8390-d1f727579258\", \"x\": [1075.0, 1075.0, 1085.0, 1085.0], \"xaxis\": \"x\", \"y\": [0.0, 0.16666666666666666, 0.16666666666666666, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_211.16902_440.0\", \"cluster: 16, component: QE_2017_001814_211.16902_440.0\", \"cluster: 16, component: QE_2017_001815_211.16913_450.0\", \"cluster: 16, component: QE_2017_001815_211.16913_450.0\"], \"type\": \"scatter\", \"uid\": \"edde9605-e68f-4896-ab17-38e355b3370f\", \"x\": [1115.0, 1115.0, 1125.0, 1125.0], \"xaxis\": \"x\", \"y\": [0.0, 0.10638297872340426, 0.10638297872340426, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_209.0807_405.0\", \"cluster: 16, component: QE_2017_001815_209.0807_405.0\", null, null], \"type\": \"scatter\", \"uid\": \"7abba628-7c24-4df8-835a-fba36970d3e3\", \"x\": [1105.0, 1105.0, 1120.0, 1120.0], \"xaxis\": \"x\", \"y\": [0.0, 0.11827956989247312, 0.11827956989247312, 0.10638297872340426], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001816_211.16916_405.0\", \"cluster: 16, component: QE_2017_001816_211.16916_405.0\", null, null], \"type\": \"scatter\", \"uid\": \"d7d51e47-d6b5-4dbd-ac21-c8d329170490\", \"x\": [1095.0, 1095.0, 1112.5, 1112.5], \"xaxis\": \"x\", \"y\": [0.0, 0.17647058823529413, 0.17647058823529413, 0.11827956989247312], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_215.164_550.0\", \"cluster: 16, component: QE_2017_001815_215.164_550.0\", \"cluster: 16, component: QE_2017_001816_215.16411_482.0\", \"cluster: 16, component: QE_2017_001816_215.16411_482.0\"], \"type\": \"scatter\", \"uid\": \"f8fb8182-8adc-4bbf-9c3d-60115b2596cf\", \"x\": [1135.0, 1135.0, 1145.0, 1145.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3220338983050847, 0.3220338983050847, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ff33afe5-f082-4c83-83f6-36ba832eb9ae\", \"x\": [1103.75, 1103.75, 1140.0, 1140.0], \"xaxis\": \"x\", \"y\": [0.17647058823529413, 0.41025641025641024, 0.41025641025641024, 0.3220338983050847], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7df0cbf5-d5f8-43db-869a-c159547350e5\", \"x\": [1080.0, 1080.0, 1121.875, 1121.875], \"xaxis\": \"x\", \"y\": [0.16666666666666666, 0.5932203389830508, 0.5932203389830508, 0.41025641025641024], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"45f251ee-690f-4587-a11d-96300feff807\", \"x\": [1020.0, 1020.0, 1100.9375, 1100.9375], \"xaxis\": \"x\", \"y\": [0.5454545454545454, 0.6170212765957447, 0.6170212765957447, 0.5932203389830508], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_219.17416_517.0\", \"cluster: 16, component: QE_2017_001814_219.17416_517.0\", \"cluster: 16, component: QE_2017_001815_219.17421_516.0\", \"cluster: 16, component: QE_2017_001815_219.17421_516.0\"], \"type\": \"scatter\", \"uid\": \"a94f4d79-b5d0-49b2-b8e8-1c0d24fea1fa\", \"x\": [1165.0, 1165.0, 1175.0, 1175.0], \"xaxis\": \"x\", \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_219.17401_452.0\", \"cluster: 16, component: QE_2017_001814_219.17401_452.0\", \"cluster: 16, component: QE_2017_001814_219.17409_442.0\", \"cluster: 16, component: QE_2017_001814_219.17409_442.0\"], \"type\": \"scatter\", \"uid\": \"306d4d62-9e84-4e4b-aa97-050b0d19b3ff\", \"x\": [1195.0, 1195.0, 1205.0, 1205.0], \"xaxis\": \"x\", \"y\": [0.0, 0.18518518518518517, 0.18518518518518517, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001816_219.17438_502.0\", \"cluster: 16, component: QE_2017_001816_219.17438_502.0\", null, null], \"type\": \"scatter\", \"uid\": \"a6605237-a2fa-4dae-95b1-4dab6a20d842\", \"x\": [1185.0, 1185.0, 1200.0, 1200.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2558139534883721, 0.2558139534883721, 0.18518518518518517], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"708ba157-6531-431c-bb56-1bc796f4c342\", \"x\": [1170.0, 1170.0, 1192.5, 1192.5], \"xaxis\": \"x\", \"y\": [0.14285714285714285, 0.2972972972972973, 0.2972972972972973, 0.2558139534883721], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001815_191.14287_312.0\", \"cluster: 16, component: QE_2017_001815_191.14287_312.0\", \"cluster: 16, component: QE_2017_001816_191.14291_404.0\", \"cluster: 16, component: QE_2017_001816_191.14291_404.0\"], \"type\": \"scatter\", \"uid\": \"307e234b-17d9-4fce-9566-753f0d5cab95\", \"x\": [1225.0, 1225.0, 1235.0, 1235.0], \"xaxis\": \"x\", \"y\": [0.0, 0.27472527472527475, 0.27472527472527475, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001814_191.14291_389.0\", \"cluster: 16, component: QE_2017_001814_191.14291_389.0\", null, null], \"type\": \"scatter\", \"uid\": \"9fdb3c4b-59c9-434f-a142-f5f770308fd9\", \"x\": [1215.0, 1215.0, 1230.0, 1230.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.27472527472527475], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"c039fc70-3b06-4ad8-8446-692bd3e88946\", \"x\": [1181.25, 1181.25, 1222.5, 1222.5], \"xaxis\": \"x\", \"y\": [0.2972972972972973, 0.5151515151515151, 0.5151515151515151, 0.3333333333333333], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 16, component: QE_2017_001816_137.09584_445.0\", \"cluster: 16, component: QE_2017_001816_137.09584_445.0\", null, null], \"type\": \"scatter\", \"uid\": \"f301875b-67f2-4d28-a87f-df5d8b3de19e\", \"x\": [1155.0, 1155.0, 1201.875, 1201.875], \"xaxis\": \"x\", \"y\": [0.0, 0.6428571428571429, 0.6428571428571429, 0.5151515151515151], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"44ecc761-68d0-4b5c-bbab-172060acc2f1\", \"x\": [1060.46875, 1060.46875, 1178.4375, 1178.4375], \"xaxis\": \"x\", \"y\": [0.6170212765957447, 0.6907216494845361, 0.6907216494845361, 0.6428571428571429], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"55f9d169-786e-44d4-a6ee-2c8343b5e7df\", \"x\": [940.0, 940.0, 1119.453125, 1119.453125], \"xaxis\": \"x\", \"y\": [0.31868131868131866, 0.7272727272727273, 0.7272727272727273, 0.6907216494845361], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 17, component: QE_2017_001814_209.08058_363.0\", \"cluster: 17, component: QE_2017_001814_209.08058_363.0\", \"cluster: 17, component: QE_2017_001816_207.13779_561.0\", \"cluster: 17, component: QE_2017_001816_207.13779_561.0\"], \"type\": \"scatter\", \"uid\": \"f1697a3c-044b-4e59-9009-618747f023f3\", \"x\": [1245.0, 1245.0, 1255.0, 1255.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7477477477477478, 0.7477477477477478, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e4e62308-1232-42ab-a4ad-28aacae9342c\", \"x\": [1029.7265625, 1029.7265625, 1250.0, 1250.0], \"xaxis\": \"x\", \"y\": [0.7272727272727273, 0.8409090909090909, 0.8409090909090909, 0.7477477477477478], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"7f625b9d-b78c-43c9-ae3a-85b90129fae5\", \"x\": [901.875, 901.875, 1139.86328125, 1139.86328125], \"xaxis\": \"x\", \"y\": [0.8235294117647058, 0.9767441860465116, 0.9767441860465116, 0.8409090909090909], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 18, component: QE_2017_001815_333.15173_245.0\", \"cluster: 18, component: QE_2017_001815_333.15173_245.0\", \"cluster: 18, component: QE_2017_001816_333.15204_235.0\", \"cluster: 18, component: QE_2017_001816_333.15204_235.0\"], \"type\": \"scatter\", \"uid\": \"166feacc-5097-45e8-961a-497b54a837ec\", \"x\": [1265.0, 1265.0, 1275.0, 1275.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7333333333333333, 0.7333333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 19, component: QE_2017_001814_194.1174_244.0\", \"cluster: 19, component: QE_2017_001814_194.1174_244.0\", \"cluster: 19, component: QE_2017_001816_194.11746_133.0\", \"cluster: 19, component: QE_2017_001816_194.11746_133.0\"], \"type\": \"scatter\", \"uid\": \"c5d8228d-6f81-47cc-9bdc-f19691aa4201\", \"x\": [1285.0, 1285.0, 1295.0, 1295.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5555555555555556, 0.5555555555555556, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 20, component: QE_2017_001814_320.29471_529.0\", \"cluster: 20, component: QE_2017_001814_320.29471_529.0\", \"cluster: 20, component: QE_2017_001815_320.29486_538.0\", \"cluster: 20, component: QE_2017_001815_320.29486_538.0\"], \"type\": \"scatter\", \"uid\": \"22ad41b7-d860-4cc5-8f16-0622cf8be154\", \"x\": [1335.0, 1335.0, 1345.0, 1345.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2857142857142857, 0.2857142857142857, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 20, component: QE_2017_001814_320.29477_539.0\", \"cluster: 20, component: QE_2017_001814_320.29477_539.0\", null, null], \"type\": \"scatter\", \"uid\": \"b86fe40c-8e89-41eb-bb3e-3eb1fdbaddb1\", \"x\": [1325.0, 1325.0, 1340.0, 1340.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4117647058823529, 0.4117647058823529, 0.2857142857142857], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 20, component: QE_2017_001814_320.29468_638.0\", \"cluster: 20, component: QE_2017_001814_320.29468_638.0\", null, null], \"type\": \"scatter\", \"uid\": \"8c912d4a-afa1-45cd-96d8-ab016059f6cd\", \"x\": [1315.0, 1315.0, 1332.5, 1332.5], \"xaxis\": \"x\", \"y\": [0.0, 0.6470588235294118, 0.6470588235294118, 0.4117647058823529], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 21, component: QE_2017_001816_320.29483_548.0\", \"cluster: 21, component: QE_2017_001816_320.29483_548.0\", null, null], \"type\": \"scatter\", \"uid\": \"b2dce56c-3b2d-4f1b-918f-7a2e31252d62\", \"x\": [1305.0, 1305.0, 1323.75, 1323.75], \"xaxis\": \"x\", \"y\": [0.0, 0.8857142857142857, 0.8857142857142857, 0.6470588235294118], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"1f3d432a-5f9e-417d-bab9-70ed95a1294a\", \"x\": [1290.0, 1290.0, 1314.375, 1314.375], \"xaxis\": \"x\", \"y\": [0.5555555555555556, 0.9090909090909091, 0.9090909090909091, 0.8857142857142857], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 22, component: QE_2017_001814_241.15384_47.0\", \"cluster: 22, component: QE_2017_001814_241.15384_47.0\", \"cluster: 22, component: QE_2017_001814_241.15446_57.0\", \"cluster: 22, component: QE_2017_001814_241.15446_57.0\"], \"type\": \"scatter\", \"uid\": \"812435a0-b6fb-4fb3-8aef-c79ddef3e742\", \"x\": [1355.0, 1355.0, 1365.0, 1365.0], \"xaxis\": \"x\", \"y\": [0.0, 0.4666666666666667, 0.4666666666666667, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 23, component: QE_2017_001815_332.25827_508.0\", \"cluster: 23, component: QE_2017_001815_332.25827_508.0\", \"cluster: 23, component: QE_2017_001816_332.25842_487.0\", \"cluster: 23, component: QE_2017_001816_332.25842_487.0\"], \"type\": \"scatter\", \"uid\": \"12109328-94f5-451d-b784-32a8d9cdd5e8\", \"x\": [1385.0, 1385.0, 1395.0, 1395.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5185185185185185, 0.5185185185185185, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 23, component: QE_2017_001814_332.25827_467.0\", \"cluster: 23, component: QE_2017_001814_332.25827_467.0\", null, null], \"type\": \"scatter\", \"uid\": \"a96b6692-c8a6-4287-8a8c-51923e6610cb\", \"x\": [1375.0, 1375.0, 1390.0, 1390.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6666666666666666, 0.6666666666666666, 0.5185185185185185], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"67779036-1231-401c-8b6a-1a13a6f0d408\", \"x\": [1360.0, 1360.0, 1382.5, 1382.5], \"xaxis\": \"x\", \"y\": [0.4666666666666667, 0.9354838709677419, 0.9354838709677419, 0.6666666666666666], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"b716ec19-a486-42ee-a33c-f3352abf0f04\", \"x\": [1302.1875, 1302.1875, 1371.25, 1371.25], \"xaxis\": \"x\", \"y\": [0.9090909090909091, 0.9555555555555556, 0.9555555555555556, 0.9354838709677419], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 24, component: QE_2017_001814_319.13638_117.0\", \"cluster: 24, component: QE_2017_001814_319.13638_117.0\", \"cluster: 24, component: QE_2017_001816_319.13614_143.0\", \"cluster: 24, component: QE_2017_001816_319.13614_143.0\"], \"type\": \"scatter\", \"uid\": \"d9adfd95-8856-4970-8271-52b33374fc23\", \"x\": [1405.0, 1405.0, 1415.0, 1415.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6, 0.6, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 25, component: QE_2017_001815_219.10139_360.0\", \"cluster: 25, component: QE_2017_001815_219.10139_360.0\", \"cluster: 25, component: QE_2017_001816_219.10153_382.0\", \"cluster: 25, component: QE_2017_001816_219.10153_382.0\"], \"type\": \"scatter\", \"uid\": \"4a351707-33db-44e3-835b-af980731e020\", \"x\": [1445.0, 1445.0, 1455.0, 1455.0], \"xaxis\": \"x\", \"y\": [0.0, 0.23595505617977527, 0.23595505617977527, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 25, component: QE_2017_001815_219.10159_438.0\", \"cluster: 25, component: QE_2017_001815_219.10159_438.0\", null, null], \"type\": \"scatter\", \"uid\": \"fba9f679-6593-4971-b6d1-211fcdf860ee\", \"x\": [1435.0, 1435.0, 1450.0, 1450.0], \"xaxis\": \"x\", \"y\": [0.0, 0.30275229357798167, 0.30275229357798167, 0.23595505617977527], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 25, component: QE_2017_001814_251.09117_393.0\", \"cluster: 25, component: QE_2017_001814_251.09117_393.0\", null, null], \"type\": \"scatter\", \"uid\": \"44a30475-05d4-42ca-8180-142e3c30d1f4\", \"x\": [1425.0, 1425.0, 1442.5, 1442.5], \"xaxis\": \"x\", \"y\": [0.0, 0.4845360824742268, 0.4845360824742268, 0.30275229357798167], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001814_291.1442_241.0\", \"cluster: 26, component: QE_2017_001814_291.1442_241.0\", \"cluster: 26, component: QE_2017_001816_291.14493_243.0\", \"cluster: 26, component: QE_2017_001816_291.14493_243.0\"], \"type\": \"scatter\", \"uid\": \"dcdf7260-6eb5-4d85-8349-76525ba815d5\", \"x\": [1465.0, 1465.0, 1475.0, 1475.0], \"xaxis\": \"x\", \"y\": [0.0, 0.22727272727272727, 0.22727272727272727, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001815_273.13425_199.0\", \"cluster: 26, component: QE_2017_001815_273.13425_199.0\", \"cluster: 26, component: QE_2017_001815_273.13434_243.0\", \"cluster: 26, component: QE_2017_001815_273.13434_243.0\"], \"type\": \"scatter\", \"uid\": \"51f3396d-5b5f-4604-acb8-52604b8e377a\", \"x\": [1495.0, 1495.0, 1505.0, 1505.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2, 0.2, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 26, component: QE_2017_001816_291.14499_200.0\", \"cluster: 26, component: QE_2017_001816_291.14499_200.0\", null, null], \"type\": \"scatter\", \"uid\": \"7a03f29f-27b7-467d-af6b-6ba7c8154c92\", \"x\": [1485.0, 1485.0, 1500.0, 1500.0], \"xaxis\": \"x\", \"y\": [0.0, 0.2653061224489796, 0.2653061224489796, 0.2], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"88d1a695-ef31-4a3f-bbaf-433b8aaaad38\", \"x\": [1470.0, 1470.0, 1492.5, 1492.5], \"xaxis\": \"x\", \"y\": [0.22727272727272727, 0.34782608695652173, 0.34782608695652173, 0.2653061224489796], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 27, component: QE_2017_001815_235.14398_226.0\", \"cluster: 27, component: QE_2017_001815_235.14398_226.0\", \"cluster: 27, component: QE_2017_001816_235.14397_183.0\", \"cluster: 27, component: QE_2017_001816_235.14397_183.0\"], \"type\": \"scatter\", \"uid\": \"b90bf199-47ec-4aed-a00b-67e42de44a6f\", \"x\": [1525.0, 1525.0, 1535.0, 1535.0], \"xaxis\": \"x\", \"y\": [0.0, 0.35714285714285715, 0.35714285714285715, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 27, component: QE_2017_001815_251.13873_202.0\", \"cluster: 27, component: QE_2017_001815_251.13873_202.0\", null, null], \"type\": \"scatter\", \"uid\": \"a8ec98b9-0d17-4c48-97fe-699c277b5c20\", \"x\": [1515.0, 1515.0, 1530.0, 1530.0], \"xaxis\": \"x\", \"y\": [0.0, 0.76, 0.76, 0.35714285714285715], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"cf929561-0601-4004-92be-a32d884aea74\", \"x\": [1481.25, 1481.25, 1522.5, 1522.5], \"xaxis\": \"x\", \"y\": [0.34782608695652173, 0.8461538461538461, 0.8461538461538461, 0.76], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8e512295-43e9-483a-b7fe-6f3322b4c231\", \"x\": [1433.75, 1433.75, 1501.875, 1501.875], \"xaxis\": \"x\", \"y\": [0.4845360824742268, 0.978494623655914, 0.978494623655914, 0.8461538461538461], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 28, component: QE_2017_001814_250.10149_516.0\", \"cluster: 28, component: QE_2017_001814_250.10149_516.0\", \"cluster: 28, component: QE_2017_001815_222.07033_315.0\", \"cluster: 28, component: QE_2017_001815_222.07033_315.0\"], \"type\": \"scatter\", \"uid\": \"d5c542e9-2c57-468c-963b-a00c9f11fadb\", \"x\": [1565.0, 1565.0, 1575.0, 1575.0], \"xaxis\": \"x\", \"y\": [0.0, 0.34065934065934067, 0.34065934065934067, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 28, component: QE_2017_001816_268.59351_445.0\", \"cluster: 28, component: QE_2017_001816_268.59351_445.0\", null, null], \"type\": \"scatter\", \"uid\": \"86cf6ecd-b98d-4875-b0f6-d32cc6708230\", \"x\": [1555.0, 1555.0, 1570.0, 1570.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5294117647058824, 0.5294117647058824, 0.34065934065934067], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 29, component: QE_2017_001814_247.05975_245.0\", \"cluster: 29, component: QE_2017_001814_247.05975_245.0\", \"cluster: 29, component: QE_2017_001815_247.0598_242.0\", \"cluster: 29, component: QE_2017_001815_247.0598_242.0\"], \"type\": \"scatter\", \"uid\": \"e4ac8d20-9113-43d9-9897-8248ffeb8940\", \"x\": [1585.0, 1585.0, 1595.0, 1595.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21428571428571427, 0.21428571428571427, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 29, component: QE_2017_001815_212.03883_181.0\", \"cluster: 29, component: QE_2017_001815_212.03883_181.0\", \"cluster: 29, component: QE_2017_001815_214.56488_409.0\", \"cluster: 29, component: QE_2017_001815_214.56488_409.0\"], \"type\": \"scatter\", \"uid\": \"ae1d0d93-d944-48db-aa28-513d9222b872\", \"x\": [1615.0, 1615.0, 1625.0, 1625.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6363636363636364, 0.6363636363636364, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 29, component: QE_2017_001816_219.04672_291.0\", \"cluster: 29, component: QE_2017_001816_219.04672_291.0\", null, null], \"type\": \"scatter\", \"uid\": \"efef8592-4aa2-4f8c-a0da-ff42327243b5\", \"x\": [1605.0, 1605.0, 1620.0, 1620.0], \"xaxis\": \"x\", \"y\": [0.0, 0.6842105263157895, 0.6842105263157895, 0.6363636363636364], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ac4816c6-4bca-4607-882c-24e3ae1d4464\", \"x\": [1590.0, 1590.0, 1612.5, 1612.5], \"xaxis\": \"x\", \"y\": [0.21428571428571427, 0.75, 0.75, 0.6842105263157895], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"2a3ea756-cea3-4a80-ac20-218287753a06\", \"x\": [1562.5, 1562.5, 1601.25, 1601.25], \"xaxis\": \"x\", \"y\": [0.5294117647058824, 0.8481012658227848, 0.8481012658227848, 0.75], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 30, component: QE_2017_001815_214.51021_60.0\", \"cluster: 30, component: QE_2017_001815_214.51021_60.0\", null, null], \"type\": \"scatter\", \"uid\": \"a1f22e0f-d19c-49bd-a20c-b483299b023d\", \"x\": [1545.0, 1545.0, 1581.875, 1581.875], \"xaxis\": \"x\", \"y\": [0.0, 0.9111111111111111, 0.9111111111111111, 0.8481012658227848], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 31, component: QE_2017_001815_246.14465_137.0\", \"cluster: 31, component: QE_2017_001815_246.14465_137.0\", \"cluster: 31, component: QE_2017_001815_247.12865_158.0\", \"cluster: 31, component: QE_2017_001815_247.12865_158.0\"], \"type\": \"scatter\", \"uid\": \"4d80e083-3539-4fe4-8cdb-835820589f43\", \"x\": [1655.0, 1655.0, 1665.0, 1665.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3333333333333333, 0.3333333333333333, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 32, component: QE_2017_001814_260.16037_143.0\", \"cluster: 32, component: QE_2017_001814_260.16037_143.0\", \"cluster: 32, component: QE_2017_001816_260.16022_145.0\", \"cluster: 32, component: QE_2017_001816_260.16022_145.0\"], \"type\": \"scatter\", \"uid\": \"6f9631a9-b998-480b-a975-ea9140017f96\", \"x\": [1675.0, 1675.0, 1685.0, 1685.0], \"xaxis\": \"x\", \"y\": [0.0, 0.16666666666666666, 0.16666666666666666, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 32, component: QE_2017_001814_233.14948_126.0\", \"cluster: 32, component: QE_2017_001814_233.14948_126.0\", \"cluster: 32, component: QE_2017_001816_233.14955_129.0\", \"cluster: 32, component: QE_2017_001816_233.14955_129.0\"], \"type\": \"scatter\", \"uid\": \"6878c4a9-1ea0-445a-8411-dfa6bb4e5b33\", \"x\": [1705.0, 1705.0, 1715.0, 1715.0], \"xaxis\": \"x\", \"y\": [0.0, 0.15151515151515152, 0.15151515151515152, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 32, component: QE_2017_001814_233.14957_152.0\", \"cluster: 32, component: QE_2017_001814_233.14957_152.0\", null, null], \"type\": \"scatter\", \"uid\": \"082e82b4-82bc-443e-a931-d55e664933e2\", \"x\": [1695.0, 1695.0, 1710.0, 1710.0], \"xaxis\": \"x\", \"y\": [0.0, 0.37142857142857144, 0.37142857142857144, 0.15151515151515152], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"e37432d2-1ae7-46eb-a02f-e6e34c6d7e66\", \"x\": [1680.0, 1680.0, 1702.5, 1702.5], \"xaxis\": \"x\", \"y\": [0.16666666666666666, 0.7619047619047619, 0.7619047619047619, 0.37142857142857144], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"83ef583d-29f0-4971-9d8c-75f48026d95e\", \"x\": [1660.0, 1660.0, 1691.25, 1691.25], \"xaxis\": \"x\", \"y\": [0.3333333333333333, 0.9183673469387755, 0.9183673469387755, 0.7619047619047619], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 33, component: QE_2017_001816_132.04436_283.0\", \"cluster: 33, component: QE_2017_001816_132.04436_283.0\", null, null], \"type\": \"scatter\", \"uid\": \"9ae6b1c7-2342-4916-a603-6ac73507d189\", \"x\": [1645.0, 1645.0, 1675.625, 1675.625], \"xaxis\": \"x\", \"y\": [0.0, 0.9607843137254902, 0.9607843137254902, 0.9183673469387755], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 34, component: QE_2017_001815_260.16016_64.0\", \"cluster: 34, component: QE_2017_001815_260.16016_64.0\", null, null], \"type\": \"scatter\", \"uid\": \"a6022639-373e-4252-9e93-b458d3cebbcb\", \"x\": [1635.0, 1635.0, 1660.3125, 1660.3125], \"xaxis\": \"x\", \"y\": [0.0, 0.9696969696969697, 0.9696969696969697, 0.9607843137254902], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(133,20,75)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 35, component: QE_2017_001815_221.12837_99.0\", \"cluster: 35, component: QE_2017_001815_221.12837_99.0\", \"cluster: 35, component: QE_2017_001816_237.12325_171.0\", \"cluster: 35, component: QE_2017_001816_237.12325_171.0\"], \"type\": \"scatter\", \"uid\": \"80fec091-5db7-4dcf-92ad-485f21a5a494\", \"x\": [1725.0, 1725.0, 1735.0, 1735.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5555555555555556, 0.5555555555555556, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 36, component: QE_2017_001814_237.12305_220.0\", \"cluster: 36, component: QE_2017_001814_237.12305_220.0\", \"cluster: 37, component: QE_2017_001816_237.12323_53.0\", \"cluster: 37, component: QE_2017_001816_237.12323_53.0\"], \"type\": \"scatter\", \"uid\": \"e14f7b2d-d9d6-43b1-8753-00a011462823\", \"x\": [1745.0, 1745.0, 1755.0, 1755.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8947368421052632, 0.8947368421052632, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"258161c7-44d0-4e74-bb60-c11c40b76452\", \"x\": [1730.0, 1730.0, 1750.0, 1750.0], \"xaxis\": \"x\", \"y\": [0.5555555555555556, 0.9534883720930233, 0.9534883720930233, 0.8947368421052632], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 38, component: QE_2017_001814_229.15399_46.0\", \"cluster: 38, component: QE_2017_001814_229.15399_46.0\", \"cluster: 38, component: QE_2017_001816_229.15451_66.0\", \"cluster: 38, component: QE_2017_001816_229.15451_66.0\"], \"type\": \"scatter\", \"uid\": \"c23f716a-fdd2-4706-8f1b-5a8d735ffc7a\", \"x\": [1775.0, 1775.0, 1785.0, 1785.0], \"xaxis\": \"x\", \"y\": [0.0, 0.23809523809523808, 0.23809523809523808, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,220,0)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 38, component: QE_2017_001816_229.15469_52.0\", \"cluster: 38, component: QE_2017_001816_229.15469_52.0\", null, null], \"type\": \"scatter\", \"uid\": \"796aeaac-d3cc-4da8-bdec-68d2bdefd253\", \"x\": [1765.0, 1765.0, 1780.0, 1780.0], \"xaxis\": \"x\", \"y\": [0.0, 0.7777777777777778, 0.7777777777777778, 0.23809523809523808], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(40,35,35)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 39, component: QE_2017_001814_182.08116_51.0\", \"cluster: 39, component: QE_2017_001814_182.08116_51.0\", \"cluster: 39, component: QE_2017_001816_182.08116_55.0\", \"cluster: 39, component: QE_2017_001816_182.08116_55.0\"], \"type\": \"scatter\", \"uid\": \"a1382379-4ecd-406d-a12c-5f58657c8cf6\", \"x\": [1795.0, 1795.0, 1805.0, 1805.0], \"xaxis\": \"x\", \"y\": [0.0, 0.28, 0.28, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(61,153,112)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 40, component: QE_2017_001815_194.04474_330.0\", \"cluster: 40, component: QE_2017_001815_194.04474_330.0\", \"cluster: 40, component: QE_2017_001816_212.05518_300.0\", \"cluster: 40, component: QE_2017_001816_212.05518_300.0\"], \"type\": \"scatter\", \"uid\": \"9717147b-cbae-4232-bc41-b14aa43211a1\", \"x\": [1815.0, 1815.0, 1825.0, 1825.0], \"xaxis\": \"x\", \"y\": [0.0, 0.3670886075949367, 0.3670886075949367, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"a592ebd4-7a2b-4a7c-aa3d-1f84677ab24c\", \"x\": [1800.0, 1800.0, 1820.0, 1820.0], \"xaxis\": \"x\", \"y\": [0.28, 0.855072463768116, 0.855072463768116, 0.3670886075949367], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001814_177.05418_236.0\", \"cluster: 41, component: QE_2017_001814_177.05418_236.0\", \"cluster: 41, component: QE_2017_001815_177.05444_307.0\", \"cluster: 41, component: QE_2017_001815_177.05444_307.0\"], \"type\": \"scatter\", \"uid\": \"426d7bfb-d62a-4aac-947a-2d25f417a5e8\", \"x\": [1845.0, 1845.0, 1855.0, 1855.0], \"xaxis\": \"x\", \"y\": [0.0, 0.21212121212121213, 0.21212121212121213, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001816_177.05449_217.0\", \"cluster: 41, component: QE_2017_001816_177.05449_217.0\", null, null], \"type\": \"scatter\", \"uid\": \"c90909fe-5797-4b3d-8cc2-e3c3f9c51a5f\", \"x\": [1835.0, 1835.0, 1850.0, 1850.0], \"xaxis\": \"x\", \"y\": [0.0, 0.24324324324324326, 0.24324324324324326, 0.21212121212121213], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001816_199.98769_294.0\", \"cluster: 41, component: QE_2017_001816_199.98769_294.0\", \"cluster: 41, component: QE_2017_001816_199.98776_304.0\", \"cluster: 41, component: QE_2017_001816_199.98776_304.0\"], \"type\": \"scatter\", \"uid\": \"c2454b49-d50f-47f1-a07d-4dca9248e5be\", \"x\": [1865.0, 1865.0, 1875.0, 1875.0], \"xaxis\": \"x\", \"y\": [0.0, 0.20588235294117646, 0.20588235294117646, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001814_199.98778_290.0\", \"cluster: 41, component: QE_2017_001814_199.98778_290.0\", \"cluster: 41, component: QE_2017_001815_199.98779_30.0\", \"cluster: 41, component: QE_2017_001815_199.98779_30.0\"], \"type\": \"scatter\", \"uid\": \"e37b3604-e116-4eef-9934-67213d406c8a\", \"x\": [1885.0, 1885.0, 1895.0, 1895.0], \"xaxis\": \"x\", \"y\": [0.0, 0.17647058823529413, 0.17647058823529413, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001815_199.98772_326.0\", \"cluster: 41, component: QE_2017_001815_199.98772_326.0\", \"cluster: 41, component: QE_2017_001816_199.98781_313.0\", \"cluster: 41, component: QE_2017_001816_199.98781_313.0\"], \"type\": \"scatter\", \"uid\": \"7223c8f0-c55a-4e69-9cce-86801f5512df\", \"x\": [1905.0, 1905.0, 1915.0, 1915.0], \"xaxis\": \"x\", \"y\": [0.0, 0.1, 0.1, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001816_199.98776_254.0\", \"cluster: 41, component: QE_2017_001816_199.98776_254.0\", \"cluster: 41, component: QE_2017_001816_199.98779_335.0\", \"cluster: 41, component: QE_2017_001816_199.98779_335.0\"], \"type\": \"scatter\", \"uid\": \"13673154-bbbf-451d-adf5-4df9bfe33c42\", \"x\": [1935.0, 1935.0, 1945.0, 1945.0], \"xaxis\": \"x\", \"y\": [0.0, 0.14285714285714285, 0.14285714285714285, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 41, component: QE_2017_001816_199.98772_359.0\", \"cluster: 41, component: QE_2017_001816_199.98772_359.0\", null, null], \"type\": \"scatter\", \"uid\": \"9b83ae0f-8741-4ddc-8750-de97fb1f19c4\", \"x\": [1925.0, 1925.0, 1940.0, 1940.0], \"xaxis\": \"x\", \"y\": [0.0, 0.18518518518518517, 0.18518518518518517, 0.14285714285714285], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"ed4dfe10-4dd9-46b3-99d2-93b0b67a747a\", \"x\": [1910.0, 1910.0, 1932.5, 1932.5], \"xaxis\": \"x\", \"y\": [0.1, 0.2222222222222222, 0.2222222222222222, 0.18518518518518517], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6a9d93c5-ee78-4856-b75b-bd1bfaf82520\", \"x\": [1890.0, 1890.0, 1921.25, 1921.25], \"xaxis\": \"x\", \"y\": [0.17647058823529413, 0.2692307692307692, 0.2692307692307692, 0.2222222222222222], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6f9fd7de-e199-4928-8bbd-586972b4a8d6\", \"x\": [1870.0, 1870.0, 1905.625, 1905.625], \"xaxis\": \"x\", \"y\": [0.20588235294117646, 0.3103448275862069, 0.3103448275862069, 0.2692307692307692], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(255,65,54)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8f6e892f-7b4e-429a-abfa-98459a939e5a\", \"x\": [1842.5, 1842.5, 1887.8125, 1887.8125], \"xaxis\": \"x\", \"y\": [0.24324324324324326, 0.696969696969697, 0.696969696969697, 0.3103448275862069], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(35,205,205)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 42, component: QE_2017_001815_463.12268_358.0\", \"cluster: 42, component: QE_2017_001815_463.12268_358.0\", \"cluster: 42, component: QE_2017_001815_625.17633_345.0\", \"cluster: 42, component: QE_2017_001815_625.17633_345.0\"], \"type\": \"scatter\", \"uid\": \"1c42e043-ed5c-4713-b779-fa8931d58cd2\", \"x\": [1975.0, 1975.0, 1985.0, 1985.0], \"xaxis\": \"x\", \"y\": [0.0, 0.5121951219512195, 0.5121951219512195, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 43, component: QE_2017_001815_595.16559_315.0\", \"cluster: 43, component: QE_2017_001815_595.16559_315.0\", null, null], \"type\": \"scatter\", \"uid\": \"958cd381-3d72-4ef4-b952-b50b46afc8ba\", \"x\": [1965.0, 1965.0, 1980.0, 1980.0], \"xaxis\": \"x\", \"y\": [0.0, 0.8095238095238095, 0.8095238095238095, 0.5121951219512195], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 44, component: QE_2017_001815_141.0508_33.0\", \"cluster: 44, component: QE_2017_001815_141.0508_33.0\", \"cluster: 45, component: QE_2017_001815_265.01532_33.0\", \"cluster: 45, component: QE_2017_001815_265.01532_33.0\"], \"type\": \"scatter\", \"uid\": \"a20a3bc2-ce5e-40c2-8eed-e29d7bb06621\", \"x\": [1995.0, 1995.0, 2005.0, 2005.0], \"xaxis\": \"x\", \"y\": [0.0, 1.0, 1.0, 0.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"3e7b8930-8dfa-47ec-a2f0-09ee17282769\", \"x\": [1972.5, 1972.5, 2000.0, 2000.0], \"xaxis\": \"x\", \"y\": [0.8095238095238095, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [\"cluster: 46, component: QE_2017_001815_797.51746_866.0\", \"cluster: 46, component: QE_2017_001815_797.51746_866.0\", null, null], \"type\": \"scatter\", \"uid\": \"93e92b04-f2a5-409c-aa69-ceb837b92d97\", \"x\": [1955.0, 1955.0, 1986.25, 1986.25], \"xaxis\": \"x\", \"y\": [0.0, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"22fea627-b690-4443-8c82-aa0e67da0908\", \"x\": [1865.15625, 1865.15625, 1970.625, 1970.625], \"xaxis\": \"x\", \"y\": [0.696969696969697, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"09788544-d57e-4a2d-8b17-3fa413463fd7\", \"x\": [1810.0, 1810.0, 1917.890625, 1917.890625], \"xaxis\": \"x\", \"y\": [0.855072463768116, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"d594ebfd-da01-4012-9769-05237e6c4074\", \"x\": [1772.5, 1772.5, 1863.9453125, 1863.9453125], \"xaxis\": \"x\", \"y\": [0.7777777777777778, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"6b7fdb77-8864-47f2-b675-078bfc62bcf8\", \"x\": [1740.0, 1740.0, 1818.22265625, 1818.22265625], \"xaxis\": \"x\", \"y\": [0.9534883720930233, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"0a6899a1-00ef-4929-b699-3b22de0bfa19\", \"x\": [1647.65625, 1647.65625, 1779.111328125, 1779.111328125], \"xaxis\": \"x\", \"y\": [0.9696969696969697, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"aaabf2be-e831-4f4c-bc32-5709c144e980\", \"x\": [1563.4375, 1563.4375, 1713.3837890625, 1713.3837890625], \"xaxis\": \"x\", \"y\": [0.9111111111111111, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"80122dd5-3494-411e-8662-9b414891df1f\", \"x\": [1467.8125, 1467.8125, 1638.41064453125, 1638.41064453125], \"xaxis\": \"x\", \"y\": [0.978494623655914, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"8b5e341b-da41-46ed-89fb-650083f9d0dd\", \"x\": [1410.0, 1410.0, 1553.111572265625, 1553.111572265625], \"xaxis\": \"x\", \"y\": [0.6, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"f213be62-6d87-4143-a526-db8b4e1ddbf9\", \"x\": [1336.71875, 1336.71875, 1481.5557861328125, 1481.5557861328125], \"xaxis\": \"x\", \"y\": [0.9555555555555556, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"aaaab86d-23cf-4fbd-bafe-f0c283d58672\", \"x\": [1270.0, 1270.0, 1409.1372680664062, 1409.1372680664062], \"xaxis\": \"x\", \"y\": [0.7333333333333333, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"893dde72-f919-4f0b-b64f-00a2a8be2786\", \"x\": [1020.869140625, 1020.869140625, 1339.5686340332031, 1339.5686340332031], \"xaxis\": \"x\", \"y\": [0.9767441860465116, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"4a065a8e-5054-4ff0-81fb-606120a30749\", \"x\": [734.912109375, 734.912109375, 1180.2188873291016, 1180.2188873291016], \"xaxis\": \"x\", \"y\": [0.9411764705882353, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"64dd5645-af8b-4680-b795-f345259bcec4\", \"x\": [619.6875, 619.6875, 957.5654983520508, 957.5654983520508], \"xaxis\": \"x\", \"y\": [0.9636363636363636, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"03b6bf8a-e9eb-473d-b435-423d718f309f\", \"x\": [521.875, 521.875, 788.6264991760254, 788.6264991760254], \"xaxis\": \"x\", \"y\": [0.971830985915493, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}, {\"hoverinfo\": \"text\", \"marker\": {\"color\": \"rgb(0,116,217)\"}, \"mode\": \"lines\", \"text\": [null, null, null, null], \"type\": \"scatter\", \"uid\": \"fd2602b6-63db-4cc0-8f27-e1974a8827b4\", \"x\": [221.85302734375, 221.85302734375, 655.2507495880127, 655.2507495880127], \"xaxis\": \"x\", \"y\": [0.927710843373494, 1.0, 1.0, 1.0], \"yaxis\": \"y\"}],\n",
+       "                        {\"autosize\": false, \"height\": 800, \"hovermode\": \"closest\", \"margin\": {\"b\": 372}, \"showlegend\": false, \"title\": {\"text\": \"Component clusters. method = braycurtis, cutoff = 0.8, threshold = 0.0008\"}, \"width\": 900, \"xaxis\": {\"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showgrid\": false, \"showline\": true, \"showticklabels\": true, \"tickmode\": \"array\", \"ticks\": \"outside\", \"ticktext\": [\"QE_2017_001816_613.4826_738.0\", \"QE_2017_001816_613.48218_838.0\", \"QE_2017_001816_792.56232_718.0\", \"QE_2017_001814_596.30963_602.0\", \"QE_2017_001815_792.5625_866.0\", \"QE_2017_001815_571.4292_870.0\", \"QE_2017_001814_497.31033_643.0\", \"QE_2017_001815_507.27145_607.0\", \"QE_2017_001816_571.47186_717.0\", \"QE_2017_001814_335.25772_725.0\", \"QE_2017_001814_335.25784_608.0\", \"QE_2017_001816_335.25772_723.0\", \"QE_2017_001814_335.25784_628.0\", \"QE_2017_001815_335.25745_642.0\", \"QE_2017_001814_261.22073_634.0\", \"QE_2017_001815_335.25784_587.0\", \"QE_2017_001814_353.26889_609.0\", \"QE_2017_001815_353.26862_642.0\", \"QE_2017_001815_261.22073_643.0\", \"QE_2017_001814_335.25772_638.0\", \"QE_2017_001815_335.2579_601.0\", \"QE_2017_001816_272.25824_582.0\", \"QE_2017_001814_338.34146_850.0\", \"QE_2017_001815_244.19048_762.0\", \"QE_2017_001814_353.26868_633.0\", \"QE_2017_001816_353.26892_600.0\", \"QE_2017_001814_279.23157_719.0\", \"QE_2017_001815_278.24762_684.0\", \"QE_2017_001816_435.25037_666.0\", \"QE_2017_001816_337.27338_826.0\", \"QE_2017_001816_337.27341_632.0\", \"QE_2017_001814_618.42633_695.0\", \"QE_2017_001816_583.41382_731.0\", \"QE_2017_001816_599.40948_660.0\", \"QE_2017_001814_601.42426_706.0\", \"QE_2017_001816_599.40869_793.0\", \"QE_2017_001815_618.42773_646.0\", \"QE_2017_001816_618.427_682.0\", \"QE_2017_001815_568.42627_841.0\", \"QE_2017_001814_565.4035_722.0\", \"QE_2017_001814_583.41406_682.0\", \"QE_2017_001815_583.41406_707.0\", \"QE_2017_001814_601.42334_783.0\", \"QE_2017_001815_583.41388_735.0\", \"QE_2017_001815_583.41418_647.0\", \"QE_2017_001814_194.04424_237.0\", \"QE_2017_001815_194.11751_218.0\", \"QE_2017_001815_194.04469_299.0\", \"QE_2017_001815_194.04471_314.0\", \"QE_2017_001815_212.05513_328.0\", \"QE_2017_001815_212.05505_267.0\", \"QE_2017_001814_226.07077_397.0\", \"QE_2017_001815_194.04471_397.0\", \"QE_2017_001816_533.15442_247.0\", \"QE_2017_001816_533.15466_222.0\", \"QE_2017_001815_533.1546_207.0\", \"QE_2017_001816_533.1546_271.0\", \"QE_2017_001814_347.09097_122.0\", \"QE_2017_001815_347.09067_204.0\", \"QE_2017_001815_268.10373_58.0\", \"QE_2017_001816_269.16055_60.0\", \"QE_2017_001815_364.34189_705.0\", \"QE_2017_001816_408.36832_704.0\", \"QE_2017_001816_466.40979_731.0\", \"QE_2017_001815_408.36853_717.0\", \"QE_2017_001815_482.40488_739.0\", \"QE_2017_001814_364.34244_761.0\", \"QE_2017_001815_364.34253_752.0\", \"QE_2017_001816_421.35226_731.0\", \"QE_2017_001816_424.36325_712.0\", \"QE_2017_001816_463.12311_410.0\", \"QE_2017_001814_611.15997_285.0\", \"QE_2017_001815_611.16046_309.0\", \"QE_2017_001814_339.10742_366.0\", \"QE_2017_001816_339.10733_298.0\", \"QE_2017_001814_498.2543_475.0\", \"QE_2017_001815_340.16019_314.0\", \"QE_2017_001815_231.04973_403.0\", \"QE_2017_001815_231.04968_315.0\", \"QE_2017_001814_231.04971_516.0\", \"QE_2017_001815_231.04971_369.0\", \"QE_2017_001815_314.14453_76.0\", \"QE_2017_001816_314.14462_79.0\", \"QE_2017_001816_310.14957_134.0\", \"QE_2017_001816_342.17584_257.0\", \"QE_2017_001814_241.15466_73.0\", \"QE_2017_001815_507.18192_178.0\", \"QE_2017_001814_483.27118_651.0\", \"QE_2017_001816_338.26062_643.0\", \"QE_2017_001814_320.29456_577.0\", \"QE_2017_001815_320.29471_563.0\", \"QE_2017_001815_129.12741_349.0\", \"QE_2017_001815_171.14914_420.0\", \"QE_2017_001815_201.16367_442.0\", \"QE_2017_001816_201.16362_435.0\", \"QE_2017_001815_209.15352_479.0\", \"QE_2017_001815_209.15349_295.0\", \"QE_2017_001815_209.1535_312.0\", \"QE_2017_001816_209.15344_311.0\", \"QE_2017_001814_243.15892_533.0\", \"QE_2017_001814_281.1745_492.0\", \"QE_2017_001814_293.2106_579.0\", \"QE_2017_001815_227.16408_344.0\", \"QE_2017_001815_283.19009_564.0\", \"QE_2017_001815_207.13785_297.0\", \"QE_2017_001814_227.1275_293.0\", \"QE_2017_001816_227.12766_295.0\", \"QE_2017_001815_181.1221_767.0\", \"QE_2017_001816_181.12199_794.0\", \"QE_2017_001816_211.16916_405.0\", \"QE_2017_001815_209.0807_405.0\", \"QE_2017_001814_211.16902_440.0\", \"QE_2017_001815_211.16913_450.0\", \"QE_2017_001815_215.164_550.0\", \"QE_2017_001816_215.16411_482.0\", \"QE_2017_001816_137.09584_445.0\", \"QE_2017_001814_219.17416_517.0\", \"QE_2017_001815_219.17421_516.0\", \"QE_2017_001816_219.17438_502.0\", \"QE_2017_001814_219.17401_452.0\", \"QE_2017_001814_219.17409_442.0\", \"QE_2017_001814_191.14291_389.0\", \"QE_2017_001815_191.14287_312.0\", \"QE_2017_001816_191.14291_404.0\", \"QE_2017_001814_209.08058_363.0\", \"QE_2017_001816_207.13779_561.0\", \"QE_2017_001815_333.15173_245.0\", \"QE_2017_001816_333.15204_235.0\", \"QE_2017_001814_194.1174_244.0\", \"QE_2017_001816_194.11746_133.0\", \"QE_2017_001816_320.29483_548.0\", \"QE_2017_001814_320.29468_638.0\", \"QE_2017_001814_320.29477_539.0\", \"QE_2017_001814_320.29471_529.0\", \"QE_2017_001815_320.29486_538.0\", \"QE_2017_001814_241.15384_47.0\", \"QE_2017_001814_241.15446_57.0\", \"QE_2017_001814_332.25827_467.0\", \"QE_2017_001815_332.25827_508.0\", \"QE_2017_001816_332.25842_487.0\", \"QE_2017_001814_319.13638_117.0\", \"QE_2017_001816_319.13614_143.0\", \"QE_2017_001814_251.09117_393.0\", \"QE_2017_001815_219.10159_438.0\", \"QE_2017_001815_219.10139_360.0\", \"QE_2017_001816_219.10153_382.0\", \"QE_2017_001814_291.1442_241.0\", \"QE_2017_001816_291.14493_243.0\", \"QE_2017_001816_291.14499_200.0\", \"QE_2017_001815_273.13425_199.0\", \"QE_2017_001815_273.13434_243.0\", \"QE_2017_001815_251.13873_202.0\", \"QE_2017_001815_235.14398_226.0\", \"QE_2017_001816_235.14397_183.0\", \"QE_2017_001815_214.51021_60.0\", \"QE_2017_001816_268.59351_445.0\", \"QE_2017_001814_250.10149_516.0\", \"QE_2017_001815_222.07033_315.0\", \"QE_2017_001814_247.05975_245.0\", \"QE_2017_001815_247.0598_242.0\", \"QE_2017_001816_219.04672_291.0\", \"QE_2017_001815_212.03883_181.0\", \"QE_2017_001815_214.56488_409.0\", \"QE_2017_001815_260.16016_64.0\", \"QE_2017_001816_132.04436_283.0\", \"QE_2017_001815_246.14465_137.0\", \"QE_2017_001815_247.12865_158.0\", \"QE_2017_001814_260.16037_143.0\", \"QE_2017_001816_260.16022_145.0\", \"QE_2017_001814_233.14957_152.0\", \"QE_2017_001814_233.14948_126.0\", \"QE_2017_001816_233.14955_129.0\", \"QE_2017_001815_221.12837_99.0\", \"QE_2017_001816_237.12325_171.0\", \"QE_2017_001814_237.12305_220.0\", \"QE_2017_001816_237.12323_53.0\", \"QE_2017_001816_229.15469_52.0\", \"QE_2017_001814_229.15399_46.0\", \"QE_2017_001816_229.15451_66.0\", \"QE_2017_001814_182.08116_51.0\", \"QE_2017_001816_182.08116_55.0\", \"QE_2017_001815_194.04474_330.0\", \"QE_2017_001816_212.05518_300.0\", \"QE_2017_001816_177.05449_217.0\", \"QE_2017_001814_177.05418_236.0\", \"QE_2017_001815_177.05444_307.0\", \"QE_2017_001816_199.98769_294.0\", \"QE_2017_001816_199.98776_304.0\", \"QE_2017_001814_199.98778_290.0\", \"QE_2017_001815_199.98779_30.0\", \"QE_2017_001815_199.98772_326.0\", \"QE_2017_001816_199.98781_313.0\", \"QE_2017_001816_199.98772_359.0\", \"QE_2017_001816_199.98776_254.0\", \"QE_2017_001816_199.98779_335.0\", \"QE_2017_001815_797.51746_866.0\", \"QE_2017_001815_595.16559_315.0\", \"QE_2017_001815_463.12268_358.0\", \"QE_2017_001815_625.17633_345.0\", \"QE_2017_001815_141.0508_33.0\", \"QE_2017_001815_265.01532_33.0\"], \"tickvals\": [5.0, 15.0, 25.0, 35.0, 45.0, 55.0, 65.0, 75.0, 85.0, 95.0, 105.0, 115.0, 125.0, 135.0, 145.0, 155.0, 165.0, 175.0, 185.0, 195.0, 205.0, 215.0, 225.0, 235.0, 245.0, 255.0, 265.0, 275.0, 285.0, 295.0, 305.0, 315.0, 325.0, 335.0, 345.0, 355.0, 365.0, 375.0, 385.0, 395.0, 405.0, 415.0, 425.0, 435.0, 445.0, 455.0, 465.0, 475.0, 485.0, 495.0, 505.0, 515.0, 525.0, 535.0, 545.0, 555.0, 565.0, 575.0, 585.0, 595.0, 605.0, 615.0, 625.0, 635.0, 645.0, 655.0, 665.0, 675.0, 685.0, 695.0, 705.0, 715.0, 725.0, 735.0, 745.0, 755.0, 765.0, 775.0, 785.0, 795.0, 805.0, 815.0, 825.0, 835.0, 845.0, 855.0, 865.0, 875.0, 885.0, 895.0, 905.0, 915.0, 925.0, 935.0, 945.0, 955.0, 965.0, 975.0, 985.0, 995.0, 1005.0, 1015.0, 1025.0, 1035.0, 1045.0, 1055.0, 1065.0, 1075.0, 1085.0, 1095.0, 1105.0, 1115.0, 1125.0, 1135.0, 1145.0, 1155.0, 1165.0, 1175.0, 1185.0, 1195.0, 1205.0, 1215.0, 1225.0, 1235.0, 1245.0, 1255.0, 1265.0, 1275.0, 1285.0, 1295.0, 1305.0, 1315.0, 1325.0, 1335.0, 1345.0, 1355.0, 1365.0, 1375.0, 1385.0, 1395.0, 1405.0, 1415.0, 1425.0, 1435.0, 1445.0, 1455.0, 1465.0, 1475.0, 1485.0, 1495.0, 1505.0, 1515.0, 1525.0, 1535.0, 1545.0, 1555.0, 1565.0, 1575.0, 1585.0, 1595.0, 1605.0, 1615.0, 1625.0, 1635.0, 1645.0, 1655.0, 1665.0, 1675.0, 1685.0, 1695.0, 1705.0, 1715.0, 1725.0, 1735.0, 1745.0, 1755.0, 1765.0, 1775.0, 1785.0, 1795.0, 1805.0, 1815.0, 1825.0, 1835.0, 1845.0, 1855.0, 1865.0, 1875.0, 1885.0, 1895.0, 1905.0, 1915.0, 1925.0, 1935.0, 1945.0, 1955.0, 1965.0, 1975.0, 1985.0, 1995.0, 2005.0], \"title\": {\"text\": \"Components\"}, \"type\": \"linear\", \"zeroline\": false}, \"yaxis\": {\"mirror\": \"allticks\", \"rangemode\": \"tozero\", \"showgrid\": false, \"showline\": true, \"showticklabels\": true, \"ticks\": \"outside\", \"title\": {\"text\": \"Distance\"}, \"type\": \"linear\", \"zeroline\": false}},\n",
+       "                        {\"showLink\": false, \"linkText\": \"Export to plot.ly\", \"plotlyServerURL\": \"https://plot.ly\"}\n",
+       "                    )\n",
+       "                };\n",
+       "                });\n",
+       "            </script>\n",
+       "        </div>"
       ]
      },
      "metadata": {},
@@ -5099,38 +6506,25 @@
     "# View the new dendrogram cutoff inline\n",
     "\n",
     "plotly.offline.init_notebook_mode(connected=True) # for visualising plot inline\n",
-    "iplot = tree.iplot(width=900, height=500)\n",
+    "iplot = tree.plot(width=900, height=800)\n",
     "plotly.offline.iplot(iplot)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
    "source": [
-    "# Generate the out plots and tables of the new clusters.\n",
-    "os.makedirs(\"results\", exist_ok=True)\n",
-    "tree.write_summaries(path=\"results\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cutoff: 0.8 n clusters: 44\n"
-     ]
-    }
-   ],
-   "source": [
-    "# To view the number of clusters at the new cutoff\n",
+    "## Command line API\n",
     "\n",
-    "print(\"Cutoff:\", tree.cutoff, \"n clusters:\", len(set(tree.clusters)))"
+    "The pipeline can also be run from a bash or bash-like terminal.\n",
+    "This is useful if you're not planning on tweaking the parameters much and just want to run the darn thing.\n",
+    "\n",
+    "For these examples, we're using the ipython magic command `%%bash` to run the commands in bash.\n",
+    "You can omit the %%bash bit if you're running straight in the terminal.\n",
+    "\n",
+    "To get a list of all options available use the `--help` (or `-h`) flag."
    ]
   },
   {
@@ -5142,53 +6536,217 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: BioDendro [-h] [-n] [-c CUTOFF] [-b BIN_THRESHOLD]\r\n",
-      "                 [-d {jaccard,braycurtis}] [-p PROCESSED] [-o OUT_HTML]\r\n",
-      "                 [-r RESULTS_DIR] [-x WIDTH_PX] [-y HEIGHT_PX] [-q]\r\n",
-      "                 mgf components\r\n",
-      "\r\n",
-      "Run the BioDendro pipeline.\r\n",
-      "\r\n",
-      "positional arguments:\r\n",
-      "  mgf                   MGF input file.\r\n",
-      "  components            Listed components file.\r\n",
-      "\r\n",
-      "optional arguments:\r\n",
-      "  -h, --help            show this help message and exit\r\n",
-      "  -n, --neutral         Apply neutral loss.\r\n",
-      "  -c CUTOFF, --cutoff CUTOFF\r\n",
-      "                        Distance threshold for selecting clusters from tree.\r\n",
-      "  -b BIN_THRESHOLD, --bin-threshold BIN_THRESHOLD\r\n",
-      "                        Threshold for binning m/z values prior to clustering.\r\n",
-      "  -d {jaccard,braycurtis}, --cluster-method {jaccard,braycurtis}\r\n",
-      "                        The distance metric used during tree construction.\r\n",
-      "  -p PROCESSED, --processed PROCESSED\r\n",
-      "                        Path to write preprocessed output to.\r\n",
-      "  -o OUT_HTML, --output OUT_HTML\r\n",
-      "                        Path to write interactive html plot to.\r\n",
-      "  -r RESULTS_DIR, --results-dir RESULTS_DIR\r\n",
-      "                        Directory to write per-cluster plots and table\r\n",
-      "                        to.Default is to use 'results_20180606112200' where\r\n",
-      "                        the number isthe current datetime. WARNING: will\r\n",
-      "                        overwrite contents of existing directories.\r\n",
-      "  -x WIDTH_PX, --width WIDTH_PX\r\n",
-      "                        The width of the dendrogram plot in pixels.\r\n",
-      "  -y HEIGHT_PX, --height HEIGHT_PX\r\n",
-      "                        The height of the dendrogram plot in pixels.\r\n",
-      "  -q, --quiet           Suppress status notifications written to stdout.\r\n"
+      "usage: BioDendro [-h] [-n] [-c CUTOFF] [-b BIN_THRESHOLD]\n",
+      "                 [-d {jaccard,braycurtis}] [-p PROCESSED] [-o OUT_HTML]\n",
+      "                 [-r RESULTS_DIR] [-x WIDTH_PX] [-y HEIGHT_PX] [-q] [-s] [-f]\n",
+      "                 [-e EPS] [-mz_tol MZ_TOL] [-retention_tol RETENTION_TOL]\n",
+      "                 mgf components\n",
+      "\n",
+      "Run the BioDendro pipeline.\n",
+      "\n",
+      "positional arguments:\n",
+      "  mgf                   MGF input file.\n",
+      "  components            Listed components file.\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  -n, --neutral         Apply neutral loss.\n",
+      "  -c CUTOFF, --cutoff CUTOFF\n",
+      "                        Distance threshold for selecting clusters from tree.\n",
+      "  -b BIN_THRESHOLD, --bin-threshold BIN_THRESHOLD\n",
+      "                        Threshold for binning m/z values prior to clustering.\n",
+      "  -d {jaccard,braycurtis}, --cluster-method {jaccard,braycurtis}\n",
+      "                        The distance metric used during tree construction.\n",
+      "  -p PROCESSED, --processed PROCESSED\n",
+      "                        Path to write preprocessed output to.\n",
+      "  -o OUT_HTML, --output OUT_HTML\n",
+      "                        Path to write interactive html plot to.\n",
+      "  -r RESULTS_DIR, --results-dir RESULTS_DIR\n",
+      "                        Directory to write per-cluster plots and table\n",
+      "                        to.Default is to use 'results_20180606112200' where\n",
+      "                        the number isthe current datetime. WARNING: will\n",
+      "                        overwrite contents of existing directories.\n",
+      "  -x WIDTH_PX, --width WIDTH_PX\n",
+      "                        The width of the dendrogram plot in pixels.\n",
+      "  -y HEIGHT_PX, --height HEIGHT_PX\n",
+      "                        The height of the dendrogram plot in pixels.\n",
+      "  -q, --quiet           Suppress status notifications written to stdout.\n",
+      "  -s, --scaling         Flag to scale the m/z intensities values\n",
+      "  -f, --filtering       Flag to filter the m/z intensities values\n",
+      "  -e EPS, --eps EPS     Intensity threshold for filtering, set value between\n",
+      "                        0.0-1.0\n",
+      "  -mz_tol MZ_TOL, --mz_tol MZ_TOL\n",
+      "                        Mass tolerance to remove redundancy, default is 0.002\n",
+      "  -retention_tol RETENTION_TOL, --retention_tol RETENTION_TOL\n",
+      "                        Retention time tolerance to remove redundancy, default\n",
+      "                        is 5 secs\n"
      ]
     }
    ],
    "source": [
-    "! BioDendro -h"
+    "%%bash\n",
+    "BioDendro --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The minimum options to run the pipeline are the MGF file and a components list.\n",
+    "\n",
+    "Using the example data in the BioDendro repo we could run..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running BioDendro v0.0.1\n",
+      "\n",
+      "- input mgf file = MSMS.mgf\n",
+      "- input components file = component_list.txt\n",
+      "- neutral = False\n",
+      "- cutoff = 0.6\n",
+      "- bin_threshold = 0.0008\n",
+      "- clustering_method = jaccard\n",
+      "- output processed file = results_20190417165621/processed.xlsx\n",
+      "- output results directory = results_20190417165621\n",
+      "- output html dendrogram = results_20190417165621/simple_dendrogram.html\n",
+      "- dendrogram figure width = 900\n",
+      "- dendrogram figure height = 800\n",
+      "- scaling = False\n",
+      "- filtering = False\n",
+      "- eps = 0.6\n",
+      "- mz_tolerance = 0.002\n",
+      "- retention_tolerance = 5\n",
+      "\n",
+      "\n",
+      "Processing inputs\n",
+      "Binning and clustering\n",
+      "This may take some time...\n",
+      "Writing per-cluster summaries\n",
+      "Writing output html dendrogram\n",
+      "Finished\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "BioDendro MSMS.mgf component_list.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, the results will be stored in a directory with the current date and the current time added to the end of it.\n",
+    "\n",
+    "You can change the parameters to use by supplying additional flags, however, this will run the whole pipeline again, so it you just need to adjust the cutoff or decide to use braycurtis instead of jaccard distances, you might be better off using the python API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running BioDendro v0.0.1\n",
+      "\n",
+      "- input mgf file = MSMS.mgf\n",
+      "- input components file = component_list.txt\n",
+      "- neutral = False\n",
+      "- cutoff = 0.5\n",
+      "- bin_threshold = 0.0008\n",
+      "- clustering_method = braycurtis\n",
+      "- output processed file = results_20190417165736/processed.xlsx\n",
+      "- output results directory = results_20190417165736\n",
+      "- output html dendrogram = results_20190417165736/simple_dendrogram.html\n",
+      "- dendrogram figure width = 900\n",
+      "- dendrogram figure height = 800\n",
+      "- scaling = True\n",
+      "- filtering = False\n",
+      "- eps = 0.6\n",
+      "- mz_tolerance = 0.002\n",
+      "- retention_tolerance = 5\n",
+      "\n",
+      "\n",
+      "Processing inputs\n",
+      "Binning and clustering\n",
+      "This may take some time...\n",
+      "Writing per-cluster summaries\n",
+      "Writing output html dendrogram\n",
+      "Finished\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "BioDendro --scaling --cluster-method braycurtis --cutoff 0.5 MSMS.mgf component_list.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "would be equivalent to running the following in python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running BioDendro v0.0.1\n",
+      "\n",
+      "- input mgf file = MSMS.mgf\n",
+      "- input components file = component_list.txt\n",
+      "- neutral = False\n",
+      "- cutoff = 0.5\n",
+      "- bin_threshold = 0.0008\n",
+      "- clustering_method = braycurtis\n",
+      "- output processed file = results_20190417165856/processed.xlsx\n",
+      "- output results directory = results_20190417165856\n",
+      "- output html dendrogram = results_20190417165856/simple_dendrogram.html\n",
+      "- dendrogram figure width = 900\n",
+      "- dendrogram figure height = 800\n",
+      "- scaling = True\n",
+      "- filtering = False\n",
+      "- eps = 0.6\n",
+      "- mz_tolerance = 0.002\n",
+      "- retention_tolerance = 5\n",
+      "\n",
+      "\n",
+      "Processing inputs\n",
+      "Binning and clustering\n",
+      "This may take some time...\n",
+      "Writing per-cluster summaries\n",
+      "Writing output html dendrogram\n",
+      "Finished\n"
+     ]
+    }
+   ],
+   "source": [
+    "tree = BioDendro.pipeline(\"MSMS.mgf\", \"component_list.txt\", clustering_method=\"braycurtis\", scaling=True, cutoff=0.5)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -5209,7 +6767,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
 
     # Sorry about the hard dependency for scikit-learn.
-    # The way that the PCA model is stored is not necessarily stable across 
+    # The way that the PCA model is stored is not necessarily stable across
     # versions of scikit-learn, so I have to keep it fixed.
     install_requires=[
         'wheel', # Required for older plotly install
@@ -90,7 +90,7 @@ setup(
         'scikit-learn',
         'xlrd',
         'xlsxwriter',
-        'plotly==2.7.0',
+        'plotly',
         'pillow', # Provides PIL
         ],
 


### PR DESCRIPTION
Small changes requested by Cat.
Updated interactive plots.
Updated documentation.
General tidying.

Updated scaling/filtering code to something that I think is more readable.
The speed benefits of using numpy were offset by the cost of small datasize and converting between numpy and bare python types.
It just didn't seem necessary and it made it harder for me to comprehend.
Others may disagree, we can revert back, that's totally fine.
Would be good if someone else can check that they do the same thing.
It looks right to me, but I'll have my blind spots.

If I had the time I would like to see more unit-tests, tests for multiple versions of dependencies (e.g. with tox, especially for plotly and python versions), and continuous testing (e.g. with travis).

I think moving the examples to it's own separate folder would be good too.
But I don't want to scare anyone by changing that external stuff too much.

Having some more documentation outside of juptyer notebooks would be good.
Some people don't like them.
Easiest solution is to render the notebooks using `nbconvert` and publishing html files somewhere.

Also need to investigate getting code onto pypi/conda for easier install.

Please discuss!